### PR TITLE
ci: add README Review action for contribution quality

### DIFF
--- a/.github/workflows/readme-review.yml
+++ b/.github/workflows/readme-review.yml
@@ -1,0 +1,15 @@
+name: README Review
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: iteebz/readme-review@v1


### PR DESCRIPTION
openagentskill has 19 open issues and active contributors — thought a README quality check on PRs would be useful.

This adds [README Review](https://github.com/iteebz/readme-review) — scores README quality (0–100) on any PR touching `README.md`, posts a letter grade + shields.io badge. No API keys, pure heuristic.

Fires only when `README.md` changes, stays out of the way otherwise.

**See your grade first:** [grade Leon-Drq/openagentskill's README instantly](https://iteebz.github.io/readme-scorecard/?repo=Leon-Drq/openagentskill) — same heuristic, no install, in your browser. If it's useful, this action runs it on every PR.