### PR TITLE
Open the skill submission pipeline

### DIFF
--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from 'next'
 import Link from 'next/link'
 import { MarketingHero, MarketingPageShell } from '@/components/marketing-page'
-import { SKILL_SUBMISSION_MIN_STARS } from '@/lib/skills/submission-policy'
 
 export const metadata: Metadata = {
   title: 'API Reference - OpenAgentSkill',
@@ -910,7 +909,7 @@ This skill enables agents to perform comprehensive web research...`}</code>
             </div>
             <div className="p-4 sm:p-6">
               <p className="text-base sm:text-lg mb-4 sm:mb-6">
-                {`Submit a GitHub repository as a skill. The repository must have at least ${SKILL_SUBMISSION_MIN_STARS} stars and pass static security analysis plus AI scoring before automatic publishing. Used by OpenClaw and other agents to submit skill candidates.`}
+                {'Submit any valid SKILL.md from a GitHub repository, directory, or file URL. Zero-star repositories are eligible. The API returns a receipt immediately and reviews the submission asynchronously.'}
               </p>
 
               <h3 className="font-semibold mb-3 text-sm sm:text-base">{'Request Body'}</h3>
@@ -920,8 +919,12 @@ This skill enables agents to perform comprehensive web research...`}</code>
                   <span className="text-secondary">{'GitHub repository URL (required) — e.g. https://github.com/owner/repo'}</span>
                 </div>
                 <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-3">
+                  <code className="font-mono bg-muted px-2 py-1 w-fit shrink-0">{'skillPath'}</code>
+                  <span className="text-secondary">{'Exact SKILL.md path returned by POST /api/skills/validate (required)'}</span>
+                </div>
+                <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-3">
                   <code className="font-mono bg-muted px-2 py-1 w-fit shrink-0">{'category'}</code>
-                  <span className="text-secondary">{'Skill category (required)'}</span>
+                  <span className="text-secondary">{'Skill category (optional; auto-detected when omitted)'}</span>
                 </div>
                 <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-3">
                   <code className="font-mono bg-muted px-2 py-1 w-fit shrink-0">{'tags'}</code>
@@ -935,6 +938,10 @@ This skill enables agents to perform comprehensive web research...`}</code>
                   <code className="font-mono bg-muted px-2 py-1 w-fit shrink-0">{'submittedByAgent'}</code>
                   <span className="text-secondary">{'Agent identifier string, e.g. "openclaw-v1.2" (optional)'}</span>
                 </div>
+                <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-3">
+                  <code className="font-mono bg-muted px-2 py-1 w-fit shrink-0">{'makerGithub / makerX'}</code>
+                  <span className="text-secondary">{'Optional declared maker handles. They remain unverified until OAuth or repository ownership proof.'}</span>
+                </div>
               </div>
 
               <h3 className="font-semibold mb-3 text-sm sm:text-base">{'Example Request'}</h3>
@@ -944,8 +951,10 @@ Content-Type: application/json
 
 {
   "repository": "https://github.com/owner/my-skill",
-  "category": "Web Scraping",
+  "skillPath": "SKILL.md",
   "tags": ["crawler", "llm", "python"],
+  "makerGithub": "owner",
+  "makerX": "owner_on_x",
   "submissionSource": "agent",
   "submittedByAgent": "openclaw-v1.2"
 }`}</code>
@@ -955,21 +964,13 @@ Content-Type: application/json
               <div className="bg-card p-3 sm:p-4 font-mono text-xs sm:text-sm overflow-x-auto border border-border whitespace-pre-wrap">
                 <code>{`{
   "success": true,
-  "approved": true,
-  "skill": {
-    "id": "...",
-    "slug": "owner-my-skill",
-    "name": "My Skill"
-  },
-  "review": {
-    "approved": true,
-    "totalScore": 36,
-    "summary": "High quality skill with clear documentation",
-    "policy": {
-      "status": "approved",
-      "min_stars": ${SKILL_SUBMISSION_MIN_STARS},
-      "checks": ["GitHub adoption", "Static security scan", "AI total score"]
-    }
+  "accepted": true,
+  "submission": {
+    "id": "7f3f...",
+    "token": "private-status-token",
+    "status": "submitted",
+    "statusUrl": "/api/skills/submissions/7f3f...?token=...",
+    "skill": { "name": "My Skill", "path": "SKILL.md" }
   }
 }`}</code>
               </div>
@@ -983,7 +984,7 @@ Content-Type: application/json
             {'OpenClaw Auto-Submit'}
           </h2>
           <p className="text-base sm:text-lg leading-relaxed text-secondary mb-8">
-            {'If you use OpenClaw, you can configure it to automatically publish your skills to OpenAgentSkill whenever a repo crosses the 50-star threshold.'}
+            {'Agents can submit a skill as soon as a valid SKILL.md is available. GitHub stars remain a ranking signal, not a publishing gate.'}
           </p>
 
           <div className="space-y-8">
@@ -999,9 +1000,8 @@ Content-Type: application/json
 publish:
   - target: openagentskill
     url: https://openagentskill.com/api/skills/submit
-    trigger:
-      stars_threshold: 50
     payload:
+      skillPath: SKILL.md
       submissionSource: agent
       submittedByAgent: "openclaw-v1.2"`}</code>
                 </div>
@@ -1013,8 +1013,8 @@ publish:
                 {'2'}
               </div>
               <div className="min-w-0 flex-1">
-                <h3 className="font-semibold mb-2 text-sm sm:text-base">{'OpenClaw will POST automatically when the threshold is reached'}</h3>
-                <p className="text-secondary text-sm mb-3">{`Once configured, every time a monitored repo crosses ${SKILL_SUBMISSION_MIN_STARS} stars, OpenClaw will call the submit API with the repo details. You can also trigger it manually:`}</p>
+                <h3 className="font-semibold mb-2 text-sm sm:text-base">{'OpenClaw can POST when SKILL.md is created or updated'}</h3>
+                <p className="text-secondary text-sm mb-3">{'No star threshold is required. The agent can also trigger submission manually:'}</p>
                 <div className="bg-card p-3 sm:p-4 font-mono text-xs sm:text-sm overflow-x-auto border border-border whitespace-pre-wrap">
                   <code>{`# Manually submit a specific repo via OpenClaw
 openclaw publish --target openagentskill --repo owner/my-skill`}</code>
@@ -1028,7 +1028,7 @@ openclaw publish --target openagentskill --repo owner/my-skill`}</code>
               </div>
               <div className="min-w-0 flex-1">
                 <h3 className="font-semibold mb-2 text-sm sm:text-base">{'AI review runs automatically'}</h3>
-                <p className="text-secondary text-sm">{'Submitted skills go through the same review pipeline as manual submissions: minimum-star gate, static security analysis, AI quality scoring, and a final publish policy gate. Only approved skills appear immediately with the activity feed noting they were discovered by OpenClaw.'}</p>
+                <p className="text-secondary text-sm">{'Every submission is persisted before review. Critical security findings are quarantined; other submissions are reviewed and published or kept in the community review queue.'}</p>
               </div>
             </div>
           </div>
@@ -1040,7 +1040,7 @@ openclaw publish --target openagentskill --repo owner/my-skill`}</code>
   -H "Content-Type: application/json" \\
   -d '{
     "repository": "https://github.com/your-org/your-skill",
-    "category": "Web Scraping",
+    "skillPath": "SKILL.md",
     "tags": ["python", "llm"],
     "submissionSource": "agent",
     "submittedByAgent": "my-custom-agent"

--- a/app/api/skills/submissions/[id]/route.ts
+++ b/app/api/skills/submissions/[id]/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { submissionTokenMatches } from '@/lib/skills/open-submission'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const IdSchema = z.string().uuid()
+const TokenSchema = z.string().regex(/^[a-f0-9]{48}$/)
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+  const token = request.nextUrl.searchParams.get('token') || ''
+  if (!IdSchema.safeParse(id).success || !TokenSchema.safeParse(token).success) {
+    return NextResponse.json({ error: 'Invalid submission receipt.' }, { status: 400 })
+  }
+
+  const supabase = createAdminClient({ requestTimeoutMs: 8_000 })
+  const { data, error } = await supabase
+    .from('skill_submissions')
+    .select(`
+      id,
+      status,
+      skill_name,
+      skill_description,
+      skill_path,
+      repository_url,
+      identity_verified,
+      ai_review_result,
+      created_at,
+      updated_at,
+      reviewed_at,
+      status_token_hash,
+      skills ( slug )
+    `)
+    .eq('id', id)
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json({ error: 'Unable to read submission status.' }, { status: 500 })
+  }
+  if (!data || !data.status_token_hash || !submissionTokenMatches(token, data.status_token_hash)) {
+    return NextResponse.json({ error: 'Submission not found.' }, { status: 404 })
+  }
+
+  const review = data.ai_review_result && typeof data.ai_review_result === 'object'
+    ? data.ai_review_result as Record<string, unknown>
+    : {}
+  const relatedSkill = Array.isArray(data.skills) ? data.skills[0] : data.skills
+
+  return NextResponse.json({
+    submission: {
+      id: data.id,
+      status: data.status,
+      skill: {
+        name: data.skill_name,
+        description: data.skill_description,
+        path: data.skill_path,
+        sourceUrl: data.repository_url,
+        slug: relatedSkill?.slug || null,
+      },
+      identityVerified: Boolean(data.identity_verified),
+      review: {
+        scores: review.scores || null,
+        totalScore: review.totalScore || null,
+        issues: Array.isArray(review.issues) ? review.issues.slice(0, 20) : [],
+        suggestions: Array.isArray(review.suggestions) ? review.suggestions.slice(0, 20) : [],
+        reasoning: typeof review.reasoning === 'string' ? review.reasoning : null,
+      },
+      createdAt: data.created_at,
+      updatedAt: data.updated_at,
+      reviewedAt: data.reviewed_at,
+    },
+  })
+}

--- a/app/api/skills/submit/route.ts
+++ b/app/api/skills/submit/route.ts
@@ -1,26 +1,33 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { after, NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
+import { validateGitHubRepo, GitHubAPIError } from '@/lib/github/api'
 import {
-  validateGitHubRepo,
-  fetchReadme,
-  fetchSkillManifest,
-  fetchCodeFiles,
-  parseGitHubUrl,
-} from '@/lib/github/api'
-import { reviewSkill } from '@/lib/ai-review/reviewer'
-import { analyzeCode } from '@/lib/security/static-analysis'
+  discoverGitHubSkills,
+  fetchSkillPackageFiles,
+  parseGitHubSkillReference,
+} from '@/lib/github/skill-source'
 import {
-  evaluateSkillSubmissionPolicy,
-  SKILL_SUBMISSION_MIN_STARS,
-} from '@/lib/skills/submission-policy'
-import { createPublicClient } from '@/lib/supabase/public'
+  buildRequestFingerprint,
+  createOpenSubmission,
+  reviewOpenSubmission,
+} from '@/lib/skills/open-submission'
+
+export const runtime = 'nodejs'
+export const maxDuration = 60
+
+const githubHandle = z.string().trim().max(39).regex(/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/)
+const xHandle = z.string().trim().max(15).regex(/^[A-Za-z0-9_]{1,15}$/)
 
 const SkillSubmitRequestSchema = z.object({
-  repository: z.string().min(1),
-  category: z.string().min(1),
-  tags: z.array(z.string().min(1).max(40)).min(1).max(10),
+  repository: z.string().trim().min(1).max(500),
+  skillPath: z.string().trim().min(1).max(500),
+  sourceRef: z.string().trim().min(1).max(200).optional(),
+  category: z.string().trim().max(80).optional(),
+  tags: z.array(z.string().trim().min(1).max(40)).max(10).default([]),
+  makerGithub: githubHandle.optional().or(z.literal('')).transform((value) => value || undefined),
+  makerX: xHandle.optional().or(z.literal('')).transform((value) => value || undefined),
   submissionSource: z.enum(['web', 'api', 'agent']).default('web'),
-  submittedByAgent: z.string().min(1).max(200).optional(),
+  submittedByAgent: z.string().trim().min(1).max(200).optional(),
 })
 
 export async function POST(request: NextRequest) {
@@ -29,7 +36,8 @@ export async function POST(request: NextRequest) {
     if (!parsed.success) {
       return NextResponse.json(
         {
-          error: 'Invalid submission payload',
+          code: 'INVALID_SUBMISSION',
+          error: 'Invalid submission payload.',
           issues: parsed.error.issues.map((issue) => ({
             path: issue.path.join('.'),
             message: issue.message,
@@ -40,283 +48,88 @@ export async function POST(request: NextRequest) {
     }
 
     const body = parsed.data
-    const { repository, category, tags, submissionSource } = body
-
-    console.log('[v0] Skill submission received:', { repository, category, tags })
-
-    // Parse GitHub URL
-    const repoRef = parseGitHubUrl(repository)
-    if (!repoRef) {
+    const reference = parseGitHubSkillReference(body.repository)
+    if (!reference) {
       return NextResponse.json(
-        { code: 'INVALID_REPOSITORY', error: 'Invalid GitHub repository format' },
+        { code: 'INVALID_REPOSITORY', error: 'Enter a GitHub repository, skill directory, or SKILL.md URL.' },
         { status: 400 }
       )
     }
 
-    const { owner, repo } = repoRef
-
-    // Step 1: Validate GitHub repository
-    console.log('[v0] Validating repository...')
-    const repoData = await validateGitHubRepo(repository)
-
-    // Enforce minimum star threshold (also checked client-side but enforced here)
-    if (repoData.stars < SKILL_SUBMISSION_MIN_STARS) {
+    const selectedReference = {
+      ...reference,
+      ref: body.sourceRef || reference.ref,
+      path: body.skillPath,
+    }
+    const repository = await validateGitHubRepo(`${reference.owner}/${reference.repo}`, {
+      checkReadme: false,
+      checkSkillJson: false,
+    })
+    const discovery = await discoverGitHubSkills(selectedReference, repository)
+    const skill = discovery.skills.find((candidate) => candidate.path === body.skillPath)
+    if (!skill) {
       return NextResponse.json(
-        {
-          code: 'MINIMUM_STARS',
-          error: `This repository has ${repoData.stars} stars and does not meet the minimum requirement of ${SKILL_SUBMISSION_MIN_STARS} stars.`,
-          stars: repoData.stars,
-          minStars: SKILL_SUBMISSION_MIN_STARS,
-        },
+        { code: 'SKILL_PATH_NOT_FOUND', error: 'The selected SKILL.md path no longer exists or is invalid.' },
         { status: 400 }
       )
     }
 
-    if (!repoData.hasReadme) {
-      return NextResponse.json(
-        { code: 'MISSING_README', error: 'This repository does not have a README.' },
-        { status: 400 }
-      )
-    }
+    const codeFiles = await fetchSkillPackageFiles(skill)
+    const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    const ip = forwardedFor || request.headers.get('x-real-ip') || 'unknown'
+    const userAgent = request.headers.get('user-agent') || 'unknown'
 
-    // Step 2: Fetch repository content
-    console.log('[v0] Fetching repository content...')
-    const [readmeContent, manifestData, codeFiles] = await Promise.all([
-      fetchReadme(owner, repo),
-      fetchSkillManifest(owner, repo).catch(() => null),
-      fetchCodeFiles(owner, repo).catch(() => []),
-    ])
-
-    // Step 3: Static security analysis
-    console.log('[v0] Running static analysis...')
-    const staticResult = analyzeCode(
-      codeFiles.map((f: { path: string; content: string }) => ({
-        path: f.path,
-        content: f.content,
-      }))
-    )
-
-    if (!staticResult.passed) {
-      return NextResponse.json(
-        {
-          error: 'Skill rejected: critical security issues detected',
-          issues: staticResult.issues,
-          riskLevel: staticResult.riskLevel,
-        },
-        { status: 400 }
-      )
-    }
-
-    // Step 4: AI Review
-    console.log('[v0] Starting AI review...')
-    const review = await reviewSkill({
-      repository: repoData.fullName,
-      readmeContent,
+    const submissionInput = {
+      repository,
+      skill,
+      category: body.category,
+      tags: body.tags,
+      submissionSource: body.submissionSource,
+      submittedByAgent: body.submittedByAgent,
+      makerGithub: body.makerGithub,
+      makerX: body.makerX,
+      requestFingerprint: buildRequestFingerprint(ip, userAgent),
       codeFiles,
-      manifestData,
-      githubStats: {
-        stars: repoData.stars,
-        forks: repoData.forks,
-        lastUpdated: repoData.updatedAt,
-        license: repoData.license,
-        language: repoData.language,
-      },
-    })
-
-    console.log('[v0] AI review completed:', {
-      approved: review.approved,
-      totalScore: review.totalScore,
-    })
-
-    const policy = evaluateSkillSubmissionPolicy({
-      stars: repoData.stars,
-      hasReadme: repoData.hasReadme,
-      staticAnalysis: staticResult,
-      review,
-    })
-    const reviewedResult = {
-      ...review,
-      approved: policy.approved,
-      issues: policy.issues,
-      suggestions: policy.suggestions,
-      policy,
     }
+    const receipt = await createOpenSubmission(submissionInput)
 
-    if (!policy.approved) {
-      return NextResponse.json({
-        success: false,
-        approved: false,
-        review: reviewedResult,
-        policy,
-        error:
-          policy.status === 'manual_review'
-            ? 'Skill requires manual review before publishing'
-            : 'Skill did not pass the automatic submission gate',
-      })
+    if (receipt.status === 'submitted') {
+      after(() => reviewOpenSubmission(submissionInput, receipt.id))
     }
-
-    // Step 4: Create skill object
-    const skillName = manifestData?.name || repo.replace(/-/g, ' ')
-    const slug = `${owner}-${repo}`.toLowerCase()
-
-    const newSkill = {
-      id: `skill-${Date.now()}`,
-      slug,
-      name: skillName,
-      tagline: manifestData?.description || repoData.description || '',
-      description: manifestData?.description || repoData.description || '',
-      longDescription: readmeContent.slice(0, 500),
-      category,
-      tags,
-      author: {
-        id: `author-${owner}`,
-        name: owner,
-        username: owner,
-        reputation: 0,
-        skillCount: 1,
-        verified: false,
-      },
-      stats: {
-        downloads: 0,
-        stars: repoData.stars,
-        forks: repoData.forks,
-        usedBy: 0,
-        rating: 0,
-        reviewCount: 0,
-      },
-      technical: {
-        version: manifestData?.version || '1.0.0',
-        language: repoData.language ? [repoData.language] : [],
-        frameworks: manifestData?.frameworks || [],
-        dependencies: [],
-        documentation: `https://github.com/${owner}/${repo}`,
-        repository: `https://github.com/${owner}/${repo}`,
-        license: repoData.license || 'Unknown',
-        size: '0 MB',
-        lastUpdated: repoData.updatedAt,
-        installCommand: `npx skills add ${owner}/${repo}`,
-        githubRepo: `${owner}/${repo}`,
-      },
-      pricing: {
-        type: 'free' as const,
-      },
-      compatibility: [],
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-      featured: false,
-      verified: policy.verified,
-    }
-
-    try {
-      const serverSecret = process.env.INDEXER_SECRET
-      if (!serverSecret) {
-        throw new Error('Missing INDEXER_SECRET for reviewed skill submission.')
-      }
-
-      const supabase = createPublicClient()
-      const activity = {
-        event_type: submissionSource === 'agent' ? 'agent_submitted' : 'skill_published',
-        actor_name: submissionSource === 'agent' ? (body.submittedByAgent || 'Unknown Agent') : owner,
-        actor_type: submissionSource === 'agent' ? 'agent' : 'human',
-        description: `${submissionSource === 'agent' ? 'Discovered and submitted' : 'Published'} ${skillName} — ${repoData.description || ''}`,
-        metadata: {
-          stars: repoData.stars,
-          source: submissionSource,
-          static_analysis: staticResult,
-          submission_policy: policy,
-        },
-      }
-
-      const { data: saveResult, error: saveError } = await supabase.rpc('submit_reviewed_skill', {
-        p_server_secret: serverSecret,
-        p_skill: {
-          slug,
-          name: skillName,
-          description: manifestData?.description || repoData.description || '',
-          long_description: readmeContent.slice(0, 1000),
-          tagline: manifestData?.tagline || repoData.description || '',
-          author_name: owner,
-          author_url: `https://github.com/${owner}`,
-          repository: `https://github.com/${owner}/${repo}`,
-          github_repo: `${owner}/${repo}`,
-          github_stars: repoData.stars,
-          github_forks: repoData.forks,
-          category,
-          tags,
-          frameworks: manifestData?.frameworks || [],
-          version: manifestData?.version || '1.0.0',
-          license: repoData.license || 'Unknown',
-          install_command: `npx skills add ${owner}/${repo}`,
-          verified: policy.verified,
-          submission_source: submissionSource,
-          submitted_by_agent: body.submittedByAgent,
-          ai_review_score: review.scores,
-          ai_review_approved: policy.approved,
-          ai_review_issues: policy.issues,
-          ai_review_suggestions: policy.suggestions,
-        },
-        p_submission: {
-          github_repo: `${owner}/${repo}`,
-          submission_source: submissionSource,
-          submitted_by_agent: body.submittedByAgent,
-          ai_review_result: reviewedResult,
-          status: policy.status,
-        },
-        p_activity: activity,
-      })
-
-      if (saveError) {
-        throw saveError
-      }
-
-      const skillRecord = saveResult?.skill
-      if (!skillRecord?.id) {
-        throw new Error('Reviewed skill submission did not return a skill record.')
-      }
-
-      console.log('[v0] Skill saved to database:', skillRecord.id)
-
-      return NextResponse.json({
-        success: true,
-        approved: policy.approved,
-        review: reviewedResult,
-        policy,
-        skill: {
-          ...newSkill,
-          id: skillRecord.id,
-        },
-      })
-    } catch (dbError: any) {
-      console.error('[v0] Database save error:', dbError)
-
-      if (dbError?.code === '23505') {
-        return NextResponse.json(
-          {
-            code: 'SKILL_ALREADY_EXISTS',
-            error: 'Skill already exists',
-            slug,
-          },
-          { status: 409 }
-        )
-      }
-
-      return NextResponse.json({
-        code: 'SAVE_FAILED',
-        success: false,
-        approved: policy.approved,
-        review: reviewedResult,
-        policy,
-        error: 'Skill reviewed but database save failed',
-      }, { status: 500 })
-    }
-  } catch (error: any) {
-    console.error('[v0] Submission error:', error)
 
     return NextResponse.json(
       {
-        code: 'SUBMISSION_FAILED',
-        error: error.message || 'Submission failed. Please try again later.',
+        success: true,
+        accepted: true,
+        message: receipt.status === 'quarantined'
+          ? 'Submission saved but quarantined by the critical-risk scanner.'
+          : 'Submission saved. Automated review continues in the background.',
+        submission: {
+          id: receipt.id,
+          token: receipt.token,
+          status: receipt.status,
+          skill: receipt.skill,
+          statusUrl: `/api/skills/submissions/${receipt.id}?token=${receipt.token}`,
+        },
       },
+      { status: 202 }
+    )
+  } catch (error) {
+    console.error('[skill-submission] error:', error)
+    if (error instanceof GitHubAPIError) {
+      return NextResponse.json(
+        { code: 'GITHUB_ERROR', error: error.message },
+        { status: error.statusCode || 400 }
+      )
+    }
+    if (error instanceof Error && error.name === 'SubmissionRateLimitError') {
+      return NextResponse.json(
+        { code: 'RATE_LIMITED', error: error.message },
+        { status: 429, headers: { 'Retry-After': '3600' } }
+      )
+    }
+    return NextResponse.json(
+      { code: 'SUBMISSION_FAILED', error: error instanceof Error ? error.message : 'Submission failed.' },
       { status: 500 }
     )
   }

--- a/app/api/skills/validate/route.ts
+++ b/app/api/skills/validate/route.ts
@@ -1,43 +1,50 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 import { validateGitHubRepo, GitHubAPIError } from '@/lib/github/api'
-import { SKILL_SUBMISSION_MIN_STARS } from '@/lib/skills/submission-policy'
+import { discoverGitHubSkills, parseGitHubSkillReference } from '@/lib/github/skill-source'
+import { buildRequestFingerprint, enforceValidationRateLimit } from '@/lib/skills/open-submission'
+
+export const runtime = 'nodejs'
+
+const ValidateRequestSchema = z.object({
+  repository: z.string().trim().min(1).max(500),
+})
 
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json()
-    const { repository } = body
-
-    if (!repository) {
+    const parsed = ValidateRequestSchema.safeParse(await request.json())
+    if (!parsed.success) {
       return NextResponse.json(
-        { code: 'REPOSITORY_REQUIRED', error: 'GitHub repository URL is required' },
+        { valid: false, code: 'REPOSITORY_REQUIRED', error: 'A GitHub repository or SKILL.md URL is required.' },
         { status: 400 }
       )
     }
 
-    // Validate GitHub repository
-    const repoData = await validateGitHubRepo(repository)
+    const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    const ip = forwardedFor || request.headers.get('x-real-ip') || 'unknown'
+    const userAgent = request.headers.get('user-agent') || 'unknown'
+    await enforceValidationRateLimit(buildRequestFingerprint(ip, userAgent))
 
-    // Check minimum star threshold
-    if (repoData.stars < SKILL_SUBMISSION_MIN_STARS) {
+    const reference = parseGitHubSkillReference(parsed.data.repository)
+    if (!reference) {
+      return NextResponse.json(
+        { valid: false, code: 'INVALID_REPOSITORY', error: 'Enter a GitHub repository, skill directory, or SKILL.md URL.' },
+        { status: 400 }
+      )
+    }
+
+    const repoData = await validateGitHubRepo(`${reference.owner}/${reference.repo}`, {
+      checkReadme: false,
+      checkSkillJson: false,
+    })
+    const discovery = await discoverGitHubSkills(reference, repoData)
+    if (discovery.skills.length === 0) {
       return NextResponse.json(
         {
           valid: false,
-          code: 'MINIMUM_STARS',
-          error: `This repository has ${repoData.stars} stars and does not meet the minimum requirement of ${SKILL_SUBMISSION_MIN_STARS} stars.`,
+          code: 'MISSING_SKILL_FILE',
+          error: 'No valid SKILL.md with name and description frontmatter was found at this source.',
           stars: repoData.stars,
-          minStars: SKILL_SUBMISSION_MIN_STARS,
-        },
-        { status: 400 }
-      )
-    }
-
-    // Check basic requirements
-    if (!repoData.hasReadme) {
-      return NextResponse.json(
-        { 
-          valid: false,
-          code: 'MISSING_README',
-          error: 'This repository does not have a README. Add one and try again.'
         },
         { status: 400 }
       )
@@ -45,22 +52,42 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       valid: true,
-      repository: repoData,
+      repository: {
+        owner: repoData.owner,
+        repo: repoData.repo,
+        fullName: repoData.fullName,
+        stars: repoData.stars,
+        forks: repoData.forks,
+        defaultBranch: repoData.defaultBranch,
+        hasReadme: repoData.hasReadme,
+      },
       stars: repoData.stars,
-      minStars: SKILL_SUBMISSION_MIN_STARS,
+      zeroStarEligible: true,
+      treeTruncated: discovery.truncated,
+      skills: discovery.skills.map((skill) => ({
+        name: skill.frontmatter.name,
+        description: skill.frontmatter.description,
+        path: skill.path,
+        ref: skill.ref,
+        sourceUrl: skill.sourceUrl,
+      })),
     })
   } catch (error) {
-    console.error('[v0] Validation error:', error)
-
+    console.error('[skill-validation] error:', error)
     if (error instanceof GitHubAPIError) {
       return NextResponse.json(
-        { valid: false, error: error.message },
+        { valid: false, code: 'GITHUB_ERROR', error: error.message },
         { status: error.statusCode || 400 }
       )
     }
-
+    if (error instanceof Error && error.name === 'ValidationRateLimitError') {
+      return NextResponse.json(
+        { valid: false, code: 'RATE_LIMITED', error: error.message },
+        { status: 429, headers: { 'Retry-After': '3600' } }
+      )
+    }
     return NextResponse.json(
-      { code: 'VALIDATION_FAILED', valid: false, error: 'Validation failed. Please try again later.' },
+      { valid: false, code: 'VALIDATION_FAILED', error: error instanceof Error ? error.message : 'Validation failed.' },
       { status: 500 }
     )
   }

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -121,26 +121,25 @@ GET /api/agent/skills/advanced-web-research?format=text`}</code>
           </p>
           <ol className="list-decimal list-inside space-y-3 text-base sm:text-lg leading-relaxed text-secondary mb-6">
             <li>{'Create a GitHub repository with your skill code'}</li>
-            <li>{'Add a skill.json manifest file describing your skill'}</li>
+            <li>{'Add a SKILL.md file with name and description frontmatter'}</li>
             <li>{'Include clear documentation and usage examples'}</li>
             <li>{'Submit your skill to the marketplace'}</li>
           </ol>
           <p className="text-base sm:text-lg leading-relaxed">
-            {'Example skill.json structure:'}
+            {'Example SKILL.md structure:'}
           </p>
           <div className="border border-border bg-card p-4 sm:p-6 mt-4">
             <pre className="font-mono text-xs sm:text-sm overflow-x-auto">
-              <code>{`{
-  "name": "my-awesome-skill",
-  "version": "1.0.0",
-  "description": "A skill that does something amazing",
-  "category": "productivity",
-  "platforms": ["langchain", "autogpt"],
-  "author": {
-    "name": "Your Name",
-    "github": "yourusername"
-  }
-}`}</code>
+              <code>{`---
+name: my-awesome-skill
+description: A skill that does something amazing
+version: 1.0.0
+category: productivity
+---
+
+# My Awesome Skill
+
+Explain when an agent should use the skill and the steps it should follow.`}</code>
             </pre>
           </div>
         </section>

--- a/app/skills/[slug]/page.tsx
+++ b/app/skills/[slug]/page.tsx
@@ -302,6 +302,10 @@ export default async function SkillDetailPage({
       'Do not skip repository, license, permission, and dependency review before production use.',
     ]
   const outcomeFeedback = agentReadableMetadata?.outcome_feedback || null
+  const publisherProfiles = [
+    dbSkill?.publisher_github ? `https://github.com/${dbSkill.publisher_github}` : null,
+    dbSkill?.publisher_x ? `https://x.com/${dbSkill.publisher_x}` : null,
+  ].filter((profile): profile is string => Boolean(profile))
 
   const structuredData = {
     '@context': 'https://schema.org',
@@ -326,6 +330,7 @@ export default async function SkillDetailPage({
       '@type': skill.author.verified ? 'Organization' : 'Person',
       name: skill.author.name,
       url: attribution?.creatorUrl || undefined,
+      sameAs: publisherProfiles.length > 0 ? publisherProfiles : undefined,
     },
     sameAs: [attribution?.sourceUrl, attribution?.creatorUrl].filter(Boolean),
     downloadUrl: skill.technical.repository,
@@ -2125,6 +2130,23 @@ export default async function SkillDetailPage({
                       <p className="text-xs text-secondary">
                         @{skill.author.username}
                       </p>
+                    )}
+                    {publisherProfiles.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-3 text-xs">
+                        {dbSkill?.publisher_github && (
+                          <a href={`https://github.com/${dbSkill.publisher_github}`} target="_blank" rel="noreferrer" className="underline underline-offset-4">
+                            GitHub @{dbSkill.publisher_github}
+                          </a>
+                        )}
+                        {dbSkill?.publisher_x && (
+                          <a href={`https://x.com/${dbSkill.publisher_x}`} target="_blank" rel="noreferrer" className="underline underline-offset-4">
+                            X @{dbSkill.publisher_x}
+                          </a>
+                        )}
+                        {!dbSkill?.publisher_verified && (
+                          <span className="font-mono text-[10px] uppercase text-secondary">Unverified</span>
+                        )}
+                      </div>
                     )}
                   </div>
                 </div>

--- a/app/skills/new/page.tsx
+++ b/app/skills/new/page.tsx
@@ -1,0 +1,146 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { SiteFooter } from '@/components/site-footer'
+import { SiteHeader } from '@/components/site-header'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'New Agent Skill submissions | OpenAgentSkill',
+  description: 'A chronological community queue of standards-compliant SKILL.md submissions.',
+  alternates: { canonical: 'https://www.openagentskill.com/skills/new' },
+}
+
+interface CommunitySubmission {
+  id: string
+  status: string
+  skill_name: string | null
+  skill_description: string | null
+  skill_path: string | null
+  repository_url: string | null
+  submitter_github: string | null
+  submitter_x: string | null
+  identity_verified: boolean
+  created_at: string
+  skills: { slug: string }[] | { slug: string } | null
+}
+
+async function getCommunitySubmissions() {
+  try {
+    const supabase = createAdminClient({ requestTimeoutMs: 8_000 })
+    const { data, error } = await supabase
+      .from('skill_submissions')
+      .select(`
+        id,
+        status,
+        skill_name,
+        skill_description,
+        skill_path,
+        repository_url,
+        submitter_github,
+        submitter_x,
+        identity_verified,
+        created_at,
+        skills ( slug )
+      `)
+      .in('status', ['submitted', 'processing', 'listed', 'reviewed', 'duplicate'])
+      .order('created_at', { ascending: false })
+      .limit(60)
+    if (error) throw error
+    return (data || []) as CommunitySubmission[]
+  } catch (error) {
+    console.warn('[new-skills] community queue unavailable:', error)
+    return []
+  }
+}
+
+function statusCopy(status: string) {
+  if (status === 'reviewed') return 'Reviewed'
+  if (status === 'listed') return 'Community listed'
+  if (status === 'duplicate') return 'Already listed'
+  if (status === 'processing') return 'Reviewing'
+  return 'Submitted'
+}
+
+export default async function NewSkillsPage() {
+  const submissions = await getCommunitySubmissions()
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <SiteHeader />
+      <main>
+        <section className="border-b border-border">
+          <div className="mx-auto max-w-6xl px-6 py-14 sm:py-18">
+            <p className="font-mono text-xs uppercase tracking-[0.24em] text-secondary">Community queue</p>
+            <div className="mt-5 grid gap-6 lg:grid-cols-[1fr_auto] lg:items-end">
+              <div>
+                <h1 className="font-display text-4xl font-normal sm:text-5xl">New Agent Skills</h1>
+                <p className="mt-4 max-w-3xl text-base leading-7 text-secondary">
+                  Every valid SKILL.md can enter the community queue. Reviewed and verified skills earn stronger placement in search and Agent Resolve.
+                </p>
+              </div>
+              <Link href="/submit" className="inline-flex h-11 items-center justify-center bg-[#006b4f] px-5 text-sm font-semibold text-white">
+                Submit a Skill
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-6xl px-6 py-10 sm:py-12">
+          {submissions.length === 0 ? (
+            <div className="border border-border bg-card p-8">
+              <h2 className="font-display text-2xl">The queue is ready for its next submission.</h2>
+              <p className="mt-3 text-sm leading-6 text-secondary">Zero-star projects are welcome when they contain a valid public SKILL.md.</p>
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {submissions.map((submission) => {
+                const relatedSkill = Array.isArray(submission.skills) ? submission.skills[0] : submission.skills
+                const destination = relatedSkill?.slug
+                  ? `/skills/${relatedSkill.slug}`
+                  : submission.repository_url || '#'
+                return (
+                  <article key={submission.id} className="border border-border bg-card p-5">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-secondary">{statusCopy(submission.status)}</p>
+                        <h2 className="mt-2 font-display text-2xl">{submission.skill_name || 'Unnamed skill'}</h2>
+                      </div>
+                      <time className="shrink-0 font-mono text-[11px] text-secondary" dateTime={submission.created_at}>
+                        {new Date(submission.created_at).toISOString().slice(0, 10)}
+                      </time>
+                    </div>
+                    <p className="mt-3 line-clamp-3 text-sm leading-6 text-secondary">{submission.skill_description}</p>
+                    <p className="mt-4 truncate font-mono text-[11px] text-secondary">{submission.skill_path}</p>
+                    <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4 text-sm">
+                      <div className="flex flex-wrap gap-3 text-secondary">
+                        {submission.submitter_github && (
+                          <a href={`https://github.com/${submission.submitter_github}`} target="_blank" rel="noreferrer" className="underline underline-offset-4">
+                            GitHub @{submission.submitter_github}
+                          </a>
+                        )}
+                        {submission.submitter_x && (
+                          <a href={`https://x.com/${submission.submitter_x}`} target="_blank" rel="noreferrer" className="underline underline-offset-4">
+                            X @{submission.submitter_x}
+                          </a>
+                        )}
+                        {(submission.submitter_github || submission.submitter_x) && !submission.identity_verified && (
+                          <span className="font-mono text-[10px] uppercase">Unverified</span>
+                        )}
+                      </div>
+                      <Link href={destination} className="font-semibold underline underline-offset-4">
+                        Open source
+                      </Link>
+                    </div>
+                  </article>
+                )
+              })}
+            </div>
+          )}
+        </section>
+      </main>
+      <SiteFooter />
+    </div>
+  )
+}

--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -1,258 +1,179 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { SkillSubmitForm, SubmitFormData } from '@/components/skill-submit-form'
-import { interpolate, useI18n } from '@/lib/i18n/context'
+import { useI18n } from '@/lib/i18n/context'
 import { SiteFooter } from '@/components/site-footer'
 import { SiteHeader } from '@/components/site-header'
-import { SKILL_SUBMISSION_MIN_STARS } from '@/lib/skills/submission-policy'
 import { trackAnalyticsEvent } from '@/lib/analytics'
 
-type SubmissionReview = {
-  scores: {
-    security: number
-    quality: number
-    usefulness: number
-    compliance: number
-  }
-  totalScore: number
-  suggestions: string[]
-  issues: string[]
-  reasoning: string
+type SubmissionStatus = 'submitted' | 'processing' | 'listed' | 'reviewed' | 'duplicate' | 'quarantined'
+
+type Review = {
+  totalScore?: number
+  scores?: { security?: number; quality?: number; usefulness?: number; compliance?: number }
+  issues?: string[]
+  suggestions?: string[]
+  reasoning?: string
 }
 
-type SubmissionResult =
-  | { approved: true; skill: { slug: string }; review: SubmissionReview }
-  | { approved: false; skill?: { slug: string }; review: SubmissionReview }
+type SubmissionReceipt = {
+  id: string
+  token: string
+  status: SubmissionStatus
+  statusUrl: string
+  skill: { name: string; description: string; path: string; sourceUrl: string }
+}
+
+type SubmissionState = {
+  id: string
+  status: SubmissionStatus
+  skill: { name: string; slug?: string | null; sourceUrl?: string }
+  review?: Review | null
+}
 
 export default function SubmitPage() {
-  const { t } = useI18n()
-  const [submitted, setSubmitted] = useState(false)
-  const [reviewResult, setReviewResult] = useState<SubmissionResult | null>(null)
+  const { locale } = useI18n()
+  const zh = locale === 'zh'
+  const [receipt, setReceipt] = useState<SubmissionReceipt | null>(null)
+  const [result, setResult] = useState<SubmissionState | null>(null)
 
-  const getSubmissionError = (error: {
-    code?: string
-    error?: string
-    stars?: number
-    minStars?: number
-  }) => {
-    switch (error.code) {
-      case 'INVALID_REPOSITORY':
-        return t.submitPage.form.repoValidError
-      case 'MINIMUM_STARS':
-        return interpolate(t.submitPage.form.minimumStarsError, {
-          stars: error.stars ?? 0,
-          minStars: error.minStars ?? SKILL_SUBMISSION_MIN_STARS,
-        })
-      case 'MISSING_README':
-        return t.submitPage.form.missingReadme
-      case 'SKILL_ALREADY_EXISTS':
-        return t.submitPage.form.skillAlreadyExists
-      case 'SAVE_FAILED':
-        return t.submitPage.form.saveFailed
-      case 'SUBMISSION_FAILED':
-        return t.submitPage.form.submissionFailed
-      default:
-        return error.error || t.common.error
+  useEffect(() => {
+    if (!receipt || !['submitted', 'processing'].includes(result?.status || receipt.status)) return
+    let cancelled = false
+    let attempts = 0
+
+    async function poll() {
+      attempts += 1
+      try {
+        const response = await fetch(receipt!.statusUrl, { cache: 'no-store' })
+        if (response.ok && !cancelled) {
+          const data = await response.json() as { submission: SubmissionState }
+          setResult(data.submission)
+          if (!['submitted', 'processing'].includes(data.submission.status)) return
+        }
+      } catch {
+        // Keep the receipt on screen; the user can return to the private status URL.
+      }
+      if (!cancelled && attempts < 30) window.setTimeout(poll, 2000)
     }
-  }
 
-  const handleSubmit = async (data: SubmitFormData) => {
-    console.log('[v0] Submitting skill:', data)
+    const timer = window.setTimeout(poll, 1200)
+    return () => { cancelled = true; window.clearTimeout(timer) }
+  }, [receipt, result?.status])
 
+  async function handleSubmit(data: SubmitFormData) {
     const response = await fetch('/api/skills/submit', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
     })
+    const payload = await response.json()
+    if (!response.ok) throw new Error(payload.error || (zh ? '提交失败。' : 'Submission failed.'))
 
-    if (!response.ok) {
-      const error = await response.json()
-      throw new Error(getSubmissionError(error))
-    }
-
-    const result = (await response.json()) as SubmissionResult
-    console.log('[v0] Submission result:', result)
-
-    trackAnalyticsEvent('skill_submission_result', {
-      approved: Boolean(result.approved),
-      category: data.category || 'unspecified',
-      skill_slug: result.skill?.slug,
-      review_score: result.review?.totalScore,
+    const nextReceipt = payload.submission as SubmissionReceipt
+    setReceipt(nextReceipt)
+    setResult({ id: nextReceipt.id, status: nextReceipt.status, skill: nextReceipt.skill })
+    trackAnalyticsEvent('skill_submission_accepted', {
+      category: data.category || 'auto',
+      status: nextReceipt.status,
+      has_github_identity: Boolean(data.makerGithub),
+      has_x_identity: Boolean(data.makerX),
     })
-
-    setReviewResult(result)
-    setSubmitted(true)
   }
 
-  if (submitted && reviewResult) {
-    return (
-      <div className="min-h-screen bg-background text-foreground">
-        <SiteHeader />
-
-        {/* Result */}
-        <main className="container mx-auto px-4 sm:px-6 py-8 sm:py-12">
-          <div className="max-w-2xl mx-auto text-center">
-            {reviewResult.approved ? (
-              <>
-                <h1 className="font-display text-3xl sm:text-4xl font-bold mb-4">
-                  {t.submitPage.result.approved.title}
-                </h1>
-                <p className="text-base sm:text-lg text-secondary mb-8">
-                  {t.submitPage.result.approved.subtitle}
-                </p>
-                <div className="border border-border p-4 sm:p-6 mb-8 text-left">
-                  <h2 className="font-semibold text-lg sm:text-xl mb-4">
-                    {t.submitPage.result.approved.reviewDetails}
-                  </h2>
-                  <div className="space-y-2 text-sm">
-                    <p>
-                      <span className="text-secondary">{t.submitPage.result.approved.security}</span>{' '}
-                      <span className="font-mono">{reviewResult.review.scores.security}/10</span>
-                    </p>
-                    <p>
-                      <span className="text-secondary">{t.submitPage.result.approved.quality}</span>{' '}
-                      <span className="font-mono">{reviewResult.review.scores.quality}/10</span>
-                    </p>
-                    <p>
-                      <span className="text-secondary">{t.submitPage.result.approved.usefulness}</span>{' '}
-                      <span className="font-mono">{reviewResult.review.scores.usefulness}/10</span>
-                    </p>
-                    <p>
-                      <span className="text-secondary">{t.submitPage.result.approved.compliance}</span>{' '}
-                      <span className="font-mono">{reviewResult.review.scores.compliance}/10</span>
-                    </p>
-                    <p className="pt-2 border-t border-border mt-2">
-                      <span className="text-secondary">{t.submitPage.result.approved.totalScore}</span>{' '}
-                      <span className="font-mono font-semibold">{reviewResult.review.totalScore}/40</span>
-                    </p>
-                  </div>
-                  {reviewResult.review.suggestions.length > 0 && (
-                    <div className="mt-4 pt-4 border-t border-border">
-                      <h3 className="font-semibold mb-2">{t.submitPage.result.approved.suggestions}</h3>
-                      <ul className="list-disc list-inside text-sm text-secondary space-y-1">
-                        {reviewResult.review.suggestions.map((suggestion: string, i: number) => (
-                          <li key={i}>{suggestion}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                </div>
-                <Link
-                  href={`/skills/${reviewResult.skill.slug}`}
-                  className="inline-block px-4 sm:px-6 py-2 sm:py-3 border-2 border-foreground font-semibold hover:bg-foreground hover:text-background transition-colors text-sm sm:text-base"
-                >
-                  {t.submitPage.result.approved.viewSkill}
-                </Link>
-                <div className="mt-8 border border-border p-4 text-left sm:p-5">
-                  <p className="mb-2 text-xs uppercase tracking-widest text-secondary">
-                    {t.submitPage.result.approved.badgeEyebrow}
-                  </p>
-                  <p className="mb-3 text-sm leading-relaxed text-secondary">
-                    {t.submitPage.result.approved.badgeDescription}
-                  </p>
-                  <pre className="overflow-x-auto border border-border bg-background p-3 font-mono text-[11px] leading-relaxed text-secondary">
-                    <code>{`[![OpenAgentSkill](https://www.openagentskill.com/api/badge/${reviewResult.skill.slug})](https://www.openagentskill.com/skills/${reviewResult.skill.slug})`}</code>
-                  </pre>
-                </div>
-              </>
-            ) : (
-              <>
-                <h1 className="font-display text-3xl sm:text-4xl font-bold mb-4">
-                  {t.submitPage.result.rejected.title}
-                </h1>
-                <p className="text-base sm:text-lg text-secondary mb-8">
-                  {t.submitPage.result.rejected.subtitle}
-                </p>
-                <div className="border border-destructive p-4 sm:p-6 mb-8 text-left">
-                  <h2 className="font-semibold text-lg sm:text-xl mb-4">
-                    {t.submitPage.result.rejected.reviewIssues}
-                  </h2>
-                  <ul className="list-disc list-inside text-sm space-y-2">
-                    {reviewResult.review.issues.map((issue: string, i: number) => (
-                      <li key={i} className="text-destructive">{issue}</li>
-                    ))}
-                  </ul>
-                  {reviewResult.review.suggestions.length > 0 && (
-                    <div className="mt-4 pt-4 border-t border-border">
-                      <h3 className="font-semibold mb-2">{t.submitPage.result.rejected.suggestions}</h3>
-                      <ul className="list-disc list-inside text-sm text-secondary space-y-1">
-                        {reviewResult.review.suggestions.map((suggestion: string, i: number) => (
-                          <li key={i}>{suggestion}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-                  <div className="mt-4 pt-4 border-t border-border text-sm text-secondary">
-                    <p>{reviewResult.review.reasoning}</p>
-                  </div>
-                </div>
-                <button
-                  onClick={() => setSubmitted(false)}
-                  className="inline-block px-4 sm:px-6 py-2 sm:py-3 border-2 border-foreground font-semibold hover:bg-foreground hover:text-background transition-colors text-sm sm:text-base"
-                >
-                  {t.submitPage.result.rejected.resubmit}
-                </button>
-              </>
-            )}
-          </div>
-        </main>
-        <SiteFooter />
-      </div>
-    )
-  }
+  const status = result?.status || receipt?.status
+  const finished = status && !['submitted', 'processing'].includes(status)
 
   return (
     <div className="min-h-screen bg-background text-foreground">
       <SiteHeader />
-
-      {/* Main Content */}
       <main>
         <section className="relative overflow-hidden border-b border-border">
           <div className="brand-grain pointer-events-none absolute inset-0 opacity-60" />
           <div className="relative mx-auto max-w-6xl px-6 py-14 text-center sm:py-16 lg:py-20">
-            <p className="font-mono text-xs uppercase tracking-[0.24em] text-secondary">{t.submitPage.eyebrow}</p>
+            <p className="font-mono text-xs uppercase tracking-[0.24em] text-secondary">
+              {zh ? '开放提交 · 0 STAR 可用' : 'OPEN SUBMISSION · ZERO STARS OK'}
+            </p>
             <h1 className="mx-auto mt-5 max-w-4xl font-display text-4xl font-normal leading-[0.98] text-balance sm:text-5xl lg:text-6xl">
-              {t.submitPage.title}
+              {zh ? '粘贴一个链接，让 Skill 被发现' : 'Paste one link. Make your skill discoverable.'}
             </h1>
             <p className="mx-auto mt-6 max-w-2xl text-base leading-7 text-secondary sm:text-lg">
-              {t.submitPage.subtitle}
+              {zh
+                ? '支持仓库、子目录和 SKILL.md 链接。先进入社区队列，再异步审核；不再要求 Star、README、分类或标签。'
+                : 'Repository, subdirectory, and SKILL.md URLs are supported. We save first and review asynchronously—no star, README, category, or tag gate.'}
             </p>
           </div>
         </section>
 
         <div className="mx-auto max-w-4xl px-6 py-10 sm:py-12">
-          <SkillSubmitForm onSubmit={handleSubmit} />
+          {!receipt ? (
+            <SkillSubmitForm onSubmit={handleSubmit} />
+          ) : (
+            <section className="mx-auto max-w-2xl border border-border bg-card p-6 sm:p-8">
+              <p className="font-mono text-xs uppercase tracking-[0.2em] text-secondary">
+                {finished ? (zh ? '处理完成' : 'PROCESSING COMPLETE') : (zh ? '已保存' : 'SAVED')}
+              </p>
+              <h1 className="mt-3 font-display text-3xl">
+                {status === 'reviewed' && (zh ? '已通过审核并发布' : 'Reviewed and published')}
+                {status === 'listed' && (zh ? '已进入社区待审队列' : 'Listed for community review')}
+                {status === 'duplicate' && (zh ? '这个 Skill 已经收录' : 'This skill is already listed')}
+                {status === 'quarantined' && (zh ? '已隔离，暂不公开' : 'Quarantined and not public')}
+                {(!finished || !status) && (zh ? '正在执行安全与质量审核' : 'Security and quality review in progress')}
+              </h1>
+              <p className="mt-4 text-sm leading-6 text-secondary">
+                {result?.skill.name || receipt.skill.name} · <span className="font-mono">{receipt.skill.path}</span>
+              </p>
 
-          <section className="mx-auto mt-8 max-w-2xl border border-border bg-card p-5 sm:mt-10 sm:p-6">
-            <p className="mb-3 text-xs uppercase tracking-widest text-secondary">{t.submitPage.afterApproval.eyebrow}</p>
-            <h2 className="font-display text-2xl font-semibold">{t.submitPage.afterApproval.title}</h2>
-            <p className="mt-3 text-sm leading-relaxed text-secondary">
-              {t.submitPage.afterApproval.description}
-            </p>
-            <pre className="mt-5 overflow-x-auto border border-border bg-background p-3 font-mono text-[11px] leading-relaxed text-secondary">
-              <code>{`[![OpenAgentSkill](https://www.openagentskill.com/api/badge/YOUR-SKILL-SLUG)](https://www.openagentskill.com/skills/YOUR-SKILL-SLUG)`}</code>
-            </pre>
-            <div className="mt-5 grid gap-3 text-sm sm:grid-cols-3">
-              {t.submitPage.afterApproval.steps.map((copy, index) => (
-                <div key={copy} className="border border-border bg-background p-4">
-                  <span className="font-mono text-xs text-secondary">{index + 1}</span>
-                  <p className="mt-2 leading-relaxed">{copy}</p>
+              {result?.review?.issues && result.review.issues.length > 0 && (
+                <div className="mt-6 border border-border p-4">
+                  <p className="font-semibold">{zh ? '发现的问题' : 'Review notes'}</p>
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-secondary">
+                    {result.review.issues.map((issue) => <li key={issue}>{issue}</li>)}
+                  </ul>
                 </div>
-              ))}
+              )}
+              {result?.review?.suggestions && result.review.suggestions.length > 0 && (
+                <div className="mt-4 border border-border p-4">
+                  <p className="font-semibold">{zh ? '改进建议' : 'Suggestions'}</p>
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-secondary">
+                    {result.review.suggestions.map((suggestion) => <li key={suggestion}>{suggestion}</li>)}
+                  </ul>
+                </div>
+              )}
+
+              <div className="mt-7 flex flex-wrap gap-3">
+                {result?.skill.slug && (
+                  <Link href={`/skills/${result.skill.slug}`} className="bg-foreground px-5 py-2.5 text-sm font-semibold text-background">
+                    {zh ? '查看 Skill' : 'View skill'}
+                  </Link>
+                )}
+                {status === 'listed' && (
+                  <Link href="/skills/new" className="border border-foreground px-5 py-2.5 text-sm font-semibold">
+                    {zh ? '查看社区队列' : 'View community queue'}
+                  </Link>
+                )}
+                <button type="button" onClick={() => { setReceipt(null); setResult(null) }} className="border border-border px-5 py-2.5 text-sm">
+                  {zh ? '再提交一个' : 'Submit another'}
+                </button>
+              </div>
+              <p className="mt-6 break-all font-mono text-[11px] leading-5 text-secondary">
+                {zh ? '私密状态链接：' : 'Private status URL: '}{receipt.statusUrl}
+              </p>
+            </section>
+          )}
+
+          <section className="mx-auto mt-10 max-w-2xl border-t border-border pt-8">
+            <h2 className="font-display text-2xl">{zh ? '新的收录规则' : 'How listing now works'}</h2>
+            <div className="mt-5 grid gap-3 text-sm sm:grid-cols-3">
+              {[
+                zh ? '1. 有效 SKILL.md 即可提交' : '1. Submit any valid SKILL.md',
+                zh ? '2. 先保存，再异步审核' : '2. Save first, review async',
+                zh ? '3. 高风险内容隔离，其余进入社区队列' : '3. Quarantine critical risk; queue the rest',
+              ].map((item) => <div key={item} className="border border-border p-4 leading-6">{item}</div>)}
             </div>
           </section>
-
-          {/* Info */}
-          <div className="max-w-2xl mx-auto mt-8 sm:mt-12 border-t border-border pt-6 sm:pt-8">
-            <h2 className="font-semibold text-lg sm:text-xl mb-4">{t.submitPage.guidelines.title}</h2>
-            <ul className="space-y-2 text-sm text-secondary">
-              {t.submitPage.guidelines.items.map((item, i) => (
-                <li key={i}>• {item}</li>
-              ))}
-            </ul>
-          </div>
         </div>
       </main>
       <SiteFooter />

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -62,6 +62,7 @@ export function SiteFooter() {
               <h2 className="font-mono text-[11px] uppercase tracking-[0.22em] text-secondary">{shell.footerExplore}</h2>
               <div className="mt-4 grid gap-2 text-secondary">
                 <FooterLink href="/skills" className="hover:text-foreground">{t.nav.skills}</FooterLink>
+                <FooterLink href="/skills/new" className="hover:text-foreground">New submissions</FooterLink>
                 <FooterLink href="/agent-skills" className="hover:text-foreground">Agent Skills</FooterLink>
                 <FooterLink href="/agent-skill" className="hover:text-foreground">What Is an Agent Skill?</FooterLink>
                 <FooterLink href="/ai-agent-skills" className="hover:text-foreground">AI Agent Skills</FooterLink>

--- a/components/skill-submit-form.tsx
+++ b/components/skill-submit-form.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import { parseGitHubUrl } from '@/lib/github/api'
-import { interpolate, useI18n } from '@/lib/i18n/context'
-import { SKILL_SUBMISSION_MIN_STARS } from '@/lib/skills/submission-policy'
+import { useEffect, useMemo, useState } from 'react'
+import { useI18n } from '@/lib/i18n/context'
 
 interface SubmitFormProps {
   onSubmit: (data: SubmitFormData) => Promise<void>
@@ -11,286 +9,333 @@ interface SubmitFormProps {
 
 export interface SubmitFormData {
   repository: string
-  category: string
+  skillPath: string
+  sourceRef?: string
+  category?: string
   tags: string[]
-  submissionSource: 'web' | 'api' | 'agent'
+  makerGithub?: string
+  makerX?: string
+  submissionSource: 'web'
 }
 
+interface SkillCandidate {
+  name: string
+  description: string
+  path: string
+  ref: string
+  sourceUrl: string
+}
+
+interface ValidationResponse {
+  valid?: boolean
+  code?: string
+  error?: string
+  stars?: number
+  repository?: { owner: string; fullName: string; stars: number }
+  skills?: SkillCandidate[]
+}
+
+const DRAFT_KEY = 'openagentskill.submitDraft.v2'
+
+const categories = [
+  ['data-analysis', 'Data Analysis'],
+  ['code-generation', 'Code Generation'],
+  ['research', 'Research'],
+  ['automation', 'Automation'],
+  ['communication', 'Communication'],
+  ['creative', 'Creative'],
+  ['business', 'Business'],
+  ['developer-tools', 'Developer Tools'],
+  ['security', 'Security'],
+  ['integration', 'Integration'],
+]
+
 export function SkillSubmitForm({ onSubmit }: SubmitFormProps) {
-  const { t } = useI18n()
+  const { locale } = useI18n()
+  const zh = locale === 'zh'
   const [repository, setRepository] = useState('')
   const [category, setCategory] = useState('')
   const [tagInput, setTagInput] = useState('')
   const [tags, setTags] = useState<string[]>([])
+  const [makerGithub, setMakerGithub] = useState('')
+  const [makerX, setMakerX] = useState('')
+  const [candidates, setCandidates] = useState<SkillCandidate[]>([])
+  const [selectedPath, setSelectedPath] = useState('')
   const [validating, setValidating] = useState(false)
   const [repoValid, setRepoValid] = useState<boolean | null>(null)
   const [repoStars, setRepoStars] = useState<number | null>(null)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
+  const [draftLoaded, setDraftLoaded] = useState(false)
 
-  const getValidationError = (data: {
-    code?: string
-    error?: string
-    stars?: number
-    minStars?: number
-  }) => {
-    switch (data.code) {
-      case 'REPOSITORY_REQUIRED':
-        return t.submitPage.form.repositoryRequired
-      case 'MINIMUM_STARS':
-        return interpolate(t.submitPage.form.minimumStarsError, {
-          stars: data.stars ?? 0,
-          minStars: data.minStars ?? SKILL_SUBMISSION_MIN_STARS,
-        })
-      case 'MISSING_README':
-        return t.submitPage.form.missingReadme
-      default:
-        return data.error || t.submitPage.form.validationFailed
+  const selectedCandidate = useMemo(
+    () => candidates.find((candidate) => candidate.path === selectedPath) || null,
+    [candidates, selectedPath]
+  )
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      try {
+        const raw = window.localStorage.getItem(DRAFT_KEY)
+        if (raw) {
+          const draft = JSON.parse(raw) as Partial<SubmitFormData>
+          setRepository(draft.repository || '')
+          setCategory(draft.category || '')
+          setTags(Array.isArray(draft.tags) ? draft.tags.slice(0, 10) : [])
+          setMakerGithub(draft.makerGithub || '')
+          setMakerX(draft.makerX || '')
+        }
+      } catch {
+        // Local drafts are a convenience and must never block the form.
+      } finally {
+        setDraftLoaded(true)
+      }
+    }, 0)
+    return () => window.clearTimeout(timer)
+  }, [])
+
+  useEffect(() => {
+    if (!draftLoaded) return
+    try {
+      window.localStorage.setItem(DRAFT_KEY, JSON.stringify({
+        repository,
+        category: category || undefined,
+        tags,
+        makerGithub: makerGithub || undefined,
+        makerX: makerX || undefined,
+      }))
+    } catch {
+      // Private browsing may disable localStorage.
     }
+  }, [category, draftLoaded, makerGithub, makerX, repository, tags])
+
+  function validationMessage(data: ValidationResponse) {
+    if (data.code === 'MISSING_SKILL_FILE') {
+      return zh
+        ? '没有找到包含 name 和 description 的有效 SKILL.md。也可以直接粘贴 Skill 目录或 SKILL.md 链接。'
+        : 'No valid SKILL.md with name and description was found. You can paste a skill directory or SKILL.md URL.'
+    }
+    if (data.code === 'INVALID_REPOSITORY') {
+      return zh
+        ? '请输入 GitHub 仓库、Skill 目录或 SKILL.md 链接。'
+        : 'Enter a GitHub repository, skill directory, or SKILL.md URL.'
+    }
+    return data.error || (zh ? '验证失败，请稍后重试。' : 'Validation failed. Please try again.')
   }
 
-  const categories = [
-    { value: 'data-analysis', label: t.submitPage.form.categories.dataAnalysis },
-    { value: 'code-generation', label: t.submitPage.form.categories.codeGeneration },
-    { value: 'research', label: t.submitPage.form.categories.research },
-    { value: 'automation', label: t.submitPage.form.categories.automation },
-    { value: 'communication', label: t.submitPage.form.categories.communication },
-    { value: 'creative', label: t.submitPage.form.categories.creative },
-    { value: 'business', label: t.submitPage.form.categories.business },
-    { value: 'developer-tools', label: t.submitPage.form.categories.developerTools },
-    { value: 'security', label: t.submitPage.form.categories.security },
-    { value: 'integration', label: t.submitPage.form.categories.integration },
-  ]
-
-  const validateRepo = async (repoUrl: string) => {
-    if (!repoUrl) {
-      setRepoValid(null)
-      return
-    }
-
-    const parsed = parseGitHubUrl(repoUrl)
-    if (!parsed) {
-      setRepoValid(false)
-      setError(t.submitPage.form.repoValidError)
-      return
-    }
-
+  async function validateRepo() {
+    if (!repository.trim()) return
     setValidating(true)
     setError('')
-
+    setCandidates([])
+    setSelectedPath('')
     try {
       const response = await fetch('/api/skills/validate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ repository: repoUrl }),
+        body: JSON.stringify({ repository }),
       })
-
-      const data = await response.json()
-
-      if (response.ok && data.valid) {
-        setRepoValid(true)
-        setRepoStars(data.stars ?? null)
-        setError('')
-      } else {
+      const data = await response.json() as ValidationResponse
+      if (!response.ok || !data.valid || !data.skills?.length) {
         setRepoValid(false)
         setRepoStars(data.stars ?? null)
-        setError(getValidationError(data))
+        setError(validationMessage(data))
+        return
       }
-    } catch (err) {
+
+      setRepoValid(true)
+      setRepoStars(data.repository?.stars ?? data.stars ?? null)
+      setCandidates(data.skills)
+      setSelectedPath(data.skills[0].path)
+      if (!makerGithub && data.repository?.owner) setMakerGithub(data.repository.owner)
+    } catch {
       setRepoValid(false)
-      setError(t.submitPage.form.retryLater)
+      setError(zh ? '验证失败，请稍后重试。' : 'Validation failed. Please try again.')
     } finally {
       setValidating(false)
     }
   }
 
-  const handleRepoChange = (value: string) => {
-    setRepository(value)
-    setRepoValid(null)
-    setRepoStars(null)
-    setError('')
+  function addTag() {
+    const tag = tagInput.trim()
+    if (tag && !tags.includes(tag) && tags.length < 10) setTags([...tags, tag])
+    setTagInput('')
   }
 
-  const handleRepoBlur = () => {
-    validateRepo(repository)
-  }
-
-  const addTag = () => {
-    const trimmed = tagInput.trim()
-    if (trimmed && !tags.includes(trimmed) && tags.length < 10) {
-      setTags([...tags, trimmed])
-      setTagInput('')
-    }
-  }
-
-  const removeTag = (tag: string) => {
-    setTags(tags.filter(t => t !== tag))
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (!repoValid) {
-      setError(t.submitPage.form.pleaseValidate)
-      return
-    }
-
-    if (!category) {
-      setError(t.submitPage.form.pleaseSelectCategory)
-      return
-    }
-
-    if (tags.length === 0) {
-      setError(t.submitPage.form.pleaseAddTags)
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    if (!repoValid || !selectedCandidate) {
+      setError(zh ? '请先查找并选择一个 SKILL.md。' : 'Find and select a SKILL.md first.')
       return
     }
 
     setSubmitting(true)
     setError('')
-
     try {
       await onSubmit({
         repository,
-        category,
+        skillPath: selectedCandidate.path,
+        sourceRef: selectedCandidate.ref,
+        category: category || undefined,
         tags,
+        makerGithub: makerGithub || undefined,
+        makerX: makerX || undefined,
         submissionSource: 'web',
       })
-    } catch (err: any) {
-      setError(err.message || t.submitPage.form.retryLater)
+      try { window.localStorage.removeItem(DRAFT_KEY) } catch {}
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : (zh ? '提交失败。' : 'Submission failed.'))
     } finally {
       setSubmitting(false)
     }
   }
 
   return (
-    <form onSubmit={handleSubmit} className="max-w-2xl mx-auto space-y-6 sm:space-y-8">
-      {/* GitHub Repository */}
+    <form onSubmit={handleSubmit} className="mx-auto max-w-2xl space-y-7">
       <div>
-        <label htmlFor="repository" className="block text-sm font-semibold mb-2">
-          {t.submitPage.form.repository}
+        <label htmlFor="repository" className="mb-2 block text-sm font-semibold">
+          {zh ? 'GitHub 仓库或 SKILL.md 链接' : 'GitHub repository or SKILL.md URL'}
         </label>
-        <div className="relative">
+        <div className="flex flex-col gap-2 sm:flex-row">
           <input
             id="repository"
             type="text"
             value={repository}
-            onChange={(e) => handleRepoChange(e.target.value)}
-            onBlur={handleRepoBlur}
-            placeholder={t.submitPage.form.repositoryPlaceholder}
-            className="w-full border border-border bg-background px-3 sm:px-4 py-2 sm:py-3 text-sm sm:text-base focus:border-foreground focus:outline-none pr-24"
-            required
-          />
-          {repoStars !== null && repoValid === true && (
-            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs font-mono text-secondary border border-border px-2 py-0.5 bg-background">
-              {repoStars.toLocaleString()} stars
-            </span>
-          )}
-        </div>
-        <p className="mt-1.5 text-xs text-secondary">
-          {interpolate(t.submitPage.form.repositoryRequirements, {
-            minStars: SKILL_SUBMISSION_MIN_STARS,
-          })}
-        </p>
-        {validating && (
-          <p className="mt-2 text-sm text-secondary">{t.submitPage.form.validating}</p>
-        )}
-        {repoValid === true && (
-          <p className="mt-2 text-sm text-foreground">
-            {t.submitPage.form.repoValidSuccess}
-            {repoStars !== null && (
-              <span className="ml-1 text-secondary">({repoStars.toLocaleString()} stars)</span>
-            )}
-          </p>
-        )}
-        {repoValid === false && error && (
-          <p className="mt-2 text-sm text-destructive">{error}</p>
-        )}
-      </div>
-
-      {/* Category */}
-      <div>
-        <label htmlFor="category" className="block text-sm font-semibold mb-2">
-          {t.submitPage.form.category}
-        </label>
-        <select
-          id="category"
-          value={category}
-          onChange={(e) => setCategory(e.target.value)}
-          className="w-full border border-border bg-background px-3 sm:px-4 py-2 sm:py-3 text-sm sm:text-base focus:border-foreground focus:outline-none"
-          required
-        >
-          <option value="">{t.submitPage.form.categoryPlaceholder}</option>
-          {categories.map((cat) => (
-            <option key={cat.value} value={cat.value}>
-              {cat.label}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* Tags */}
-      <div>
-        <label htmlFor="tags" className="block text-sm font-semibold mb-2">
-          {t.submitPage.form.tags}
-        </label>
-        <div className="flex gap-2 mb-2">
-          <input
-            id="tags"
-            type="text"
-            value={tagInput}
-            onChange={(e) => setTagInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                addTag()
-              }
+            onChange={(event) => {
+              setRepository(event.target.value)
+              setRepoValid(null)
+              setRepoStars(null)
+              setCandidates([])
+              setSelectedPath('')
+              setError('')
             }}
-            placeholder={t.submitPage.form.tagsPlaceholder}
-            className="flex-1 border border-border bg-background px-3 sm:px-4 py-2 text-xs sm:text-sm focus:border-foreground focus:outline-none"
+            placeholder="https://github.com/owner/repo/tree/main/skills/my-skill"
+            className="min-w-0 flex-1 border border-border bg-background px-4 py-3 text-sm focus:border-foreground focus:outline-none"
+            required
           />
           <button
             type="button"
-            onClick={addTag}
-            className="px-3 sm:px-4 py-2 border border-foreground text-xs sm:text-sm hover:bg-muted transition-colors whitespace-nowrap"
+            onClick={validateRepo}
+            disabled={validating || !repository.trim()}
+            className="h-12 border border-foreground px-5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-40"
           >
-            {t.submitPage.form.addTag}
+            {validating ? (zh ? '查找中…' : 'Finding…') : (zh ? '查找 Skill' : 'Find Skills')}
           </button>
         </div>
-        {tags.length > 0 && (
-          <div className="flex flex-wrap gap-2">
-            {tags.map((tag) => (
-              <span
-                key={tag}
-                className="inline-flex items-center gap-2 px-2 sm:px-3 py-1 border border-border text-xs sm:text-sm"
-              >
-                {tag}
-                <button
-                  type="button"
-                  onClick={() => removeTag(tag)}
-                  className="hover:text-destructive"
-                >
-                  ×
-                </button>
-              </span>
-            ))}
-          </div>
+        <p className="mt-2 text-xs leading-5 text-secondary">
+          {zh
+            ? '0 Star 也可以提交。只要求有效的 SKILL.md；README、分类和标签不再是硬性门槛。'
+            : 'Zero-star skills are welcome. A valid SKILL.md is required; README, category, and tags are not hard gates.'}
+        </p>
+        {repoStars !== null && (
+          <p className="mt-2 font-mono text-xs text-secondary">
+            {repoStars.toLocaleString()} GitHub stars · {zh ? '仅作为排序信号' : 'ranking signal only'}
+          </p>
         )}
+        {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
       </div>
 
-      {/* Submit Button */}
-      <div className="pt-4">
-        <button
-          type="submit"
-          disabled={!repoValid || submitting}
-          className="w-full px-4 sm:px-6 py-2 sm:py-3 border-2 border-foreground bg-foreground text-background font-semibold hover:bg-background hover:text-foreground transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-sm sm:text-base"
-        >
-          {submitting ? t.submitPage.form.submitting : t.submitPage.form.submit}
-        </button>
-      </div>
-
-      {error && !repoValid && (
-        <p className="text-sm text-destructive text-center">{error}</p>
+      {candidates.length > 0 && (
+        <div>
+          <label htmlFor="skill-path" className="mb-2 block text-sm font-semibold">
+            {zh ? `选择 SKILL.md（发现 ${candidates.length} 个）` : `Choose SKILL.md (${candidates.length} found)`}
+          </label>
+          <select
+            id="skill-path"
+            value={selectedPath}
+            onChange={(event) => setSelectedPath(event.target.value)}
+            className="w-full border border-border bg-background px-4 py-3 text-sm focus:border-foreground focus:outline-none"
+          >
+            {candidates.map((candidate) => (
+              <option key={`${candidate.ref}:${candidate.path}`} value={candidate.path}>
+                {candidate.name} — {candidate.path}
+              </option>
+            ))}
+          </select>
+          {selectedCandidate && (
+            <div className="mt-3 border border-border bg-card p-4">
+              <p className="font-semibold">{selectedCandidate.name}</p>
+              <p className="mt-1 text-sm leading-6 text-secondary">{selectedCandidate.description}</p>
+              <p className="mt-2 break-all font-mono text-[11px] text-secondary">{selectedCandidate.sourceUrl}</p>
+            </div>
+          )}
+        </div>
       )}
+
+      <div className="grid gap-5 sm:grid-cols-2">
+        <div>
+          <label htmlFor="category" className="mb-2 block text-sm font-semibold">
+            {zh ? '分类（选填）' : 'Category (optional)'}
+          </label>
+          <select id="category" value={category} onChange={(event) => setCategory(event.target.value)} className="w-full border border-border bg-background px-4 py-3 text-sm focus:border-foreground focus:outline-none">
+            <option value="">{zh ? '自动识别' : 'Auto-detect'}</option>
+            {categories.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="tags" className="mb-2 block text-sm font-semibold">
+            {zh ? '标签（选填）' : 'Tags (optional)'}
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="tags"
+              value={tagInput}
+              onChange={(event) => setTagInput(event.target.value)}
+              onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); addTag() } }}
+              placeholder={zh ? '留空则自动补全' : 'Auto-filled when empty'}
+              className="min-w-0 flex-1 border border-border bg-background px-3 py-3 text-sm focus:border-foreground focus:outline-none"
+            />
+            <button type="button" onClick={addTag} className="border border-border px-3 text-sm">+</button>
+          </div>
+        </div>
+      </div>
+
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <button key={tag} type="button" onClick={() => setTags(tags.filter((item) => item !== tag))} className="border border-border px-3 py-1 text-xs">
+              {tag} ×
+            </button>
+          ))}
+        </div>
+      )}
+
+      <fieldset className="border border-border bg-card p-5">
+        <legend className="px-2 font-mono text-xs uppercase tracking-[0.18em] text-secondary">
+          {zh ? 'Maker 身份（选填）' : 'Maker identity (optional)'}
+        </legend>
+        <p className="mb-4 text-xs leading-5 text-secondary">
+          {zh
+            ? '填写账号会创建公开资料链接，但不会自动获得“已验证”标记。认证需要 OAuth 或仓库所有权证明。'
+            : 'Handles create public profile links but do not grant a verified badge. Verification requires OAuth or repository ownership proof.'}
+        </p>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="maker-github" className="mb-1.5 block text-xs font-semibold">GitHub</label>
+            <div className="flex border border-border bg-background">
+              <span className="px-3 py-2.5 text-sm text-secondary">@</span>
+              <input id="maker-github" value={makerGithub} onChange={(event) => setMakerGithub(event.target.value.replace(/^@/, ''))} maxLength={39} className="min-w-0 flex-1 bg-transparent py-2.5 pr-3 text-sm focus:outline-none" placeholder="octocat" />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="maker-x" className="mb-1.5 block text-xs font-semibold">X</label>
+            <div className="flex border border-border bg-background">
+              <span className="px-3 py-2.5 text-sm text-secondary">@</span>
+              <input id="maker-x" value={makerX} onChange={(event) => setMakerX(event.target.value.replace(/^@/, ''))} maxLength={15} className="min-w-0 flex-1 bg-transparent py-2.5 pr-3 text-sm focus:outline-none" placeholder="maker" />
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      <div className="border border-border p-4 text-xs leading-5 text-secondary">
+        {zh
+          ? '提交会先保存到社区队列，再异步执行安全与质量审核。只有 Reviewed、Verified 或 Agent Proven Skill 才会进入默认 Agent 推荐。'
+          : 'Submissions are saved to the community queue first, then reviewed asynchronously. Only Reviewed, Verified, or Agent Proven skills enter default Agent recommendations.'}
+      </div>
+
+      <button type="submit" disabled={!repoValid || !selectedCandidate || submitting} className="w-full bg-foreground px-6 py-3 font-semibold text-background transition-opacity disabled:cursor-not-allowed disabled:opacity-40">
+        {submitting ? (zh ? '正在保存…' : 'Saving…') : (zh ? '提交到社区队列' : 'Submit to community queue')}
+      </button>
     </form>
   )
 }

--- a/lib/ai-review/reviewer.ts
+++ b/lib/ai-review/reviewer.ts
@@ -1,12 +1,12 @@
 import { generateText } from 'ai'
-import { AIReviewResult } from '../schema/skill-schema'
+import type { AIReviewResult } from '../schema/skill-schema'
 import { SUBMISSION_REVIEW_MODEL } from '@/lib/ai/models'
 
 export interface SkillReviewData {
   repository: string
   readmeContent: string
   codeFiles: { path: string; content: string }[]
-  manifestData?: any
+  manifestData?: object & { license?: unknown }
   githubStats: {
     stars: number
     forks: number
@@ -25,15 +25,43 @@ function includesAny(text: string, patterns: RegExp[]) {
 }
 
 function heuristicReview(data: SkillReviewData, reason: string): AIReviewResult {
-  const readme = data.readmeContent || ''
+  const documentation = data.readmeContent || ''
   const combinedCode = data.codeFiles.map((file) => file.content).join('\n')
-  const allText = `${readme}\n${combinedCode}`.toLowerCase()
-  const hasCriticalPattern = includesAny(allText, [/rm\s+-rf/, /base64\.b64decode[\s\S]{0,120}exec/, /curl[\s\S]{0,80}\|\s*(bash|sh)/])
-  const hasExecutionSurface = includesAny(allText, [/child_process/, /\bexec\s*\(/, /subprocess/, /os\.system\s*\(/])
-  const hasEnvSurface = includesAny(allText, [/process\.env/, /os\.environ/, /\.env\b/, /load_dotenv/])
-  const hasInstallDocs = includesAny(readme.toLowerCase(), [/install/, /npx\s+skills\s+add/, /usage/, /quickstart/, /getting started/])
-  const hasExamples = includesAny(readme.toLowerCase(), [/example/, /demo/, /usage/, /```/])
-  const hasAgentLanguage = includesAny(readme.toLowerCase(), [/agent/, /skill/, /codex/, /claude code/, /cursor/, /workflow/, /automation/])
+  const allText = `${documentation}\n${combinedCode}`.toLowerCase()
+  const hasCriticalPattern = includesAny(allText, [
+    /rm\s+-rf/,
+    /base64\.b64decode[\s\S]{0,120}exec/,
+    /curl[\s\S]{0,80}\|\s*(bash|sh)/,
+  ])
+  const hasExecutionSurface = includesAny(allText, [
+    /child_process/,
+    /\bexec\s*\(/,
+    /subprocess/,
+    /os\.system\s*\(/,
+  ])
+  const hasEnvSurface = includesAny(allText, [
+    /process\.env/,
+    /os\.environ/,
+    /\.env\b/,
+    /load_dotenv/,
+  ])
+  const hasInstallDocs = includesAny(documentation.toLowerCase(), [
+    /install/,
+    /npx\s+skills\s+add/,
+    /usage/,
+    /quickstart/,
+    /getting started/,
+  ])
+  const hasExamples = includesAny(documentation.toLowerCase(), [/example/, /demo/, /usage/, /```/])
+  const hasAgentLanguage = includesAny(documentation.toLowerCase(), [
+    /agent/,
+    /skill/,
+    /codex/,
+    /claude code/,
+    /cursor/,
+    /workflow/,
+    /automation/,
+  ])
   const hasOpenLicense =
     Boolean(data.githubStats.license && data.githubStats.license !== 'NOASSERTION') ||
     Boolean(data.manifestData?.license)
@@ -41,7 +69,7 @@ function heuristicReview(data: SkillReviewData, reason: string): AIReviewResult 
   const security = clampScore(9 - (hasCriticalPattern ? 7 : 0) - (hasExecutionSurface ? 2 : 0) - (hasEnvSurface ? 1 : 0))
   const quality = clampScore(
     4 +
-      (readme.length > 1000 ? 2 : readme.length > 400 ? 1 : 0) +
+      (documentation.length > 1000 ? 2 : documentation.length > 400 ? 1 : 0) +
       (hasInstallDocs ? 1 : 0) +
       (hasExamples ? 1 : 0) +
       (data.manifestData ? 1 : 0) +
@@ -56,158 +84,133 @@ function heuristicReview(data: SkillReviewData, reason: string): AIReviewResult 
   )
   const compliance = clampScore(5 + (hasOpenLicense ? 3 : 0) + (data.repository.includes('/') ? 1 : 0))
   const totalScore = security + quality + usefulness + compliance
-  const issues = [
-    'AI model review was unavailable; heuristic scoring was used and manual review is required',
-    ...(hasCriticalPattern ? ['Critical shell or encoded execution pattern detected'] : []),
-    ...(hasExecutionSurface ? ['Command execution surface detected'] : []),
-    ...(hasEnvSurface ? ['Environment variable access detected'] : []),
-    ...(!hasInstallDocs ? ['README should include clearer install or usage instructions'] : []),
-    ...(!hasOpenLicense ? ['License metadata should be explicit'] : []),
-  ]
 
   return {
     approved: false,
-    scores: {
-      security,
-      quality,
-      usefulness,
-      compliance,
-    },
+    scores: { security, quality, usefulness, compliance },
     totalScore,
-    issues,
+    issues: [
+      'AI model review was unavailable; heuristic scoring was used and manual review is required',
+      ...(hasCriticalPattern ? ['Critical shell or encoded execution pattern detected'] : []),
+      ...(hasExecutionSurface ? ['Command execution surface detected'] : []),
+      ...(hasEnvSurface ? ['Environment variable access detected'] : []),
+      ...(!hasInstallDocs ? ['SKILL.md should include clearer install or usage instructions'] : []),
+      ...(!hasOpenLicense ? ['License metadata should be explicit'] : []),
+    ],
     suggestions: [
-      'Add a clear SKILL.md or skill.json manifest',
-      'Document install, usage, inputs, outputs, and safe operating boundaries',
+      'Add complete SKILL.md frontmatter and operating instructions',
+      'Document setup, inputs, outputs, and safe operating boundaries',
       'Request manual review before automatic publishing',
     ],
-    reasoning: `AI review failed (${reason}). A conservative heuristic review produced scores but cannot approve automatic publishing.`,
+    reasoning: `AI review failed (${reason}). Conservative heuristic scores cannot approve automatic publishing.`,
     reviewedAt: new Date().toISOString(),
-    reviewModel: 'heuristic-static-v1',
+    reviewModel: 'heuristic-static-v2',
   }
 }
 
 export async function reviewSkill(data: SkillReviewData): Promise<AIReviewResult> {
   const codePreview = data.codeFiles
-    .slice(0, 3)
-    .map(f => `// ${f.path}\n${f.content.slice(0, 1000)}`)
+    .slice(0, 6)
+    .map((file) => `// ${file.path}\n${file.content.slice(0, 1600)}`)
     .join('\n\n---\n\n')
 
-  const prompt = `你是一个专业的代码审核 AI，负责审核提交到 OpenAgentSkill 平台的技能。
+  const prompt = `You review Agent Skills submitted to OpenAgentSkill.
 
 Repository: ${data.repository}
-GitHub Stats: ${data.githubStats.stars} stars, ${data.githubStats.forks} forks
-Last Updated: ${data.githubStats.lastUpdated}
+GitHub adoption: ${data.githubStats.stars} stars, ${data.githubStats.forks} forks
+Last updated: ${data.githubStats.lastUpdated}
 
-README 内容（前 2000 字符）：
-${data.readmeContent.slice(0, 2000)}
+SKILL.md and documentation excerpt:
+${data.readmeContent.slice(0, 5000)}
 
-${data.manifestData ? `Skill Manifest:
+${data.manifestData ? `Parsed SKILL.md metadata:
 ${JSON.stringify(data.manifestData, null, 2)}` : ''}
 
-主要代码文件预览：
+Files from the submitted skill directory:
 ${codePreview}
 
-请从以下四个维度评分（0-10分）：
+Score each dimension from 0 to 10:
+1. Security: prompt injection, destructive commands, secret access, exfiltration,
+   unsafe downloads, hidden execution, and excessive permissions.
+2. Quality: purpose, inputs, workflow, outputs, setup, limitations, and safe
+   operating boundaries are clear in SKILL.md.
+3. Usefulness: this is a concrete reusable agent workflow, not a generic
+   repository, link list, placeholder, or thin prompt.
+4. Compliance: license clarity, attribution, and authorized lawful use.
 
-1. **安全性** (Security)
-   - 是否有恶意代码（eval, exec, subprocess 等）
-   - 是否有可疑的网络请求
-   - 是否泄露敏感信息（API keys, tokens）
-   - 依赖是否安全
+Policy:
+- GitHub stars are only an adoption signal. Never reject a skill because it has
+  zero or few stars.
+- A missing repository README is acceptable when SKILL.md is complete.
+- approved=true requires security >= 7, every dimension >= 6, total >= 32,
+  and no critical risk.
+- Quality shortcomings should produce actionable issues and suggestions.
+- Automated review never verifies publisher identity.
 
-2. **质量** (Quality)
-   - 代码结构是否清晰
-   - README 文档是否完整（包含安装说明、示例、API 文档）
-   - 是否遵循最佳实践
-   - 测试覆盖情况
-
-3. **实用性** (Usefulness)
-   - 功能是否有价值
-   - 是否解决真实问题
-   - 是否与现有 skills 重复
-   - 适用场景是否明确
-
-4. **合规性** (Compliance)
-   - License 是否明确且为开源协议
-   - 版权信息是否完整
-   - 是否有违规内容（政治敏感、色情暴力等）
-
-**评分标准：**
-- 9-10: 优秀，无明显问题
-- 7-8: 良好，有小问题但可接受
-- 5-6: 一般，有明显问题需改进
-- 3-4: 较差，有严重问题
-- 0-2: 很差，不可接受
-
-**审核规则：**
-- 安全性 < 7 分，必须拒绝
-- 任一维度 < 6 分，必须拒绝
-- 总分 < 32/40，必须拒绝
-- 总分 32-34/40 仅可进入人工复核，不应自动标记为 verified
-- 总分 >= 35/40 且无安全问题，才适合自动发布为 verified
-- 如果发现恶意代码，直接拒绝且安全性给 0 分
-
-请返回 JSON 格式（不要包含 markdown 代码块标记）：
+Return only JSON without markdown fences:
 {
   "approved": boolean,
-  "scores": {
-    "security": number,
-    "quality": number,
-    "usefulness": number,
-    "compliance": number
-  },
+  "scores": {"security": number, "quality": number, "usefulness": number, "compliance": number},
   "issues": string[],
   "suggestions": string[],
   "reasoning": string
-}
-
-只返回 JSON，不要其他说明。`
+}`
 
   try {
     const result = await generateText({
       model: SUBMISSION_REVIEW_MODEL,
       prompt,
-      temperature: 0.3, // Lower temperature for more consistent reviews
+      temperature: 0.2,
     })
-
-    // Parse JSON response
     const jsonMatch = result.text.match(/\{[\s\S]*\}/)
-    if (!jsonMatch) {
-      throw new Error('Invalid AI response format')
+    if (!jsonMatch) throw new Error('Invalid AI response format')
+
+    const reviewData = JSON.parse(jsonMatch[0]) as {
+      approved?: boolean
+      scores?: Record<string, unknown>
+      issues?: unknown
+      suggestions?: unknown
+      reasoning?: unknown
     }
-
-    const reviewData = JSON.parse(jsonMatch[0])
-
-    // Calculate total score
-    const totalScore = Object.values(reviewData.scores).reduce(
-      (sum: number, score) => sum + (score as number),
-      0
-    ) as number
+    const scores = {
+      security: clampScore(Number(reviewData.scores?.security || 0)),
+      quality: clampScore(Number(reviewData.scores?.quality || 0)),
+      usefulness: clampScore(Number(reviewData.scores?.usefulness || 0)),
+      compliance: clampScore(Number(reviewData.scores?.compliance || 0)),
+    }
+    const totalScore = Object.values(scores).reduce((sum, score) => sum + score, 0)
+    const meetsAutomaticGate =
+      scores.security >= 7 &&
+      scores.quality >= 6 &&
+      scores.usefulness >= 6 &&
+      scores.compliance >= 6 &&
+      totalScore >= 32
 
     return {
-      approved: reviewData.approved,
-      scores: reviewData.scores,
+      approved: Boolean(reviewData.approved) && meetsAutomaticGate,
+      scores,
       totalScore,
-      issues: reviewData.issues || [],
-      suggestions: reviewData.suggestions || [],
-      reasoning: reviewData.reasoning || '',
+      issues: Array.isArray(reviewData.issues)
+        ? reviewData.issues.filter((item): item is string => typeof item === 'string').slice(0, 20)
+        : [],
+      suggestions: Array.isArray(reviewData.suggestions)
+        ? reviewData.suggestions.filter((item): item is string => typeof item === 'string').slice(0, 20)
+        : [],
+      reasoning: typeof reviewData.reasoning === 'string' ? reviewData.reasoning.slice(0, 4000) : '',
       reviewedAt: new Date().toISOString(),
       reviewModel: SUBMISSION_REVIEW_MODEL,
     }
   } catch (error) {
-    console.error('[v0] AI review error:', error)
+    console.error('[submission-review] AI review error:', error)
     return heuristicReview(data, error instanceof Error ? error.message : 'technical error')
   }
 }
 
-// Quick security check for obvious red flags
 export function quickSecurityCheck(codeContent: string): {
   safe: boolean
   issues: string[]
 } {
   const issues: string[] = []
-  
-  // Dangerous patterns
   const dangerousPatterns = [
     { pattern: /eval\s*\(/gi, message: 'Uses eval() - potential code injection risk' },
     { pattern: /exec\s*\(/gi, message: 'Uses exec() - potential command injection risk' },
@@ -217,13 +220,8 @@ export function quickSecurityCheck(codeContent: string): {
   ]
 
   for (const { pattern, message } of dangerousPatterns) {
-    if (pattern.test(codeContent)) {
-      issues.push(message)
-    }
+    if (pattern.test(codeContent)) issues.push(message)
   }
 
-  return {
-    safe: issues.length === 0,
-    issues,
-  }
+  return { safe: issues.length === 0, issues }
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -25,6 +25,7 @@ export type AnalyticsEventName =
   | 'localized_resolve_error'
   | 'localized_resolve_copy_install'
   | 'skill_submission_result'
+  | 'skill_submission_accepted'
 
 export type AnalyticsConsent = 'granted' | 'denied'
 

--- a/lib/db/skills.ts
+++ b/lib/db/skills.ts
@@ -27,6 +27,9 @@ export interface SkillRecord {
   install_command: string | null
   npm_package: string | null
   verified: boolean
+  publisher_github?: string | null
+  publisher_x?: string | null
+  publisher_verified?: boolean
   submission_source: string
   submitted_by_agent: string | null
   ai_review_score: any

--- a/lib/github/api.ts
+++ b/lib/github/api.ts
@@ -1,4 +1,5 @@
 import { GitHubRepo, SkillManifest, SkillManifestSchema } from '../schema/skill-schema'
+import { parseGitHubSkillReference } from './skill-source'
 
 export class GitHubAPIError extends Error {
   constructor(message: string, public statusCode?: number) {
@@ -9,27 +10,14 @@ export class GitHubAPIError extends Error {
 
 // Parse GitHub URL to owner/repo format
 export function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
-  const patterns = [
-    /github\.com\/([^\/]+)\/([^\/]+)/,
-    /^([^\/]+)\/([^\/]+)$/,
-  ]
-  
-  for (const pattern of patterns) {
-    const match = url.match(pattern)
-    if (match) {
-      return {
-        owner: match[1],
-        repo: match[2].replace(/\.git$/, ''),
-      }
-    }
-  }
-  
-  return null
+  const reference = parseGitHubSkillReference(url)
+  return reference ? { owner: reference.owner, repo: reference.repo } : null
 }
 
 // Validate GitHub repository
 export async function validateGitHubRepo(
-  ownerRepo: string
+  ownerRepo: string,
+  options: { checkReadme?: boolean; checkSkillJson?: boolean } = {}
 ): Promise<GitHubRepo> {
   const parsed = parseGitHubUrl(ownerRepo)
   if (!parsed) {
@@ -58,31 +46,20 @@ export async function validateGitHubRepo(
 
   const data = await response.json()
 
-  // Check if README exists
-  const readmeResponse = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/readme`,
-    {
-      headers: {
-        'Accept': 'application/vnd.github.v3+json',
-        ...(process.env.GITHUB_TOKEN && {
-          'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
-        }),
-      },
-    }
-  )
-
-  // Check if skill.json exists
-  const skillJsonResponse = await fetch(
-    `https://api.github.com/repos/${owner}/${repo}/contents/skill.json`,
-    {
-      headers: {
-        'Accept': 'application/vnd.github.v3+json',
-        ...(process.env.GITHUB_TOKEN && {
-          'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
-        }),
-      },
-    }
-  )
+  const optionalHeaders = {
+    'Accept': 'application/vnd.github.v3+json',
+    ...(process.env.GITHUB_TOKEN && {
+      'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
+    }),
+  }
+  const [readmeResponse, skillJsonResponse] = await Promise.all([
+    options.checkReadme === false
+      ? null
+      : fetch(`https://api.github.com/repos/${owner}/${repo}/readme`, { headers: optionalHeaders }),
+    options.checkSkillJson === false
+      ? null
+      : fetch(`https://api.github.com/repos/${owner}/${repo}/contents/skill.json`, { headers: optionalHeaders }),
+  ])
 
   return {
     owner,
@@ -95,8 +72,8 @@ export async function validateGitHubRepo(
     license: data.license?.spdx_id || undefined,
     updatedAt: data.updated_at,
     defaultBranch: data.default_branch,
-    hasReadme: readmeResponse.ok,
-    hasSkillJson: skillJsonResponse.ok,
+    hasReadme: Boolean(readmeResponse?.ok),
+    hasSkillJson: Boolean(skillJsonResponse?.ok),
   }
 }
 

--- a/lib/github/skill-source.ts
+++ b/lib/github/skill-source.ts
@@ -1,0 +1,314 @@
+import type { GitHubRepo } from '@/lib/schema/skill-schema'
+
+const GITHUB_API = 'https://api.github.com'
+const MAX_DISCOVERED_SKILLS = 50
+const MAX_PACKAGE_FILES = 30
+const MAX_FILE_BYTES = 120_000
+
+export interface GitHubSkillReference {
+  owner: string
+  repo: string
+  ref: string | null
+  path: string | null
+}
+
+export interface SkillFrontmatter {
+  name: string
+  description: string
+  version?: string
+  license?: string
+  author?: string
+  category?: string
+  tags: string[]
+  frameworks: string[]
+}
+
+export interface DiscoveredGitHubSkill {
+  owner: string
+  repo: string
+  ref: string
+  path: string
+  directory: string
+  sourceUrl: string
+  document: string
+  frontmatter: SkillFrontmatter
+}
+
+interface GitHubTreeItem {
+  path: string
+  type: 'blob' | 'tree'
+  size?: number
+}
+
+function githubHeaders() {
+  const token = (process.env.GITHUB_TOKEN || '').trim()
+  return {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'OpenAgentSkill-Submission/2.0',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  }
+}
+
+function cleanSegment(value: string) {
+  return decodeURIComponent(value).trim()
+}
+
+function normalizePath(value: string | null | undefined) {
+  const normalized = (value || '')
+    .replace(/\\/g, '/')
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\/{2,}/g, '/')
+
+  if (!normalized) return null
+  if (normalized.split('/').some((segment) => segment === '.' || segment === '..')) return null
+  return normalized
+}
+
+export function parseGitHubSkillReference(input: string): GitHubSkillReference | null {
+  const value = input.trim()
+  if (!value) return null
+
+  if (/^[\w.-]+\/[\w.-]+(?:\.git)?$/.test(value)) {
+    const [owner, repoValue] = value.split('/')
+    return { owner, repo: repoValue.replace(/\.git$/i, ''), ref: null, path: null }
+  }
+
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    return null
+  }
+
+  const parts = url.pathname.split('/').filter(Boolean).map(cleanSegment)
+  if (url.hostname === 'raw.githubusercontent.com' && parts.length >= 4) {
+    return {
+      owner: parts[0],
+      repo: parts[1].replace(/\.git$/i, ''),
+      ref: parts[2],
+      path: normalizePath(parts.slice(3).join('/')),
+    }
+  }
+
+  if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') return null
+  if (parts.length < 2) return null
+
+  const owner = parts[0]
+  const repo = parts[1].replace(/\.git$/i, '')
+  const marker = parts[2]
+  if ((marker === 'tree' || marker === 'blob') && parts.length >= 4) {
+    return {
+      owner,
+      repo,
+      ref: parts[3],
+      path: normalizePath(parts.slice(4).join('/')),
+    }
+  }
+
+  return { owner, repo, ref: null, path: null }
+}
+
+function parseInlineList(value: string | undefined) {
+  if (!value) return []
+  const content = value.trim().replace(/^\[|\]$/g, '')
+  if (!content) return []
+  return content
+    .split(',')
+    .map((item) => item.trim().replace(/^['"]|['"]$/g, ''))
+    .filter(Boolean)
+    .slice(0, 10)
+}
+
+function unquote(value: string) {
+  const trimmed = value.trim()
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
+}
+
+function parseFrontmatterBlock(source: string) {
+  const match = source.match(/^---\s*\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)
+  if (!match) return { values: new Map<string, string>(), body: source }
+
+  const lines = match[1].split(/\r?\n/)
+  const values = new Map<string, string>()
+  let index = 0
+
+  while (index < lines.length) {
+    const line = lines[index]
+    const entry = line.match(/^([A-Za-z][\w-]*):\s*(.*)$/)
+    if (!entry) {
+      index += 1
+      continue
+    }
+
+    const key = entry[1].toLowerCase()
+    const rawValue = entry[2]
+    if (rawValue === '|' || rawValue === '>') {
+      const block: string[] = []
+      index += 1
+      while (index < lines.length && (/^\s+/.test(lines[index]) || !lines[index].trim())) {
+        block.push(lines[index].replace(/^\s{1,4}/, ''))
+        index += 1
+      }
+      values.set(key, rawValue === '>' ? block.join(' ').replace(/\s+/g, ' ').trim() : block.join('\n').trim())
+      continue
+    }
+
+    values.set(key, unquote(rawValue))
+    index += 1
+  }
+
+  return { values, body: source.slice(match[0].length) }
+}
+
+function firstBodyParagraph(body: string) {
+  return body
+    .split(/\r?\n\s*\r?\n/)
+    .map((paragraph) => paragraph.replace(/^#+\s*/gm, '').replace(/\s+/g, ' ').trim())
+    .find((paragraph) => paragraph.length >= 20 && !paragraph.startsWith('```')) || ''
+}
+
+export function parseSkillDocument(source: string): SkillFrontmatter | null {
+  const { values, body } = parseFrontmatterBlock(source)
+  const name = (values.get('name') || '').trim()
+  const description = (values.get('description') || firstBodyParagraph(body)).trim()
+  if (!name || !description) return null
+
+  return {
+    name: name.slice(0, 120),
+    description: description.slice(0, 1000),
+    version: values.get('version') || undefined,
+    license: values.get('license') || undefined,
+    author: values.get('author') || undefined,
+    category: values.get('category') || undefined,
+    tags: parseInlineList(values.get('tags') || values.get('keywords')),
+    frameworks: parseInlineList(values.get('frameworks')),
+  }
+}
+
+async function fetchRepositoryTree(owner: string, repo: string, ref: string) {
+  const response = await fetch(
+    `${GITHUB_API}/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}?recursive=1`,
+    { headers: githubHeaders(), signal: AbortSignal.timeout(15_000) }
+  )
+
+  if (!response.ok) throw new Error(`Unable to read repository tree (${response.status}).`)
+
+  const payload = await response.json() as { tree?: GitHubTreeItem[]; truncated?: boolean }
+  return { tree: payload.tree || [], truncated: Boolean(payload.truncated) }
+}
+
+async function fetchRepositoryFile(owner: string, repo: string, ref: string, path: string) {
+  const response = await fetch(
+    `${GITHUB_API}/repos/${owner}/${repo}/contents/${path.split('/').map(encodeURIComponent).join('/')}?ref=${encodeURIComponent(ref)}`,
+    {
+      headers: { ...githubHeaders(), Accept: 'application/vnd.github.raw+json' },
+      signal: AbortSignal.timeout(15_000),
+    }
+  )
+
+  if (!response.ok) throw new Error(`Unable to read ${path} (${response.status}).`)
+
+  const content = await response.text()
+  if (content.length > MAX_FILE_BYTES) throw new Error(`${path} is too large to review safely.`)
+  return content
+}
+
+function sourceUrl(owner: string, repo: string, ref: string, path: string) {
+  const directory = path.replace(/\/?SKILL\.md$/i, '')
+  if (!directory) return `https://github.com/${owner}/${repo}/blob/${ref}/SKILL.md`
+  return `https://github.com/${owner}/${repo}/tree/${ref}/${directory}`
+}
+
+export async function discoverGitHubSkills(
+  reference: GitHubSkillReference,
+  repository: GitHubRepo
+): Promise<{ skills: DiscoveredGitHubSkill[]; truncated: boolean }> {
+  const ref = reference.ref || repository.defaultBranch
+  const requestedPath = normalizePath(reference.path)
+  const exactSkillPath = requestedPath && /(^|\/)SKILL\.md$/i.test(requestedPath)
+    ? requestedPath
+    : null
+
+  let paths: string[] = []
+  let truncated = false
+  if (exactSkillPath) {
+    paths = [exactSkillPath]
+  } else {
+    const treeResult = await fetchRepositoryTree(reference.owner, reference.repo, ref)
+    truncated = treeResult.truncated
+    const prefix = requestedPath ? `${requestedPath.replace(/\/$/, '')}/`.toLowerCase() : null
+    paths = treeResult.tree
+      .filter((item) => item.type === 'blob' && /(^|\/)SKILL\.md$/i.test(item.path))
+      .map((item) => item.path)
+      .filter((path) => !prefix || path.toLowerCase().startsWith(prefix))
+      .slice(0, MAX_DISCOVERED_SKILLS)
+  }
+
+  const skills = (
+    await Promise.all(paths.map(async (path) => {
+      try {
+        const document = await fetchRepositoryFile(reference.owner, reference.repo, ref, path)
+        const frontmatter = parseSkillDocument(document)
+        if (!frontmatter) return null
+        const directory = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : ''
+        return {
+          owner: reference.owner,
+          repo: reference.repo,
+          ref,
+          path,
+          directory,
+          sourceUrl: sourceUrl(reference.owner, reference.repo, ref, path),
+          document,
+          frontmatter,
+        } satisfies DiscoveredGitHubSkill
+      } catch {
+        return null
+      }
+    }))
+  ).filter((skill): skill is DiscoveredGitHubSkill => Boolean(skill))
+
+  return { skills, truncated }
+}
+
+const REVIEWABLE_EXTENSIONS = new Set([
+  '.md', '.txt', '.json', '.yaml', '.yml', '.toml', '.sh', '.bash', '.zsh',
+  '.js', '.mjs', '.cjs', '.ts', '.tsx', '.py', '.go', '.rs', '.java', '.rb',
+])
+
+function extension(path: string) {
+  const file = path.slice(path.lastIndexOf('/') + 1)
+  const dot = file.lastIndexOf('.')
+  return dot >= 0 ? file.slice(dot).toLowerCase() : ''
+}
+
+export async function fetchSkillPackageFiles(skill: DiscoveredGitHubSkill) {
+  const { tree } = await fetchRepositoryTree(skill.owner, skill.repo, skill.ref)
+  const prefix = skill.directory ? `${skill.directory}/` : ''
+  const paths = tree
+    .filter((item) => item.type === 'blob')
+    .filter((item) => !prefix || item.path.startsWith(prefix))
+    .filter((item) => REVIEWABLE_EXTENSIONS.has(extension(item.path)))
+    .filter((item) => !/(^|\/)(node_modules|dist|build|vendor|\.git)(\/|$)/i.test(item.path))
+    .filter((item) => !item.size || item.size <= MAX_FILE_BYTES)
+    .sort((a, b) => {
+      if (a.path === skill.path) return -1
+      if (b.path === skill.path) return 1
+      return a.path.localeCompare(b.path)
+    })
+    .slice(0, MAX_PACKAGE_FILES)
+    .map((item) => item.path)
+
+  return Promise.all(paths.map(async (path) => ({
+    path,
+    content: path === skill.path
+      ? skill.document
+      : await fetchRepositoryFile(skill.owner, skill.repo, skill.ref, path).catch(() => ''),
+  })))
+}

--- a/lib/skills/open-submission.ts
+++ b/lib/skills/open-submission.ts
@@ -1,0 +1,406 @@
+import 'server-only'
+
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto'
+import type { GitHubRepo } from '@/lib/schema/skill-schema'
+import type { DiscoveredGitHubSkill } from '@/lib/github/skill-source'
+import { reviewSkill } from '@/lib/ai-review/reviewer'
+import { analyzeCode } from '@/lib/security/static-analysis'
+import { evaluateSkillSubmissionPolicy } from '@/lib/skills/submission-policy'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+export const SUBMISSION_RATE_LIMIT = 5
+export const SUBMISSION_RATE_WINDOW_HOURS = 24
+export const VALIDATION_RATE_LIMIT = 20
+export const VALIDATION_RATE_WINDOW_HOURS = 24
+
+export type OpenSubmissionStatus =
+  | 'submitted'
+  | 'processing'
+  | 'listed'
+  | 'reviewed'
+  | 'duplicate'
+  | 'quarantined'
+
+export interface OpenSubmissionInput {
+  repository: GitHubRepo
+  skill: DiscoveredGitHubSkill
+  category?: string
+  tags?: string[]
+  submissionSource: 'web' | 'api' | 'agent'
+  submittedByAgent?: string
+  makerGithub?: string
+  makerX?: string
+  requestFingerprint: string
+  codeFiles: { path: string; content: string }[]
+}
+
+export interface OpenSubmissionReceipt {
+  id: string
+  token: string
+  status: OpenSubmissionStatus
+  skill: {
+    name: string
+    description: string
+    path: string
+    sourceUrl: string
+  }
+}
+
+const ALLOWED_CATEGORIES = new Set([
+  'data-analysis',
+  'code-generation',
+  'research',
+  'automation',
+  'communication',
+  'creative',
+  'business',
+  'developer-tools',
+  'security',
+  'integration',
+])
+
+export function hashSubmissionToken(token: string) {
+  return createHash('sha256').update(token).digest('hex')
+}
+
+export function submissionTokenMatches(token: string, expectedHash: string) {
+  const actual = Buffer.from(hashSubmissionToken(token), 'hex')
+  const expected = Buffer.from(expectedHash, 'hex')
+  return actual.length === expected.length && timingSafeEqual(actual, expected)
+}
+
+export function buildRequestFingerprint(ip: string, userAgent: string) {
+  const secret =
+    process.env.SUBMISSION_FINGERPRINT_SECRET ||
+    process.env.INDEXER_SECRET ||
+    process.env.SUPABASE_SECRET_KEY ||
+    'openagentskill-public-intake'
+  const day = new Date().toISOString().slice(0, 10)
+  return createHash('sha256')
+    .update(`${secret}\n${day}\n${ip}\n${userAgent.slice(0, 300)}`)
+    .digest('hex')
+}
+
+export async function enforceSubmissionRateLimit(requestFingerprint: string) {
+  const supabase = createAdminClient({ requestTimeoutMs: 8_000 })
+  const since = new Date(Date.now() - SUBMISSION_RATE_WINDOW_HOURS * 60 * 60 * 1000).toISOString()
+  const { count, error } = await supabase
+    .from('skill_submissions')
+    .select('id', { count: 'exact', head: true })
+    .eq('request_fingerprint', requestFingerprint)
+    .gte('created_at', since)
+
+  if (error) throw error
+  if ((count || 0) >= SUBMISSION_RATE_LIMIT) {
+    const error = new Error('Submission rate limit reached. Please try again later.')
+    error.name = 'SubmissionRateLimitError'
+    throw error
+  }
+}
+
+export async function enforceValidationRateLimit(requestFingerprint: string) {
+  const supabase = createAdminClient({ requestTimeoutMs: 8_000 })
+  const since = new Date(Date.now() - VALIDATION_RATE_WINDOW_HOURS * 60 * 60 * 1000).toISOString()
+  const { count, error } = await supabase
+    .from('submission_validation_events')
+    .select('id', { count: 'exact', head: true })
+    .eq('request_fingerprint', requestFingerprint)
+    .gte('created_at', since)
+
+  if (error) throw error
+  if ((count || 0) >= VALIDATION_RATE_LIMIT) {
+    const limitError = new Error('Validation rate limit reached. Please try again later.')
+    limitError.name = 'ValidationRateLimitError'
+    throw limitError
+  }
+
+  const { error: insertError } = await supabase
+    .from('submission_validation_events')
+    .insert({ request_fingerprint: requestFingerprint })
+  if (insertError) throw insertError
+}
+
+function normalizeCategory(input: OpenSubmissionInput) {
+  const requested = input.category?.trim().toLowerCase()
+  if (requested && ALLOWED_CATEGORIES.has(requested)) return requested
+
+  const fromSkill = input.skill.frontmatter.category?.trim().toLowerCase()
+  if (fromSkill && ALLOWED_CATEGORIES.has(fromSkill)) return fromSkill
+
+  const text = `${input.skill.frontmatter.name} ${input.skill.frontmatter.description} ${input.skill.path}`.toLowerCase()
+  if (/security|audit|vulnerab|secret|compliance/.test(text)) return 'security'
+  if (/research|search|source|summari/.test(text)) return 'research'
+  if (/design|image|video|creative|visual/.test(text)) return 'creative'
+  if (/data|csv|spreadsheet|analytics|chart/.test(text)) return 'data-analysis'
+  if (/api|integration|connector|webhook/.test(text)) return 'integration'
+  if (/code|developer|github|test|debug/.test(text)) return 'developer-tools'
+  if (/business|marketing|sales|finance/.test(text)) return 'business'
+  if (/write|email|communication|social/.test(text)) return 'communication'
+  return 'automation'
+}
+
+function slugPart(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+}
+
+function buildSlug(input: OpenSubmissionInput) {
+  const base = `${slugPart(input.repository.owner)}-${slugPart(input.repository.repo)}`
+  const skillName = slugPart(input.skill.frontmatter.name)
+  const hasMultipleOrNestedSkill = Boolean(input.skill.directory)
+  return hasMultipleOrNestedSkill && skillName ? `${base}-${skillName}`.slice(0, 180) : base
+}
+
+function normalizeTags(input: OpenSubmissionInput) {
+  const source = [
+    ...(input.tags || []),
+    ...input.skill.frontmatter.tags,
+    'agent-skill',
+  ]
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const value of source) {
+    const tag = value.trim().toLowerCase().replace(/[^a-z0-9+#.-]+/g, '-').replace(/^-+|-+$/g, '')
+    if (!tag || seen.has(tag)) continue
+    seen.add(tag)
+    result.push(tag.slice(0, 40))
+    if (result.length >= 10) break
+  }
+  return result
+}
+
+function normalizeVersion(value: string | undefined) {
+  return value && /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/.test(value) ? value : '1.0.0'
+}
+
+export async function createOpenSubmission(input: OpenSubmissionInput): Promise<OpenSubmissionReceipt> {
+  await enforceSubmissionRateLimit(input.requestFingerprint)
+
+  const supabase = createAdminClient({ requestTimeoutMs: 12_000 })
+  const id = randomUUID()
+  const token = randomBytes(24).toString('hex')
+  const staticAnalysis = analyzeCode(input.codeFiles)
+  const initialStatus: OpenSubmissionStatus = staticAnalysis.passed ? 'submitted' : 'quarantined'
+
+  const { error } = await supabase.from('skill_submissions').insert({
+    id,
+    github_repo: input.repository.fullName,
+    repository_url: input.skill.sourceUrl,
+    source_ref: input.skill.ref,
+    skill_path: input.skill.path,
+    skill_name: input.skill.frontmatter.name,
+    skill_description: input.skill.frontmatter.description,
+    category: normalizeCategory(input),
+    tags: normalizeTags(input),
+    submission_source: input.submissionSource,
+    submitted_by_agent: input.submittedByAgent || null,
+    submitter_github: input.makerGithub || null,
+    submitter_x: input.makerX || null,
+    identity_provider: null,
+    identity_verified: false,
+    status_token_hash: hashSubmissionToken(token),
+    request_fingerprint: input.requestFingerprint,
+    validation_result: {
+      standard: 'SKILL.md',
+      source_url: input.skill.sourceUrl,
+      source_ref: input.skill.ref,
+      skill_path: input.skill.path,
+      github_stars: input.repository.stars,
+      repository_readme: input.repository.hasReadme,
+      static_analysis: staticAnalysis,
+      publisher_identity: 'declared_unverified',
+    },
+    ai_review_result: staticAnalysis.passed
+      ? {}
+      : {
+          approved: false,
+          stage: 'static_security',
+          issues: staticAnalysis.issues,
+          suggestions: ['Remove critical-risk behavior and submit a new immutable revision.'],
+        },
+    status: initialStatus,
+    reviewed_at: staticAnalysis.passed ? null : new Date().toISOString(),
+  })
+
+  if (error) throw error
+
+  return {
+    id,
+    token,
+    status: initialStatus,
+    skill: {
+      name: input.skill.frontmatter.name,
+      description: input.skill.frontmatter.description,
+      path: input.skill.path,
+      sourceUrl: input.skill.sourceUrl,
+    },
+  }
+}
+
+export async function reviewOpenSubmission(input: OpenSubmissionInput, submissionId: string) {
+  const supabase = createAdminClient({ requestTimeoutMs: 20_000 })
+  const startedAt = new Date().toISOString()
+  await supabase
+    .from('skill_submissions')
+    .update({ status: 'processing', review_started_at: startedAt })
+    .eq('id', submissionId)
+
+  const staticAnalysis = analyzeCode(input.codeFiles)
+  if (!staticAnalysis.passed) return
+
+  try {
+    const review = await reviewSkill({
+      repository: input.skill.sourceUrl,
+      readmeContent: input.skill.document,
+      codeFiles: input.codeFiles,
+      manifestData: input.skill.frontmatter,
+      githubStats: {
+        stars: input.repository.stars,
+        forks: input.repository.forks,
+        lastUpdated: input.repository.updatedAt,
+        license: input.skill.frontmatter.license || input.repository.license,
+        language: input.repository.language,
+      },
+    })
+    const policy = evaluateSkillSubmissionPolicy({
+      stars: input.repository.stars,
+      hasReadme: input.repository.hasReadme,
+      hasSkillDocument: true,
+      staticAnalysis,
+      review,
+    })
+    const reviewedAt = new Date().toISOString()
+    const reviewPayload = {
+      ...review,
+      approved: policy.approved,
+      policy,
+      static_analysis: staticAnalysis,
+      publisher_identity: 'declared_unverified',
+    }
+
+    if (!policy.approved) {
+      const { error } = await supabase
+        .from('skill_submissions')
+        .update({ status: 'listed', ai_review_result: reviewPayload, reviewed_at: reviewedAt })
+        .eq('id', submissionId)
+      if (error) throw error
+      return
+    }
+
+    const slug = buildSlug(input)
+    const category = normalizeCategory(input)
+    const tags = normalizeTags(input)
+    const authorName = input.makerGithub || input.skill.frontmatter.author || input.repository.owner
+    const skillPayload = {
+      slug,
+      name: input.skill.frontmatter.name,
+      description: input.skill.frontmatter.description,
+      long_description: input.skill.document.slice(0, 12_000),
+      tagline: input.skill.frontmatter.description.slice(0, 280),
+      author_name: authorName,
+      author_url: `https://github.com/${input.makerGithub || input.repository.owner}`,
+      repository: input.skill.sourceUrl,
+      github_repo: input.repository.fullName,
+      github_stars: input.repository.stars,
+      github_forks: input.repository.forks,
+      github_language: input.repository.language || null,
+      github_last_pushed_at: input.repository.updatedAt,
+      category,
+      tags,
+      frameworks: input.skill.frontmatter.frameworks,
+      version: normalizeVersion(input.skill.frontmatter.version),
+      license: input.skill.frontmatter.license || input.repository.license || 'Unknown',
+      install_command: `npx skills add ${input.repository.fullName} --skill ${input.skill.frontmatter.name}`,
+      verified: false,
+      listing_status: 'reviewed',
+      source_ref: input.skill.ref,
+      source_path: input.skill.path,
+      publisher_github: input.makerGithub || null,
+      publisher_x: input.makerX || null,
+      publisher_verified: false,
+      submission_source: input.submissionSource,
+      submitted_by_agent: input.submittedByAgent || null,
+      ai_review_score: {
+        ...review.scores,
+        total: review.totalScore,
+        source: 'open-skill-submission',
+        skill_path: input.skill.path,
+        source_url: input.skill.sourceUrl,
+      },
+      ai_review_approved: true,
+      ai_review_issues: policy.issues,
+      ai_review_suggestions: policy.suggestions,
+    }
+
+    const { data: createdSkill, error: createError } = await supabase
+      .from('skills')
+      .insert(skillPayload)
+      .select('id, slug')
+      .single()
+
+    if (createError) {
+      if (createError.code !== '23505') throw createError
+      const { data: existing } = await supabase
+        .from('skills')
+        .select('id, slug')
+        .eq('slug', slug)
+        .maybeSingle()
+      const { error: duplicateError } = await supabase
+        .from('skill_submissions')
+        .update({
+          status: 'duplicate',
+          skill_id: existing?.id || null,
+          ai_review_result: reviewPayload,
+          reviewed_at: reviewedAt,
+        })
+        .eq('id', submissionId)
+      if (duplicateError) throw duplicateError
+      return
+    }
+
+    const { error: updateError } = await supabase
+      .from('skill_submissions')
+      .update({
+        status: 'reviewed',
+        skill_id: createdSkill.id,
+        ai_review_result: reviewPayload,
+        reviewed_at: reviewedAt,
+      })
+      .eq('id', submissionId)
+    if (updateError) throw updateError
+
+    await supabase.from('activity_feed').insert({
+      event_type: input.submissionSource === 'agent' ? 'agent_submitted' : 'skill_published',
+      skill_id: createdSkill.id,
+      actor_name: authorName,
+      actor_type: input.submissionSource === 'agent' ? 'agent' : 'human',
+      description: `Published ${input.skill.frontmatter.name} from an explicit SKILL.md source.`,
+      metadata: {
+        source: input.submissionSource,
+        source_url: input.skill.sourceUrl,
+        source_ref: input.skill.ref,
+        skill_path: input.skill.path,
+        publisher_identity: 'declared_unverified',
+      },
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown review error'
+    await supabase
+      .from('skill_submissions')
+      .update({
+        status: 'listed',
+        reviewed_at: new Date().toISOString(),
+        ai_review_result: {
+          approved: false,
+          stage: 'review_error',
+          issues: ['Automatic review could not be completed.'],
+          suggestions: ['The submission remains in the community queue for manual review.'],
+          reasoning: message.slice(0, 1000),
+        },
+      })
+      .eq('id', submissionId)
+  }
+}

--- a/lib/skills/submission-policy.ts
+++ b/lib/skills/submission-policy.ts
@@ -1,10 +1,9 @@
 import type { AIReviewResult } from '@/lib/schema/skill-schema'
 
-// Keep the public intake open to promising early projects. Publication still
-// requires the security scan and the full quality gate below.
-export const SKILL_SUBMISSION_MIN_STARS = 3
+// Stars are an adoption signal, never an intake requirement. A new skill can
+// be useful and standards-compliant before it has an audience.
+export const SKILL_SUBMISSION_MIN_STARS = 0
 export const SKILL_SUBMISSION_MIN_TOTAL_SCORE = 32
-export const SKILL_SUBMISSION_VERIFIED_SCORE = 35
 export const SKILL_SUBMISSION_MIN_SECURITY_SCORE = 7
 export const SKILL_SUBMISSION_MIN_DIMENSION_SCORE = 6
 
@@ -49,6 +48,7 @@ function checkStatus(pass: boolean, warn = false): SubmissionGateCheck['status']
 export function evaluateSkillSubmissionPolicy(input: {
   stars: number
   hasReadme: boolean
+  hasSkillDocument?: boolean
   staticAnalysis: SubmissionStaticAnalysis
   review: AIReviewResult
 }): SubmissionPolicyGate {
@@ -64,15 +64,19 @@ export function evaluateSkillSubmissionPolicy(input: {
     {
       id: 'github_stars',
       label: 'GitHub adoption',
-      status: checkStatus(input.stars >= SKILL_SUBMISSION_MIN_STARS),
-      detail: `${input.stars} stars, minimum ${SKILL_SUBMISSION_MIN_STARS}`,
+      status: 'pass',
+      detail: `${input.stars} stars (ranking signal only; zero-star skills are welcome)`,
       score: input.stars,
     },
     {
-      id: 'readme',
-      label: 'README presence',
-      status: checkStatus(input.hasReadme),
-      detail: input.hasReadme ? 'README detected' : 'README is required',
+      id: 'skill_document',
+      label: 'SKILL.md presence',
+      status: checkStatus(Boolean(input.hasSkillDocument)),
+      detail: input.hasSkillDocument
+        ? input.hasReadme
+          ? 'Valid SKILL.md and repository README detected'
+          : 'Valid SKILL.md detected; repository README is optional'
+        : 'A valid SKILL.md is required',
     },
     {
       id: 'static_security',
@@ -152,7 +156,9 @@ export function evaluateSkillSubmissionPolicy(input: {
 
   return {
     approved,
-    verified: approved && total >= SKILL_SUBMISSION_VERIFIED_SCORE,
+    // Automated quality review cannot prove publisher identity or ownership.
+    // Verification is awarded later through the claim/ownership flow.
+    verified: false,
     status,
     min_stars: SKILL_SUBMISSION_MIN_STARS,
     min_total_score: SKILL_SUBMISSION_MIN_TOTAL_SCORE,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "next start",
     "seed:popular": "node scripts/seed-popular-skills.ts",
     "indexer:backfill": "node scripts/backfill-high-star-skills.mjs",
+    "test:submission": "node --experimental-strip-types scripts/test-skill-source.ts",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/scripts/026_open_submission_pipeline.sql
+++ b/scripts/026_open_submission_pipeline.sql
@@ -1,0 +1,73 @@
+-- Open submission pipeline: accept standards-compliant zero-star SKILL.md
+-- sources, persist review state, and keep publisher identity separate from
+-- automated quality review.
+
+alter table public.skill_submissions
+  add column if not exists repository_url text,
+  add column if not exists source_ref text,
+  add column if not exists skill_path text,
+  add column if not exists skill_name text,
+  add column if not exists skill_description text,
+  add column if not exists category text,
+  add column if not exists tags text[] not null default '{}',
+  add column if not exists submitter_github text,
+  add column if not exists submitter_x text,
+  add column if not exists identity_provider text,
+  add column if not exists identity_verified boolean not null default false,
+  add column if not exists status_token_hash text,
+  add column if not exists request_fingerprint text,
+  add column if not exists validation_result jsonb not null default '{}'::jsonb,
+  add column if not exists updated_at timestamptz not null default now(),
+  add column if not exists review_started_at timestamptz,
+  add column if not exists reviewed_at timestamptz;
+
+alter table public.skills
+  add column if not exists listing_status text not null default 'reviewed',
+  add column if not exists source_ref text,
+  add column if not exists source_path text,
+  add column if not exists publisher_github text,
+  add column if not exists publisher_x text,
+  add column if not exists publisher_verified boolean not null default false;
+
+update public.skill_submissions
+set updated_at = coalesce(updated_at, created_at, now())
+where updated_at is null;
+
+update public.skills
+set listing_status = 'listed'
+where coalesce(ai_review_approved, false) = false
+  and listing_status = 'reviewed';
+
+create index if not exists idx_skill_submissions_public_queue
+  on public.skill_submissions (status, created_at desc);
+
+create index if not exists idx_skill_submissions_fingerprint_created
+  on public.skill_submissions (request_fingerprint, created_at desc)
+  where request_fingerprint is not null;
+
+create index if not exists idx_skill_submissions_source_path
+  on public.skill_submissions (github_repo, source_ref, skill_path);
+
+create index if not exists idx_skills_listing_status
+  on public.skills (listing_status, created_at desc);
+
+drop trigger if exists update_skill_submissions_updated_at on public.skill_submissions;
+create trigger update_skill_submissions_updated_at
+  before update on public.skill_submissions
+  for each row execute function public.update_updated_at_column();
+
+alter table public.skill_submissions enable row level security;
+revoke all on table public.skill_submissions from anon, authenticated;
+
+-- Explicit grants keep server-only access working when Supabase disables
+-- automatic Data API exposure for existing projects.
+grant select, insert, update on table public.skill_submissions to service_role;
+grant select, insert, update on table public.skills to service_role;
+grant insert on table public.activity_feed to service_role;
+
+comment on column public.skill_submissions.status is
+  'draft, submitted, processing, listed, reviewed, duplicate, or quarantined';
+comment on column public.skill_submissions.identity_verified is
+  'True only after OAuth or repository ownership verification; handles alone never verify identity.';
+comment on column public.skills.listing_status is
+  'Community listing and trust lifecycle; default Resolve remains restricted to reviewed records.';

--- a/scripts/027_submission_validation_rate_limit.sql
+++ b/scripts/027_submission_validation_rate_limit.sql
@@ -1,0 +1,18 @@
+-- Protect the public preflight endpoint from exhausting the registry's GitHub
+-- API quota. Fingerprints are one-way hashes of IP, user agent, secret, and day.
+
+create table if not exists public.submission_validation_events (
+  id uuid primary key default gen_random_uuid(),
+  request_fingerprint text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_submission_validation_events_fingerprint_created
+  on public.submission_validation_events (request_fingerprint, created_at desc);
+
+alter table public.submission_validation_events enable row level security;
+revoke all on table public.submission_validation_events from anon, authenticated;
+grant select, insert, delete on table public.submission_validation_events to service_role;
+
+comment on table public.submission_validation_events is
+  'Server-only, privacy-preserving rate-limit events for public Skill source validation.';

--- a/scripts/test-skill-source.ts
+++ b/scripts/test-skill-source.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+// Node's type-stripping runner needs the explicit extension; the app compiler resolves the same module by alias.
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
+import { parseGitHubSkillReference, parseSkillDocument } from '../lib/github/skill-source.ts'
+
+assert.deepEqual(parseGitHubSkillReference('Leon-Drq/openagentskill'), {
+  owner: 'Leon-Drq',
+  repo: 'openagentskill',
+  ref: null,
+  path: null,
+})
+
+assert.deepEqual(
+  parseGitHubSkillReference('https://github.com/acme/skills/tree/main/skills/research'),
+  { owner: 'acme', repo: 'skills', ref: 'main', path: 'skills/research' }
+)
+
+assert.deepEqual(
+  parseGitHubSkillReference('https://raw.githubusercontent.com/acme/skills/v2/skills/research/SKILL.md'),
+  { owner: 'acme', repo: 'skills', ref: 'v2', path: 'skills/research/SKILL.md' }
+)
+
+assert.equal(parseGitHubSkillReference('https://example.com/acme/skills'), null)
+
+assert.deepEqual(
+  parseSkillDocument(`---
+name: research-assistant
+description: >
+  Research a question with cited,
+  primary sources.
+tags: [research, citations]
+frameworks: [Codex, Claude Code]
+---
+
+# Research Assistant
+`),
+  {
+    name: 'research-assistant',
+    description: 'Research a question with cited, primary sources.',
+    version: undefined,
+    license: undefined,
+    author: undefined,
+    category: undefined,
+    tags: ['research', 'citations'],
+    frameworks: ['Codex', 'Claude Code'],
+  }
+)
+
+assert.equal(parseSkillDocument('# Missing frontmatter and useful description'), null)
+
+console.log('skill source parser tests passed')


### PR DESCRIPTION
## What changed

- accept zero-star repositories with a valid `SKILL.md`
- discover repository, subdirectory, file, and multi-skill sources
- persist submissions before asynchronous security and quality review
- add private status receipts and a public community submission queue
- add optional GitHub and X maker profiles, clearly marked unverified until ownership proof
- protect public validation with a privacy-preserving rate limit and reduce GitHub API calls
- update submission UI, skill author profiles, API documentation, and tests

## Why

The previous flow required stars, README metadata, category/tags, and an immediate high AI score. It also only understood root-level legacy metadata and discarded failed submissions. That prevented new skill makers from participating and made GitHub rate limits unnecessarily easy to hit.

## Validation

- `pnpm test:submission`
- `pnpm exec tsc --noEmit`
- `pnpm lint` (existing warnings only; no errors)
- `pnpm build`
- Supabase migrations applied and column/RLS checks completed
