### PR TITLE
fix: make agent menu scroll and expose resolve alternatives

### DIFF
--- a/app/resolve/page.tsx
+++ b/app/resolve/page.tsx
@@ -192,6 +192,52 @@ function ResolveDecisionCard({ result }: { result: ResolveResult }) {
               </div>
             </aside>
           </div>
+
+          <div className="border-t border-border bg-card/55 p-5 sm:p-7">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="font-mono text-xs uppercase tracking-[0.22em] text-secondary">Ranked shortlist</p>
+                <h3 className="mt-2 font-display text-2xl font-normal">Compare the next-best qualified skills</h3>
+              </div>
+              <span className="font-mono text-xs text-secondary">
+                1 best match + {recommendation.alternatives.length} alternative{recommendation.alternatives.length === 1 ? '' : 's'}
+              </span>
+            </div>
+
+            {recommendation.alternatives.length > 0 ? (
+              <div className="mt-5 grid gap-3 md:grid-cols-2">
+                {recommendation.alternatives.slice(0, 4).map((item, index) => (
+                  <Link
+                    key={item.slug}
+                    href={item.url}
+                    className="group border border-border bg-background p-4 transition-colors hover:border-foreground/45"
+                  >
+                    <div className="flex items-start gap-3">
+                      <span className="font-mono text-xs text-secondary">#{index + 2}</span>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-start justify-between gap-3">
+                          <h4 className="break-words font-display text-lg font-normal [overflow-wrap:anywhere] group-hover:underline">
+                            {item.name}
+                          </h4>
+                          <span className="shrink-0 font-mono text-xs text-secondary">Trust {item.trust_score}</span>
+                        </div>
+                        <p className="mt-2 line-clamp-2 text-sm leading-6 text-secondary">{item.why_consider}</p>
+                        <div className="mt-3 flex flex-wrap gap-2 font-mono text-[10px] uppercase tracking-[0.12em] text-secondary">
+                          <span>Audit {item.audit_score}</span>
+                          <span aria-hidden="true">·</span>
+                          <span>Safety {item.safety_score}</span>
+                        </div>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-4 border border-border bg-background p-4 text-sm leading-6 text-secondary">
+                No close alternative passed the current task-fit and safety thresholds. The resolver is intentionally returning one qualified match instead of padding the list with unrelated skills.
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </section>
@@ -214,7 +260,7 @@ export default async function ResolvePage({
   const initialAgent = normalizeParam(params.agent) || 'codex'
   const maxRisk = normalizeRisk(normalizeParam(params.max_risk))
   const minStars = Number(normalizeParam(params.min_stars) || 0)
-  const live = normalizeParam(params.live) === 'true'
+  const live = normalizeParam(params.live) !== 'false'
   const initialResult = initialTask
     ? await resolveAgentSkill({
         task: initialTask,
@@ -258,7 +304,7 @@ export default async function ResolvePage({
 	          <MarketingMetricStrip
 	            columns="grid-cols-3"
 	            items={[
-	              { value: '1', label: 'Best skill' },
+	              { value: '1 + 4', label: 'Ranked skills' },
 	              { value: 'Score', label: 'Agent Proven' },
 	              { value: 'Receipt', label: 'Install handoff' },
 	            ]}
@@ -275,7 +321,7 @@ export default async function ResolvePage({
         </section>
 
         <section className="mx-auto max-w-6xl px-6 py-10 sm:py-14">
-          <AgentResolveWorkbench initialTask={initialTask} />
+          <AgentResolveWorkbench initialTask={initialTask} initialLive={live} />
         </section>
 
         <section className="border-t border-border">

--- a/components/agent-resolve-workbench.tsx
+++ b/components/agent-resolve-workbench.tsx
@@ -225,12 +225,18 @@ function copyText(value: string) {
   void navigator.clipboard?.writeText(value)
 }
 
-export function AgentResolveWorkbench({ initialTask = '' }: { initialTask?: string }) {
+export function AgentResolveWorkbench({
+  initialTask = '',
+  initialLive = true,
+}: {
+  initialTask?: string
+  initialLive?: boolean
+}) {
   const [task, setTask] = useState(initialTask || exampleTasks[0])
   const [agent, setAgent] = useState('codex')
   const [maxRisk, setMaxRisk] = useState('medium')
   const [minStars, setMinStars] = useState('0')
-  const [live, setLive] = useState(false)
+  const [live, setLive] = useState(initialLive)
   const [payload, setPayload] = useState<ResolvePayload | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -242,7 +248,7 @@ export function AgentResolveWorkbench({ initialTask = '' }: { initialTask?: stri
       max_risk: maxRisk,
       min_stars: minStars || '0',
     })
-    if (live) params.set('live', 'true')
+    params.set('live', String(live))
     return `/api/agent/resolve?${params.toString()}`
   }, [agent, live, maxRisk, minStars, task])
 
@@ -254,7 +260,7 @@ export function AgentResolveWorkbench({ initialTask = '' }: { initialTask?: stri
       min_stars: minStars || '0',
       format: 'text',
     })
-    if (live) params.set('live', 'true')
+    params.set('live', String(live))
     return `/api/agent/receipt?${params.toString()}`
   }, [agent, live, maxRisk, minStars, task])
 
@@ -281,7 +287,7 @@ export function AgentResolveWorkbench({ initialTask = '' }: { initialTask?: stri
         max_risk: maxRisk,
         min_stars: minStars || '0',
       })
-      if (live) params.set('live', 'true')
+      params.set('live', String(live))
 
       const response = await fetch(`/api/agent/resolve?${params.toString()}`)
       if (!response.ok) {
@@ -335,7 +341,7 @@ export function AgentResolveWorkbench({ initialTask = '' }: { initialTask?: stri
         <div className="flex items-start justify-between gap-4">
           <div>
             <p className="font-mono text-xs uppercase tracking-[0.22em] text-secondary">Agent Resolve</p>
-            <h2 className="mt-3 font-display text-2xl font-normal">Describe the task. Get one skill plan.</h2>
+            <h2 className="mt-3 font-display text-2xl font-normal">Describe the task. Get a ranked skill plan.</h2>
           </div>
           <span className="hidden rounded-[8px] border border-border px-2.5 py-1 font-mono text-xs text-secondary sm:inline-flex">
             API ready
@@ -406,7 +412,7 @@ export function AgentResolveWorkbench({ initialTask = '' }: { initialTask?: stri
               className="mt-1"
             />
             <span>
-              Use live registry data. Faster default mode uses the curated low-latency candidate pool for agent calls.
+              Use live registry data for the broadest shortlist. Turn this off to use the faster curated candidate pool.
             </span>
           </label>
 
@@ -480,11 +486,18 @@ export function AgentResolveWorkbench({ initialTask = '' }: { initialTask?: stri
             <h2 className="break-words font-display text-2xl font-normal [overflow-wrap:anywhere]">
               {recommendation?.best_skill.name || 'Resolve output will appear here'}
             </h2>
-            {payload?.policy_decision && (
-              <span className="w-fit border border-border px-2.5 py-1 font-mono text-xs uppercase tracking-[0.14em] text-secondary">
-                {compactStatus(payload.policy_decision.status)}
-              </span>
-            )}
+            <div className="flex flex-wrap items-center gap-2">
+              {recommendation && (
+                <span className="w-fit border border-border bg-card px-2.5 py-1 font-mono text-xs text-secondary">
+                  1 best + {recommendation.alternatives.length} alternative{recommendation.alternatives.length === 1 ? '' : 's'}
+                </span>
+              )}
+              {payload?.policy_decision && (
+                <span className="w-fit border border-border px-2.5 py-1 font-mono text-xs uppercase tracking-[0.14em] text-secondary">
+                  {compactStatus(payload.policy_decision.status)}
+                </span>
+              )}
+            </div>
           </div>
           {error && (
             <div className="mt-4 flex gap-3 border border-red-300 bg-red-50 p-3 text-sm text-red-700">
@@ -500,7 +513,7 @@ export function AgentResolveWorkbench({ initialTask = '' }: { initialTask?: stri
               <ShieldCheck className="mx-auto h-8 w-8 text-[#006b4f]" aria-hidden="true" />
               <h3 className="mt-4 font-display text-2xl font-normal">The registry returns a decision, not just links.</h3>
               <p className="mt-3 text-sm leading-6 text-secondary">
-                Your agent gets one recommended skill, alternatives, install command, Trust Score, audit summary, and a safety policy before it acts.
+                Your agent gets one primary recommendation plus qualified alternatives, install command, Trust Score, audit summary, and a safety policy before it acts.
               </p>
             </div>
           </div>
@@ -560,6 +573,54 @@ export function AgentResolveWorkbench({ initialTask = '' }: { initialTask?: stri
                   >
                     GitHub
                   </a>
+                )}
+              </div>
+
+              <div className="mt-6 border-t border-border pt-5">
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+                  <div>
+                    <p className="font-mono text-xs uppercase tracking-[0.18em] text-secondary">Ranked alternatives</p>
+                    <h3 className="mt-2 font-display text-xl font-normal">Compare before installing</h3>
+                  </div>
+                  <span className="font-mono text-xs text-secondary">
+                    {recommendation.alternatives.length > 0
+                      ? `Ranks #2–#${recommendation.alternatives.length + 1}`
+                      : '0 qualified alternatives'}
+                  </span>
+                </div>
+
+                {recommendation.alternatives.length > 0 ? (
+                  <div className="mt-4 grid gap-3 md:grid-cols-2">
+                    {recommendation.alternatives.slice(0, 4).map((item, index) => (
+                      <Link
+                        key={item.slug}
+                        href={item.url}
+                        className="group border border-border bg-card p-4 transition-colors hover:border-foreground/40"
+                      >
+                        <div className="flex items-start gap-3">
+                          <span className="font-mono text-xs text-secondary">#{index + 2}</span>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-start justify-between gap-3">
+                              <h4 className="min-w-0 break-words font-display text-lg font-normal [overflow-wrap:anywhere] group-hover:underline">
+                                {item.name}
+                              </h4>
+                              <span className="shrink-0 font-mono text-xs text-secondary">Trust {item.trust_score}</span>
+                            </div>
+                            <p className="mt-2 line-clamp-2 text-sm leading-6 text-secondary">{item.why_consider}</p>
+                            <div className="mt-3 flex flex-wrap gap-2 font-mono text-[10px] uppercase tracking-[0.12em] text-secondary">
+                              <span>Audit {item.audit_score}</span>
+                              <span aria-hidden="true">·</span>
+                              <span>Safety {item.safety_score}</span>
+                            </div>
+                          </div>
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="mt-4 border border-border bg-card p-4 text-sm leading-6 text-secondary">
+                    No close alternative passed the current task-fit and safety thresholds. The list is not padded with unrelated skills.
+                  </p>
                 )}
               </div>
             </div>
@@ -722,26 +783,6 @@ export function AgentResolveWorkbench({ initialTask = '' }: { initialTask?: stri
               </div>
             </div>
 
-            {recommendation.alternatives.length > 0 && (
-              <div className="p-4 sm:p-5">
-                <p className="font-mono text-xs uppercase tracking-[0.18em] text-secondary">Alternatives</p>
-                <div className="mt-3 grid gap-3 md:grid-cols-2">
-                  {recommendation.alternatives.slice(0, 4).map((item) => (
-                    <Link
-                      key={item.slug}
-                      href={item.url}
-                      className="border border-border bg-card p-4 transition-colors hover:border-foreground/40"
-                    >
-                      <div className="flex items-start justify-between gap-3">
-	                        <h3 className="min-w-0 break-words font-display text-lg font-normal [overflow-wrap:anywhere]">{item.name}</h3>
-	                        <span className="shrink-0 font-mono text-xs text-secondary">Trust {item.trust_score}</span>
-                      </div>
-                      <p className="mt-2 line-clamp-2 text-sm leading-6 text-secondary">{item.why_consider}</p>
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            )}
           </div>
         )}
       </section>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -130,6 +130,12 @@ function ForAgentsDropdown({ pathname }: { pathname: string }) {
       onBlur={(event) => {
         if (!event.currentTarget.contains(event.relatedTarget)) setOpen(false)
       }}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          setOpen(false)
+          event.currentTarget.querySelector<HTMLButtonElement>('button')?.focus()
+        }
+      }}
     >
       <button
         type="button"
@@ -149,13 +155,14 @@ function ForAgentsDropdown({ pathname }: { pathname: string }) {
       {open && (
         <div
           role="menu"
-          className="absolute right-0 top-[calc(100%-1px)] z-50 w-[330px] overflow-hidden rounded-[8px] border border-border bg-background shadow-[0_18px_55px_rgba(29,27,24,0.12)]"
+          aria-label={shell.agentMenuTitle}
+          className="absolute right-0 top-[calc(100%-1px)] z-50 flex max-h-[calc(100dvh-4.5rem)] w-[330px] flex-col overflow-hidden rounded-[8px] border border-border bg-background shadow-[0_18px_55px_rgba(29,27,24,0.12)]"
         >
-          <div className="border-b border-border bg-muted/35 px-4 py-3">
+          <div className="shrink-0 border-b border-border bg-muted/35 px-4 py-3">
             <p className="text-sm font-semibold text-foreground">{shell.agentMenuTitle}</p>
             <p className="mt-1 text-xs leading-5 text-secondary">{shell.agentMenuDescription}</p>
           </div>
-          <div className="grid p-1.5">
+          <div className="grid min-h-0 flex-1 overflow-y-auto overscroll-contain p-1.5 [scrollbar-gutter:stable]">
             {agentItems.map((item) => {
               const Icon = item.icon
               const itemActive = isActivePath(pathname, item.href)


### PR DESCRIPTION
## What changed

- constrain the For Agents dropdown to the viewport and give its item list an independent scroll container
- support Escape-to-close and restore focus to the dropdown trigger
- expose the Resolve shortlist immediately beside the best match instead of burying alternatives below receipts and evidence
- show rank, Trust, Audit, and Safety signals for up to four alternatives
- explain when no alternative passes task-fit and safety thresholds
- align direct Resolve URLs and the interactive workbench on live-registry defaults

## Why

The dropdown used `overflow-hidden` without a viewport height, so items below the fold could not be reached. Resolve already returned alternatives, but the page advertised “1 Best skill” and placed alternatives at the bottom, which made the result appear single-choice. The live-data checkbox also disagreed with the API default.

## Impact

Users can reach every agent navigation item at shorter desktop heights and can compare one selected Skill with up to four qualified alternatives before installing. Direct URLs and interactive requests now produce consistent live-registry rankings by default.

## Verification

- ESLint: 0 errors (20 existing warnings)
- TypeScript: passed
- Next.js production build: 440 pages passed
- Browser at 1440×800: dropdown scrolled from 0 to 167 and exposed the final Evals item
- Browser Resolve run: 1 best + 4 alternatives rendered with ranks #2–#5
- Direct task URL: selected Skill and alternative shortlist matched interactive live results
- No browser console errors or Next.js error overlay
