### PR TITLE
Fix verified install telemetry

### DIFF
--- a/app/api/agent/outcome/route.ts
+++ b/app/api/agent/outcome/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
 import {
   AGENT_OUTCOME_ERROR_TYPES,
@@ -214,6 +215,9 @@ export async function POST(request: NextRequest) {
       .select('*')
       .eq('skill_slug', payload.skill_slug)
       .maybeSingle()
+
+    revalidatePath(`/skills/${payload.skill_slug}`)
+    revalidatePath(`/api/agent/skills/${payload.skill_slug}`)
 
     return NextResponse.json({
       ok: true,

--- a/app/api/agent/skills/[slug]/route.ts
+++ b/app/api/agent/skills/[slug]/route.ts
@@ -189,6 +189,7 @@ OpenAgentSkill — ${skill.verified ? 'Verified' : 'Unverified'} skill.`
           stars: skill.github_stars,
           forks: skill.github_forks,
           downloads: skill.downloads,
+          verified_installs: outcomeStats?.verified_installs || 0,
           rating: skill.rating,
           review_count: skill.review_count,
           quality_score: Number(skill.quality_score || 0),

--- a/app/api/events/skill/route.ts
+++ b/app/api/events/skill/route.ts
@@ -37,7 +37,8 @@ export async function POST(request: NextRequest) {
   })
 
   if (error) {
-    return NextResponse.json({ ok: false, skipped: true })
+    console.error('[skill-event] Failed to record event:', error)
+    return NextResponse.json({ ok: false, error: 'Failed to record event' }, { status: 503 })
   }
 
   return NextResponse.json({ ok: true })

--- a/app/api/skills/[slug]/install/route.ts
+++ b/app/api/skills/[slug]/install/route.ts
@@ -44,6 +44,11 @@ ${payload.safety_checklist.map((item) => `- ${item}`).join('\n')}
 Verification steps:
 ${payload.verification_steps.map((item) => `- ${item}`).join('\n')}
 
+Verified install receipt:
+Endpoint: ${payload.install_receipt.method} ${payload.install_receipt.endpoint}
+Count rule: ${payload.install_receipt.count_rule}
+Example: ${JSON.stringify(payload.install_receipt.example)}
+
 Do not auto-install when:
 ${payload.do_not_auto_install_when.map((item) => `- ${item}`).join('\n')}
 

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -55,10 +55,10 @@ export default function DocsPage() {
             {'How skills are ranked'}
           </h2>
           <p className="text-base sm:text-lg leading-relaxed mb-4">
-            {'The skills leaderboard ranks skills based on anonymous telemetry data collected from the skills CLI. When users install skills, aggregated usage data helps surface the most popular and useful skills in the ecosystem.'}
+            {'Verified installs are counted only when a compatible agent or integration reports an idempotent install outcome receipt. Install-command copies and verified installs are tracked as separate signals.'}
           </p>
           <p className="text-base sm:text-lg leading-relaxed text-secondary">
-            {'This telemetry is completely anonymous and only tracks which skills are being installed—no personal information or usage patterns are collected.'}
+            {'Direct GitHub clones and third-party installer runs are not observable unless they submit a receipt. Receipts contain the skill, agent label, install result, and optional aggregate quality fields; they do not require personal identity.'}
           </p>
         </section>
 

--- a/app/skills/[slug]/page.tsx
+++ b/app/skills/[slug]/page.tsx
@@ -228,6 +228,7 @@ export default async function SkillDetailPage({
 
   const { relatedSkills, eventStats, outcomeStats, approvedClaim } =
     await getCachedSkillDetailSupport(skill.id, skill.category, skill.slug)
+  const verifiedInstalls = outcomeStats?.verified_installs || 0
   const aiScore = dbSkill?.ai_review_score?.score as number | undefined
   const matchedUseCases = dbSkill ? getUseCasesForSkill(dbSkill, 3) : []
   const matchedStacks = dbSkill ? getStacksForSkill(dbSkill, 3) : []
@@ -409,10 +410,10 @@ export default async function SkillDetailPage({
                 <div className="grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-3">
                   <div className="rounded-[8px] border border-border bg-background/85 p-3">
                     <span className="block font-mono text-[10px] uppercase tracking-[0.18em] text-secondary">
-                      <SkillDetailText id="downloads" />
+                      <SkillDetailText id="verifiedInstalls" />
                     </span>
                     <span className="mt-1 block font-mono text-base font-semibold">
-                      {formatNumber(skill.stats.downloads)}
+                      {formatNumber(verifiedInstalls)}
                     </span>
                   </div>
                   <div className="rounded-[8px] border border-border bg-background/85 p-3">

--- a/components/skill-event-tracker.tsx
+++ b/components/skill-event-tracker.tsx
@@ -78,7 +78,7 @@ export async function trackSkillEvent(
   })
 
   try {
-    await fetch('/api/events/skill', {
+    const response = await fetch('/api/events/skill', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -91,6 +91,9 @@ export async function trackSkillEvent(
       }),
       keepalive: true,
     })
+    if (!response.ok && process.env.NODE_ENV !== 'production') {
+      console.warn('[skill-event] Event was not recorded', response.status)
+    }
   } catch {
     // Engagement analytics should never block the product flow.
   }

--- a/lib/agent-outcome-summary.ts
+++ b/lib/agent-outcome-summary.ts
@@ -11,6 +11,7 @@ export function createEmptyOutcomeStats(skillSlug: string): SkillOutcomeStats {
     risk_blocked_outcomes: 0,
     setup_required_outcomes: 0,
     install_attempts: 0,
+    verified_installs: 0,
     success_rate: null,
     install_success_rate: null,
     avg_output_quality: null,

--- a/lib/db/skills.ts
+++ b/lib/db/skills.ts
@@ -472,6 +472,7 @@ export interface SkillOutcomeStats {
   risk_blocked_outcomes: number
   setup_required_outcomes: number
   install_attempts: number
+  verified_installs: number
   success_rate: number | null
   install_success_rate?: number | null
   avg_output_quality?: number | null
@@ -605,6 +606,7 @@ const getCachedAgentOutcomeStatsMap = unstable_cache(
       risk_blocked_outcomes: Number(row.risk_blocked_outcomes || 0),
       setup_required_outcomes: Number(row.setup_required_outcomes || 0),
       install_attempts: Number(row.install_attempts || 0),
+      verified_installs: Number(row.verified_installs || 0),
       success_rate: row.success_rate === null || row.success_rate === undefined ? null : Number(row.success_rate),
       install_success_rate: row.install_success_rate === null || row.install_success_rate === undefined ? null : Number(row.install_success_rate),
       avg_output_quality: row.avg_output_quality === null || row.avg_output_quality === undefined ? null : Number(row.avg_output_quality),
@@ -654,6 +656,7 @@ export async function getAgentOutcomeStats(skillSlug: string): Promise<SkillOutc
     risk_blocked_outcomes: Number(row.risk_blocked_outcomes || 0),
     setup_required_outcomes: Number(row.setup_required_outcomes || 0),
     install_attempts: Number(row.install_attempts || 0),
+    verified_installs: Number(row.verified_installs || 0),
     success_rate: row.success_rate === null || row.success_rate === undefined ? null : Number(row.success_rate),
     install_success_rate: row.install_success_rate === null || row.install_success_rate === undefined ? null : Number(row.install_success_rate),
     avg_output_quality: row.avg_output_quality === null || row.avg_output_quality === undefined ? null : Number(row.avg_output_quality),

--- a/lib/i18n/skill-detail-copy.ts
+++ b/lib/i18n/skill-detail-copy.ts
@@ -5,6 +5,7 @@ type CopyValues = Record<string, string | number>
 const en = {
   skills: 'Skills',
   downloads: 'Downloads',
+  verifiedInstalls: 'Verified installs',
   stars: 'Stars',
   usedBy: 'Used by',
   agents: 'agents',

--- a/lib/install-targets.ts
+++ b/lib/install-targets.ts
@@ -24,6 +24,19 @@ export function getSkillRepoRef(skill: InstallableSkill) {
   return skill.slug
 }
 
+
+function getVerifiedInstallReceiptInstruction(skill: InstallableSkill, agent: string) {
+  const payload = JSON.stringify({
+    event_id: 'install_<unique-id>',
+    skill_slug: skill.slug,
+    task: `Install ${skill.name}`,
+    agent,
+    outcome: 'success',
+    install_used: true,
+  })
+
+  return `After the install attempt, report the result to https://www.openagentskill.com/api/agent/outcome with POST JSON ${payload}. Replace event_id with a unique value and outcome with success or failed. Report success only after the skill is installed and a minimal verification passes.`
+}
 export function getPrimaryInstallCommand(skill: InstallableSkill) {
   return skill.install_command || `npx skills add ${getSkillRepoRef(skill)}`
 }
@@ -49,7 +62,7 @@ export function getSkillInstallTargets(skill: InstallableSkill): SkillInstallTar
       label: 'Codex',
       title: 'Codex install prompt',
       kind: 'agent-prompt',
-      value: `Install the "${skill.name}" agent skill from ${source}. Read its SKILL.md or equivalent instructions first, install only the files needed for this workspace, and summarize any required setup before using it. Skill purpose: ${description}`,
+      value: `Install the "${skill.name}" agent skill from ${source}. Read its SKILL.md or equivalent instructions first, install only the files needed for this workspace, and summarize any required setup before using it. Skill purpose: ${description} ${getVerifiedInstallReceiptInstruction(skill, 'codex')}`,
       description: 'Give Codex a repo-aware install prompt when the skill is not available through a local CLI.',
       copyLabel: 'Copy prompt',
     },
@@ -58,7 +71,7 @@ export function getSkillInstallTargets(skill: InstallableSkill): SkillInstallTar
       label: 'Claude Code',
       title: 'Claude Code skill prompt',
       kind: 'agent-prompt',
-      value: `Add "${skill.name}" as a Claude Code skill from ${source}. Inspect the skill instructions, place the reusable skill files in the appropriate local skills location for this project, and report the activation steps. Skill purpose: ${description}`,
+      value: `Add "${skill.name}" as a Claude Code skill from ${source}. Inspect the skill instructions, place the reusable skill files in the appropriate local skills location for this project, and report the activation steps. Skill purpose: ${description} ${getVerifiedInstallReceiptInstruction(skill, 'claude-code')}`,
       description: 'Use this prompt to ask Claude Code to add the skill and explain the local activation steps.',
       copyLabel: 'Copy prompt',
     },
@@ -67,7 +80,7 @@ export function getSkillInstallTargets(skill: InstallableSkill): SkillInstallTar
       label: 'Cursor',
       title: 'Cursor rule prompt',
       kind: 'agent-prompt',
-      value: `Turn "${skill.name}" from ${source} into a reusable Cursor project rule or agent instruction. Preserve the core workflow, adapt paths to this repo, and keep the rule scoped to tasks where it is relevant. Skill purpose: ${description}`,
+      value: `Turn "${skill.name}" from ${source} into a reusable Cursor project rule or agent instruction. Preserve the core workflow, adapt paths to this repo, and keep the rule scoped to tasks where it is relevant. Skill purpose: ${description} ${getVerifiedInstallReceiptInstruction(skill, 'cursor')}`,
       description: 'Use this when installing as Cursor project rules or reusable agent instructions.',
       copyLabel: 'Copy prompt',
     },

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -669,6 +669,14 @@ export function buildInstallHandoff(skill: SkillRecord) {
   const detailUrl = getSkillUrl(skill.slug)
   const audit = buildSkillAudit(skill)
   const safety = getAgentSafetyProfile(skill, audit, { max_risk: 'medium', needs_install_command: true })
+  const installReceiptExample = {
+    event_id: 'install_<unique-id>',
+    skill_slug: skill.slug,
+    task: `Install ${skill.name}`,
+    agent: 'codex',
+    outcome: 'success',
+    install_used: true,
+  }
 
   return {
     skill: {
@@ -679,6 +687,13 @@ export function buildInstallHandoff(skill: SkillRecord) {
     },
     recommended_command: install,
     install_targets: targets,
+    install_receipt: {
+      endpoint: `${SITE_URL}/api/agent/outcome`,
+      method: 'POST',
+      idempotency: 'event_id is unique; retries update the same receipt',
+      count_rule: 'verified installs require install_used=true and outcome=success',
+      example: installReceiptExample,
+    },
     safety_gate: {
       tier: safety.safety_tier.tier,
       label: safety.safety_tier.label,
@@ -691,7 +706,7 @@ export function buildInstallHandoff(skill: SkillRecord) {
       reasons: safety.safety_tier.reasons,
     },
     agent_prompt:
-      `Install the "${skill.name}" agent skill only after reviewing the OpenAgentSkill profile and source repository. Safety gate: ${safety.safety_tier.label} (${safety.safety_tier.auto_install_policy}). Start with ${detailUrl}, inspect the trust and audit notes, then use the recommended install handoff: ${install}. After installation, summarize changed files, required setup, and a minimal verification result before using the skill for real work.`,
+      `Install the "${skill.name}" agent skill only after reviewing the OpenAgentSkill profile and source repository. Safety gate: ${safety.safety_tier.label} (${safety.safety_tier.auto_install_policy}). Start with ${detailUrl}, inspect the trust and audit notes, then use the recommended install handoff: ${install}. After installation, summarize changed files, required setup, and a minimal verification result before using the skill for real work. Report the verified result to ${SITE_URL}/api/agent/outcome using a unique event_id, skill_slug=${skill.slug}, install_used=true, and outcome=success or failed.`,
     safety_checklist: [
       `Safety gate: ${safety.safety_tier.label}. Policy: ${safety.safety_tier.auto_install_policy}.`,
       safety.safety_tier.recommended_action,

--- a/scripts/024_verified_install_telemetry.sql
+++ b/scripts/024_verified_install_telemetry.sql
@@ -1,0 +1,96 @@
+-- Verified install telemetry derived from idempotent agent outcome receipts.
+-- A verified install is counted only when install_used=true and outcome=success.
+
+ALTER TABLE public.agent_outcome_stats
+  ADD COLUMN IF NOT EXISTS verified_installs INTEGER NOT NULL DEFAULT 0;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'agent_outcome_stats_verified_installs_nonnegative'
+  ) THEN
+    ALTER TABLE public.agent_outcome_stats
+      ADD CONSTRAINT agent_outcome_stats_verified_installs_nonnegative
+      CHECK (verified_installs >= 0);
+  END IF;
+END;
+$$;
+
+CREATE INDEX IF NOT EXISTS agent_outcome_stats_verified_installs_idx
+  ON public.agent_outcome_stats (verified_installs DESC, total_outcomes DESC);
+
+CREATE OR REPLACE FUNCTION private.refresh_verified_installs_for_skill(p_skill_slug TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_verified_installs INTEGER;
+BEGIN
+  IF p_skill_slug IS NULL OR length(trim(p_skill_slug)) = 0 THEN
+    RETURN;
+  END IF;
+
+  SELECT COUNT(*)::INTEGER
+  INTO v_verified_installs
+  FROM public.agent_outcomes
+  WHERE skill_slug = p_skill_slug
+    AND install_used = TRUE
+    AND outcome = 'success';
+
+  UPDATE public.agent_outcome_stats
+  SET verified_installs = v_verified_installs,
+      updated_at = NOW()
+  WHERE skill_slug = p_skill_slug;
+
+  IF NOT FOUND AND v_verified_installs > 0 THEN
+    INSERT INTO public.agent_outcome_stats (skill_slug, verified_installs, updated_at)
+    VALUES (p_skill_slug, v_verified_installs, NOW())
+    ON CONFLICT (skill_slug) DO UPDATE SET
+      verified_installs = EXCLUDED.verified_installs,
+      updated_at = NOW();
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.refresh_verified_installs_for_skill(TEXT)
+  FROM anon, authenticated, public;
+
+CREATE OR REPLACE FUNCTION private.refresh_verified_installs_for_event()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    PERFORM private.refresh_verified_installs_for_skill(OLD.skill_slug);
+    RETURN OLD;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.skill_slug IS DISTINCT FROM NEW.skill_slug THEN
+    PERFORM private.refresh_verified_installs_for_skill(OLD.skill_slug);
+  END IF;
+
+  PERFORM private.refresh_verified_installs_for_skill(NEW.skill_slug);
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.refresh_verified_installs_for_event()
+  FROM anon, authenticated, public;
+
+DROP TRIGGER IF EXISTS zz_agent_outcomes_refresh_verified_installs
+  ON public.agent_outcomes;
+CREATE TRIGGER zz_agent_outcomes_refresh_verified_installs
+  AFTER INSERT OR UPDATE OR DELETE ON public.agent_outcomes
+  FOR EACH ROW
+  EXECUTE FUNCTION private.refresh_verified_installs_for_event();
+
+UPDATE public.agent_outcome_stats AS stats
+SET verified_installs = (
+      SELECT COUNT(*)::INTEGER
+      FROM public.agent_outcomes AS outcomes

--- a/scripts/025_remove_unused_verified_install_index.sql
+++ b/scripts/025_remove_unused_verified_install_index.sql
@@ -1,0 +1,3 @@
+-- Detail and API reads use the agent_outcome_stats primary key (skill_slug).
+-- Avoid maintaining a ranking index until a verified-install leaderboard needs it.
+DROP INDEX IF EXISTS public.agent_outcome_stats_verified_installs_idx;


### PR DESCRIPTION
## What changed

- replace the misleading detail-page Downloads metric with Verified installs
- derive verified installs from idempotent successful agent outcome receipts
- add install receipt instructions to Codex, Claude Code, Cursor, and install handoff APIs
- invalidate cached skill pages and agent APIs after outcome reports
- surface skill-event ingestion failures instead of silently returning success
- correct the telemetry documentation
- add and apply Supabase migrations for the verified install aggregate

## Root cause

The UI read the static `skills.downloads` field while install-copy events and agent outcomes were stored separately. Direct agent installs had no receipt guidance, and cached pages could remain stale after a successful report.

## Validation

- `pnpm lint` — 0 errors (25 pre-existing warnings)
- `pnpm exec tsc --noEmit`
- `pnpm build`
- transactional Supabase test: success increments once, retry is idempotent, failed outcome is not counted, rollback leaves no test data
- Supabase security advisor: no new security findings
