### PR TITLE
Fix live verified install reads

### DIFF
--- a/app/api/agent/skills/[slug]/route.ts
+++ b/app/api/agent/skills/[slug]/route.ts
@@ -15,10 +15,11 @@ import { getSkillSupplyProfile } from '@/lib/supply'
 import { getSkillTrustProfile, getSkillTrustProfileV5 } from '@/lib/trust'
 import { getUseCasesForSkill } from '@/lib/use-cases'
 
-export const revalidate = 300
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
 
 const AGENT_SKILL_CACHE_HEADERS = {
-  'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600',
+  'Cache-Control': 'no-store, max-age=0',
 }
 const AGENT_SKILL_SUPPORT_TIMEOUT_MS = 1200
 


### PR DESCRIPTION
## Summary
- make the agent skill detail endpoint dynamic
- disable CDN caching for live verified-install and outcome statistics
- prevent successful install receipts from appearing stale for up to five minutes

## Validation
- `pnpm lint` (0 errors; 25 pre-existing warnings)
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`

Production regression found the database aggregate correctly reached 1 while the cached API response remained at 0; this patch fixes that read path.