### PR TITLE
perf: ship pinned lightweight CLI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,18 +159,18 @@ curl "https://www.openagentskill.com/api/agent/outcome?format=text"
 Read the integration contract before wiring a new agent:
 
 ```bash
-npx --yes github:Leon-Drq/openagentskill#main outcome-contract
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz outcome-contract
 curl "https://www.openagentskill.com/api/agent/outcome?contract=true"
 ```
 
 ## Official CLI
 
-Run the dependency-free CLI directly from the official GitHub source:
+Run the dependency-free CLI from the pinned official GitHub Release:
 
 ```bash
-npx --yes github:Leon-Drq/openagentskill#main search "extract tables from PDF reports"
-npx --yes github:Leon-Drq/openagentskill#main resolve "extract tables from PDF reports" --agent codex
-npx --yes github:Leon-Drq/openagentskill#main install anthropic-frontend-design --agent codex --dry-run
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz search "extract tables from PDF reports"
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz resolve "extract tables from PDF reports" --agent codex
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz install anthropic-frontend-design --agent codex --dry-run
 ```
 
 The publishable package source lives in [`packages/cli`](./packages/cli). Reviewed

--- a/app/api-docs/page.tsx
+++ b/app/api-docs/page.tsx
@@ -576,7 +576,7 @@ Total: 2 skills found
 [1] Crawl4AI
 - Slug: crawl4ai
 - Category: Web Scraping
-- Install: npx --yes github:Leon-Drq/openagentskill#main install crawl4ai --dry-run
+- Install: npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz install crawl4ai --dry-run
 - Trust: 91/100 Production candidate
 - Verified installs: 0
 - Outcomes: 1
@@ -585,7 +585,7 @@ Total: 2 skills found
 [2] Code Review Assistant
 - Slug: code-review-assistant
 - Category: Developer Tools
-- Install: npx --yes github:Leon-Drq/openagentskill#main install code-review-assistant --dry-run
+- Install: npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz install code-review-assistant --dry-run
 - Trust: 77/100 Strong shortlist
 - Verified installs: 0
 - Outcomes: 0
@@ -789,7 +789,7 @@ Total: 2 skills found
                 <code>{`=== Crawl4AI ===
 
 INSTALL:
-npx --yes github:Leon-Drq/openagentskill#main install crawl4ai --dry-run
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz install crawl4ai --dry-run
 
 DESCRIPTION:
 Comprehensive web research with multi-source aggregation

--- a/app/cli/page.tsx
+++ b/app/cli/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   },
 }
 
-const CLI = 'npx --yes github:Leon-Drq/openagentskill#main'
+const CLI = 'npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz'
 
 const commands = [
   {

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -41,7 +41,7 @@ export default function DocsPage() {
           </p>
           <div className="border border-border bg-card p-4 sm:p-6 mb-6">
             <pre className="font-mono text-sm sm:text-base overflow-x-auto">
-              <code>{'npx --yes github:Leon-Drq/openagentskill#main install <skill-slug> --agent codex --dry-run'}</code>
+              <code>{'npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz install <skill-slug> --agent codex --dry-run'}</code>
             </pre>
           </div>
           <p className="text-base sm:text-lg leading-relaxed text-secondary">

--- a/lib/agent-outcomes.ts
+++ b/lib/agent-outcomes.ts
@@ -77,7 +77,7 @@ export function buildOutcomeCommand(input: {
   outcome?: AgentOutcome
 }) {
   return [
-    'npx --yes github:Leon-Drq/openagentskill#main outcome',
+    'npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz outcome',
     shellQuote(input.eventId),
     '--skill',
     shellQuote(input.skillSlug),

--- a/lib/install-targets.ts
+++ b/lib/install-targets.ts
@@ -52,7 +52,7 @@ export function getSkillInstallTargets(skill: InstallableSkill): SkillInstallTar
       label: 'CLI',
       title: 'OpenAgentSkill CLI',
       kind: 'command',
-      value: `npx --yes github:Leon-Drq/openagentskill#main install ${skill.slug}`,
+      value: `npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz install ${skill.slug}`,
       description: 'Resolve policy, run the source installer safely, and report a verified install receipt.',
       copyLabel: 'Copy command',
     },

--- a/openagentskill-registry/SKILL.md
+++ b/openagentskill-registry/SKILL.md
@@ -12,7 +12,7 @@ registry returns `no_match`.
 ## Resolve a task
 
 ```bash
-npx --yes github:Leon-Drq/openagentskill#main resolve "<specific task>" --agent codex
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz resolve "<specific task>" --agent codex
 ```
 
 Review the selected Skill, alternatives, policy, Trust Score, audit result, and
@@ -21,9 +21,9 @@ repository. A high GitHub Star count is not proof that the Skill worked.
 ## Inspect and install
 
 ```bash
-npx --yes github:Leon-Drq/openagentskill#main inspect <slug>
-npx --yes github:Leon-Drq/openagentskill#main install <slug> --agent codex --dry-run
-npx --yes github:Leon-Drq/openagentskill#main install <slug> --agent codex --yes
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz inspect <slug>
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz install <slug> --agent codex --dry-run
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz install <slug> --agent codex --yes
 ```
 
 Never bypass a blocked policy. For a reviewed Skill, inspect its source and ask

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -5,11 +5,11 @@ installing a Skill through the standard `skills` installer, and reporting a
 verified install receipt.
 
 ```bash
-npx --yes github:Leon-Drq/openagentskill#main search "extract tables from PDF reports"
-npx --yes github:Leon-Drq/openagentskill#main resolve "extract tables from PDF reports" --agent codex
-npx --yes github:Leon-Drq/openagentskill#main inspect anthropic-frontend-design
-npx --yes github:Leon-Drq/openagentskill#main install anthropic-frontend-design --agent codex --dry-run
-npx --yes github:Leon-Drq/openagentskill#main install anthropic-frontend-design --agent codex --yes
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz search "extract tables from PDF reports"
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz resolve "extract tables from PDF reports" --agent codex
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz inspect anthropic-frontend-design
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz install anthropic-frontend-design --agent codex --dry-run
+npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz install anthropic-frontend-design --agent codex --yes
 ```
 
 Reviewed Skills require `--yes`; blocked Skills are never executed. Set

--- a/packages/cli/openagentskill.mjs
+++ b/packages/cli/openagentskill.mjs
@@ -4,7 +4,8 @@ import { randomUUID } from 'node:crypto'
 import { spawn } from 'node:child_process'
 
 const DEFAULT_BASE_URL = 'https://www.openagentskill.com'
-const SOURCE_COMMAND = 'npx --yes github:Leon-Drq/openagentskill#main'
+const CLI_VERSION = '0.2.1'
+const SOURCE_COMMAND = 'npx --yes https://github.com/Leon-Drq/openagentskill/releases/download/cli-v0.2.1/openagentskill-0.2.1.tgz'
 const KNOWN_AGENTS = new Set(['codex', 'claude-code', 'cursor', 'open-claw'])
 
 function help() {
@@ -195,7 +196,7 @@ async function reportInstall(baseUrl, payload, eventId, agent, outcome, notes, f
       error_type: outcome === 'success' ? null : 'install_failed',
       workspace: 'local',
       notes,
-      metadata: { source: 'openagentskill-cli', cli_version: '0.2.0' },
+      metadata: { source: 'openagentskill-cli', cli_version: CLI_VERSION },
     }),
   }).catch(() => null)
 }
@@ -280,7 +281,7 @@ async function outcome(baseUrl, eventId, flags) {
       evidence_url: flags.evidenceUrl || null,
       notes: flags.notes || null,
       dry_run: Boolean(flags.dryRun),
-      metadata: { source: 'openagentskill-cli', cli_version: '0.2.0' },
+      metadata: { source: 'openagentskill-cli', cli_version: CLI_VERSION },
     }),
   })
   if (jsonEnabled(flags)) return print(payload, flags)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openagentskill",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Official OpenAgentSkill CLI for task resolution, audited installs, and verified outcome receipts",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- publish the dependency-free CLI as a pinned GitHub Release tarball
- update every public install, outcome, and Skill workflow command to v0.2.1
- avoid installing the full Next.js application when agents invoke the CLI

## Verification
- ESLint: 0 errors (20 existing warnings)
- TypeScript: passed
- Next.js production build: 440 pages passed
- packaged CLI help: passed in about 0.48s locally
- registry Skill quick validation: passed