### PR TITLE
Launch Open Agent Skill platform and add repository documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Supabase Configuration
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# GitHub API (for auto-indexer)
+GITHUB_TOKEN=ghp_your_github_token
+
+# Optional: Indexer authentication
+INDEXER_SECRET=your-random-secret-string

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to Open Agent Skill
+
+Thank you for your interest in contributing to Open Agent Skill! This document provides guidelines and information for contributors.
+
+## How to Contribute
+
+### Reporting Bugs
+
+- Check if the bug has already been reported in Issues
+- If not, create a new issue with a clear title and description
+- Include steps to reproduce, expected behavior, and actual behavior
+- Add screenshots if applicable
+
+### Suggesting Features
+
+- Check existing issues and discussions for similar ideas
+- Create a new issue with the `enhancement` label
+- Describe the feature and its potential benefits
+
+### Pull Requests
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes with clear commit messages
+4. Ensure code follows existing patterns and style
+5. Test your changes locally
+6. Submit a pull request with a clear description
+
+## Development Setup
+
+```bash
+# Install dependencies
+pnpm install
+
+# Run development server
+pnpm dev
+
+# Run type checking
+pnpm type-check
+
+# Run linting
+pnpm lint
+```
+
+## Commit Message Convention
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` — New features
+- `fix:` — Bug fixes
+- `docs:` — Documentation changes
+- `style:` — Code style changes (formatting, etc.)
+- `refactor:` — Code refactoring
+- `test:` — Adding or updating tests
+- `chore:` — Maintenance tasks
+
+## Code Style
+
+- Use TypeScript for all new code
+- Follow existing component patterns
+- Use Tailwind CSS for styling
+- Keep components small and focused
+
+## Questions?
+
+Feel free to open an issue or reach out to the maintainers.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Open Agent Skill
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,129 @@
+# Open Agent Skill
+
+The open marketplace for AI agent skills. Discover, publish, and compose skills that extend what AI agents can do.
+
+**[openagentskill.com](https://www.openagentskill.com)**
+
+---
+
+## What is Open Agent Skill?
+
+Open Agent Skill is an open-source platform where developers and AI agents discover, share, and compose modular capabilities (skills) that enhance AI agent functionality. Think of it as **npm for AI agents** — a registry of reusable, composable skills that any agent can leverage.
+
+### Key Features
+
+- **Skill Discovery** — Browse and search skills by category, popularity, or trending
+- **Auto-Indexer** — Automatically discovers and indexes high-quality skills from GitHub
+- **AI-Powered Review** — Every skill is reviewed for quality and safety before listing
+- **Multi-Platform Support** — Skills for Claude, GPT, LangChain, CrewAI, and more
+- **Community Driven** — Submit your own skills and earn points
+
+## Tech Stack
+
+- **Framework**: [Next.js 16](https://nextjs.org/) (App Router)
+- **Database**: [Supabase](https://supabase.com/) (PostgreSQL + Auth)
+- **Styling**: [Tailwind CSS v4](https://tailwindcss.com/)
+- **UI Components**: [shadcn/ui](https://ui.shadcn.com/)
+- **Deployment**: [Vercel](https://vercel.com/)
+- **AI**: Vercel AI Gateway
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18+
+- pnpm
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/Leon-Drq/openagentskill.git
+cd openagentskill
+
+# Install dependencies
+pnpm install
+
+# Set up environment variables
+cp .env.example .env.local
+# Edit .env.local with your Supabase credentials
+
+# Run development server
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view the app.
+
+### Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anonymous key |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key (for indexer) |
+| `GITHUB_TOKEN` | GitHub token for API access |
+
+## Project Structure
+
+```
+├── app/                  # Next.js App Router pages
+│   ├── api/              # API routes
+│   ├── skills/           # Skills listing and detail pages
+│   ├── submit/           # Skill submission flow
+│   └── profile/          # User profile and points
+├── components/           # React components
+├── lib/                  # Utilities and business logic
+│   ├── db/               # Database queries
+│   ├── indexer/          # Auto-indexer for GitHub skills
+│   ├── ai-review/        # AI-powered skill review
+│   └── supabase/         # Supabase clients
+└── scripts/              # Database migrations
+```
+
+## Features
+
+### For Developers
+
+- **Submit Skills** — Publish your MCP servers, LangChain tools, or agent plugins
+- **Earn Points** — Get rewarded for quality contributions
+- **Version Control** — Track skill versions and updates
+
+### For AI Agents
+
+- **Skill Discovery API** — Query and filter skills programmatically
+- **Structured Manifests** — SKILL.md format for easy parsing
+- **Trust Scores** — AI-reviewed quality and safety ratings
+
+## Roadmap
+
+- [x] Skill marketplace with search and filters
+- [x] Auto-indexer for GitHub skill discovery
+- [x] User authentication and profiles
+- [x] Points and rewards system
+- [ ] Skill composition engine
+- [ ] Agent feedback loop
+- [ ] Community ratings and reviews
+- [ ] Achievement badges
+
+## Contributing
+
+Contributions are welcome! Please read our contributing guidelines before submitting a PR.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'feat: add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+This project is open source under the [MIT License](LICENSE).
+
+## Links
+
+- **Website**: [openagentskill.com](https://www.openagentskill.com)
+- **Twitter**: [@openagentskill](https://twitter.com/openagentskill)
+
+---
+
+Built with care by the Open Agent Skill community.


### PR DESCRIPTION
- Launched the Open Agent Skill platform.
- Added a GitHub navigation link to the interface.
- Created core project documentation including README and LICENSE files.
- Provided an `.env.example` template for environment configuration.

[v0 Session](https://v0.app/chat/tpyDY9CDX7y)