### PR TITLE
Fix new Skill discovery and review consistency

### DIFF
--- a/app/api/skills/search/route.ts
+++ b/app/api/skills/search/route.ts
@@ -27,7 +27,7 @@ const getSearchCandidatePool = unstable_cache(
     }
   },
   ['skills-search-candidate-pool-v2'],
-  { revalidate: 300 }
+  { revalidate: 300, tags: ['public-skill-directory'] }
 )
 
 function clampLimit(value: string | null) {

--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -126,6 +126,23 @@ export default function SubmitPage() {
                 {result?.skill.name || receipt.skill.name} · <span className="font-mono">{receipt.skill.path}</span>
               </p>
 
+              {result?.skill.slug && (
+                <div className="mt-5 border border-border bg-background p-4">
+                  <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-secondary">
+                    {zh ? '公开 Skill 地址' : 'PUBLIC SKILL URL'}
+                  </p>
+                  <Link
+                    href={`/skills/${result.skill.slug}`}
+                    className="mt-2 block break-all font-mono text-sm font-semibold underline underline-offset-4"
+                  >
+                    https://www.openagentskill.com/skills/{result.skill.slug}
+                  </Link>
+                  <p className="mt-2 text-xs text-secondary">
+                    {zh ? '公开 slug：' : 'Public slug: '}<span className="font-mono">{result.skill.slug}</span>
+                  </p>
+                </div>
+              )}
+
               {result?.review?.issues && result.review.issues.length > 0 && (
                 <div className="mt-6 border border-border p-4">
                   <p className="font-semibold">{zh ? '发现的问题' : 'Review notes'}</p>

--- a/lib/ai-review/reviewer.ts
+++ b/lib/ai-review/reviewer.ts
@@ -1,6 +1,7 @@
 import { generateText } from 'ai'
 import type { AIReviewResult } from '../schema/skill-schema'
 import { SUBMISSION_REVIEW_MODEL } from '@/lib/ai/models'
+import { reconcileLicenseReviewFeedback } from '@/lib/skills/license-review'
 
 export interface SkillReviewData {
   repository: string
@@ -119,6 +120,7 @@ export async function reviewSkill(data: SkillReviewData): Promise<AIReviewResult
 Repository: ${data.repository}
 GitHub adoption: ${data.githubStats.stars} stars, ${data.githubStats.forks} forks
 Last updated: ${data.githubStats.lastUpdated}
+Repository license detected by GitHub: ${data.githubStats.license || 'Unknown'}
 
 SKILL.md and documentation excerpt:
 ${data.readmeContent.slice(0, 5000)}
@@ -186,16 +188,24 @@ Return only JSON without markdown fences:
       scores.compliance >= 6 &&
       totalScore >= 32
 
+    const issues = Array.isArray(reviewData.issues)
+      ? reviewData.issues.filter((item): item is string => typeof item === 'string').slice(0, 20)
+      : []
+    const suggestions = Array.isArray(reviewData.suggestions)
+      ? reviewData.suggestions.filter((item): item is string => typeof item === 'string').slice(0, 20)
+      : []
+    const reconciledFeedback = reconcileLicenseReviewFeedback(
+      data.githubStats.license || (typeof data.manifestData?.license === 'string' ? data.manifestData.license : null),
+      issues,
+      suggestions
+    )
+
     return {
       approved: Boolean(reviewData.approved) && meetsAutomaticGate,
       scores,
       totalScore,
-      issues: Array.isArray(reviewData.issues)
-        ? reviewData.issues.filter((item): item is string => typeof item === 'string').slice(0, 20)
-        : [],
-      suggestions: Array.isArray(reviewData.suggestions)
-        ? reviewData.suggestions.filter((item): item is string => typeof item === 'string').slice(0, 20)
-        : [],
+      issues: reconciledFeedback.issues,
+      suggestions: reconciledFeedback.suggestions,
       reasoning: typeof reviewData.reasoning === 'string' ? reviewData.reasoning.slice(0, 4000) : '',
       reviewedAt: new Date().toISOString(),
       reviewModel: SUBMISSION_REVIEW_MODEL,

--- a/lib/db/skills.ts
+++ b/lib/db/skills.ts
@@ -4,6 +4,7 @@ import { withTimeout } from '@/lib/async'
 import { unstable_cache } from 'next/cache'
 import type { Skill } from '@/lib/types'
 import { CURATED_SKILL_SNAPSHOT } from '@/lib/seo/curated-skill-snapshot'
+import { getSearchTerms, normalizeExactSearchQuery } from '@/lib/search-query'
 
 export interface SkillRecord {
   id: string
@@ -931,25 +932,6 @@ export async function createSubmissionRecord(submission: {
   return data
 }
 
-function getSearchTerms(normalizedQuery: string) {
-  const stopWords = new Set([
-    'about', 'agent', 'agents', 'and', 'for', 'from', 'into', 'need', 'right', 'skill', 'skills',
-    'that', 'the', 'this', 'use', 'using', 'want', 'what', 'when', 'with',
-  ])
-
-  const terms = Array.from(
-    new Set(
-      normalizedQuery
-        .toLowerCase()
-        .split(/[^a-z0-9]+/)
-        .map((term) => term.trim())
-        .filter((term) => term.length >= 3 && !stopWords.has(term))
-    )
-  ).slice(0, 10)
-
-  return terms.length > 0 ? terms : [normalizedQuery]
-}
-
 function isMissingSearchDocumentError(error: unknown) {
   if (!error || typeof error !== 'object') return false
   const message = `${(error as { code?: string }).code || ''} ${(error as { message?: string }).message || ''}`
@@ -961,7 +943,7 @@ async function searchSkillsWithLegacyFilter(
   limit: number
 ): Promise<SkillRecord[]> {
   const supabase = createPublicClient({ requestTimeoutMs: SKILL_DIRECTORY_REQUEST_TIMEOUT_MS })
-  const fields = ['name', 'description', 'long_description', 'tagline', 'category', 'github_repo', 'repository']
+  const fields = ['slug', 'name', 'description', 'long_description', 'tagline', 'category', 'github_repo', 'repository']
   const filter = searchTerms
     .flatMap((term) => fields.map((field) => `${field}.ilike.%${term}%`))
     .join(',')
@@ -1017,12 +999,55 @@ const getCachedSearchSkills = unstable_cache(
   { revalidate: SHARED_SKILL_CACHE_REVALIDATE_SECONDS, tags: ['public-skill-directory'] }
 )
 
+async function fetchExactSearchSkills(query: string): Promise<SkillRecord[]> {
+  const exactQuery = normalizeExactSearchQuery(query)
+  if (!exactQuery) return []
+
+  const supabase = createPublicClient({ requestTimeoutMs: SKILL_DIRECTORY_REQUEST_TIMEOUT_MS })
+  const [slugResult, nameResult] = await Promise.all([
+    supabase
+      .from('skills')
+      .select(SKILL_DIRECTORY_SELECT)
+      .eq('ai_review_approved', true)
+      .eq('slug', exactQuery.toLowerCase())
+      .limit(4),
+    supabase
+      .from('skills')
+      .select(SKILL_DIRECTORY_SELECT)
+      .eq('ai_review_approved', true)
+      .ilike('name', exactQuery)
+      .limit(8),
+  ])
+
+  if (slugResult.error) throw slugResult.error
+  if (nameResult.error) throw nameResult.error
+
+  const seen = new Set<string>()
+  return filterSkillOnly([...(slugResult.data || []), ...(nameResult.data || [])] as unknown as SkillRecord[])
+    .filter((skill) => {
+      if (seen.has(skill.slug)) return false
+      seen.add(skill.slug)
+      return true
+    })
+}
+
 export async function searchSkills(query: string, limit = 120): Promise<SkillRecord[]> {
-  const normalizedQuery = query.trim().replace(/[%_,{},()]/g, ' ')
+  const normalizedQuery = normalizeExactSearchQuery(query)
   if (!normalizedQuery) return []
 
   const rowLimit = Math.min(Math.max(Math.floor(limit) || 1, 1), 200)
-  return getCachedSearchSkills(normalizedQuery.toLowerCase(), rowLimit)
+  const [exactMatches, broadMatches] = await Promise.all([
+    fetchExactSearchSkills(normalizedQuery).catch(() => [] as SkillRecord[]),
+    getCachedSearchSkills(normalizedQuery.toLowerCase(), rowLimit),
+  ])
+  const seen = new Set<string>()
+  return [...exactMatches, ...broadMatches]
+    .filter((skill) => {
+      if (seen.has(skill.slug)) return false
+      seen.add(skill.slug)
+      return true
+    })
+    .slice(0, rowLimit)
 }
 
 export async function getRelatedSkills(

--- a/lib/search-query.ts
+++ b/lib/search-query.ts
@@ -1,0 +1,26 @@
+const SEARCH_STOP_WORDS = new Set([
+  'about', 'agent', 'agents', 'and', 'as', 'for', 'from', 'into', 'need', 'right', 'skill', 'skills',
+  'that', 'the', 'this', 'use', 'using', 'want', 'what', 'when', 'with',
+])
+
+export function getSearchTerms(normalizedQuery: string) {
+  const terms = Array.from(
+    new Set(
+      normalizedQuery
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .map((term) => term.trim())
+        .filter((term) => term.length >= 2 && !SEARCH_STOP_WORDS.has(term))
+    )
+  ).slice(0, 10)
+
+  return terms.length > 0 ? terms : [normalizedQuery]
+}
+
+export function normalizeExactSearchQuery(query: string) {
+  return query
+    .trim()
+    .replace(/[%_,{},()]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .slice(0, 180)
+}

--- a/lib/skills/license-review.ts
+++ b/lib/skills/license-review.ts
@@ -1,0 +1,23 @@
+const MISSING_LICENSE_ISSUE =
+  /(?:\bno\b|\bmissing\b|\bwithout\b|\black(?:s|ing)?\b|\bnot\s+(?:present|found|provided|declared|specified)\b).{0,80}\blicen[cs]e\b|\blicen[cs]e\b.{0,80}(?:\bmissing\b|\bnot\s+(?:present|found|provided|declared|specified)\b)/i
+
+const ADD_LICENSE_SUGGESTION =
+  /\b(?:add|include|declare|provide|specify|choose)\b.{0,100}\blicen[cs]e\b/i
+
+export function hasDeclaredRepositoryLicense(license?: string | null) {
+  const value = license?.trim().toLowerCase()
+  return Boolean(value && !['unknown', 'noassertion', 'other', 'none'].includes(value))
+}
+
+export function reconcileLicenseReviewFeedback(
+  license: string | null | undefined,
+  issues: string[],
+  suggestions: string[]
+) {
+  if (!hasDeclaredRepositoryLicense(license)) return { issues, suggestions }
+
+  return {
+    issues: issues.filter((item) => !MISSING_LICENSE_ISSUE.test(item)),
+    suggestions: suggestions.filter((item) => !ADD_LICENSE_SUGGESTION.test(item)),
+  }
+}

--- a/lib/skills/open-submission.ts
+++ b/lib/skills/open-submission.ts
@@ -1,11 +1,13 @@
 import 'server-only'
 
 import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import type { GitHubRepo } from '@/lib/schema/skill-schema'
 import type { DiscoveredGitHubSkill } from '@/lib/github/skill-source'
 import { reviewSkill } from '@/lib/ai-review/reviewer'
 import { analyzeCode } from '@/lib/security/static-analysis'
 import { evaluateSkillSubmissionPolicy } from '@/lib/skills/submission-policy'
+import { estimateSubmissionQuality } from '@/lib/skills/submission-quality'
 import { createAdminClient } from '@/lib/supabase/admin'
 
 export const SUBMISSION_RATE_LIMIT = 5
@@ -294,6 +296,13 @@ export async function reviewOpenSubmission(input: OpenSubmissionInput, submissio
     const category = normalizeCategory(input)
     const tags = normalizeTags(input)
     const authorName = input.makerGithub || input.skill.frontmatter.author || input.repository.owner
+    const quality = estimateSubmissionQuality({
+      githubStars: input.repository.stars,
+      githubRepo: input.repository.fullName,
+      githubUpdatedAt: input.repository.updatedAt,
+      reviewTotal: review.totalScore,
+      tags,
+    })
     const skillPayload = {
       slug,
       name: input.skill.frontmatter.name,
@@ -333,6 +342,8 @@ export async function reviewOpenSubmission(input: OpenSubmissionInput, submissio
       ai_review_approved: true,
       ai_review_issues: policy.issues,
       ai_review_suggestions: policy.suggestions,
+      quality_score: quality.score,
+      quality_signals: quality.signals,
     }
 
     const { data: createdSkill, error: createError } = await supabase
@@ -371,6 +382,19 @@ export async function reviewOpenSubmission(input: OpenSubmissionInput, submissio
       })
       .eq('id', submissionId)
     if (updateError) throw updateError
+
+    const { error: qualityRefreshError } = await supabase.rpc('refresh_skill_quality_scores', { p_slug: slug })
+    if (qualityRefreshError) {
+      console.warn('[submission-review] Quality refresh fallback retained:', qualityRefreshError.message)
+    }
+
+    try {
+      revalidateTag('public-skill-directory', 'max')
+      revalidatePath('/skills')
+      revalidatePath('/api/skills/search')
+    } catch (cacheError) {
+      console.warn('[submission-review] Cache invalidation deferred:', cacheError)
+    }
 
     await supabase.from('activity_feed').insert({
       event_type: input.submissionSource === 'agent' ? 'agent_submitted' : 'skill_published',

--- a/lib/skills/submission-quality.ts
+++ b/lib/skills/submission-quality.ts
@@ -1,0 +1,40 @@
+export interface SubmissionQualityInput {
+  githubStars: number
+  githubRepo: string
+  githubUpdatedAt: string
+  reviewTotal: number
+  reviewMaximum?: number
+  tags: string[]
+  verified?: boolean
+}
+
+function roundScore(value: number) {
+  return Math.round(value * 100) / 100
+}
+
+export function estimateSubmissionQuality(input: SubmissionQualityInput) {
+  const stars = Math.max(0, Number(input.githubStars || 0))
+  const starScore = Math.min(35, Math.log10(stars + 1) * 7)
+  const reviewMaximum = Math.max(1, input.reviewMaximum || 40)
+  const reviewScore = Math.min(15, Math.max(0, input.reviewTotal) / reviewMaximum * 15)
+  const updatedAt = Date.parse(input.githubUpdatedAt)
+  const ageDays = Number.isFinite(updatedAt) ? (Date.now() - updatedAt) / 86_400_000 : Number.POSITIVE_INFINITY
+  const freshnessScore = ageDays <= 30 ? 15 : ageDays <= 90 ? 12 : ageDays <= 180 ? 8 : ageDays <= 365 ? 4 : 0
+  const metadataScore =
+    (/^[^/]+\/[^/]+$/.test(input.githubRepo) ? 3 : 0) +
+    (input.tags.length >= 3 ? 4 : 0) +
+    (input.verified ? 8 : 0)
+  const score = Math.min(100, starScore + reviewScore + freshnessScore + metadataScore)
+
+  return {
+    score: roundScore(score),
+    signals: {
+      star_score: roundScore(starScore),
+      review_score: roundScore(reviewScore),
+      freshness_score: freshnessScore,
+      usage_score: 0,
+      metadata_score: metadataScore,
+      model: 'v2',
+    },
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "seed:popular": "node scripts/seed-popular-skills.ts",
     "indexer:backfill": "node scripts/backfill-high-star-skills.mjs",
     "test:submission": "node --experimental-strip-types scripts/test-skill-source.ts",
+    "test:submission-discovery": "node --experimental-strip-types scripts/test-submission-discovery.ts",
     "test:cli": "node packages/cli/openagentskill.mjs --help",
     "lint": "eslint ."
   },

--- a/scripts/test-submission-discovery.ts
+++ b/scripts/test-submission-discovery.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+// Node's type-stripping runner needs explicit extensions for these standalone tests.
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
+import { getSearchTerms, normalizeExactSearchQuery } from '../lib/search-query.ts'
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
+import { reconcileLicenseReviewFeedback } from '../lib/skills/license-review.ts'
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
+import { estimateSubmissionQuality } from '../lib/skills/submission-quality.ts'
+
+assert.deepEqual(getSearchTerms('ip-as-logo'), ['ip', 'logo'])
+assert.equal(normalizeExactSearchQuery('  ip-as-logo  '), 'ip-as-logo')
+
+const feedback = reconcileLicenseReviewFeedback(
+  'MIT',
+  [
+    'No explicit license file or license text is present in the repository.',
+    'Commercial use requires confirmation.',
+  ],
+  [
+    'Add a clear open-source license to the repository root.',
+    'Add a concrete output example.',
+  ]
+)
+assert.deepEqual(feedback.issues, ['Commercial use requires confirmation.'])
+assert.deepEqual(feedback.suggestions, ['Add a concrete output example.'])
+
+const quality = estimateSubmissionQuality({
+  githubStars: 111,
+  githubRepo: 's1dashu/ip-as-logo-skill',
+  githubUpdatedAt: new Date().toISOString(),
+  reviewTotal: 35,
+  tags: ['agent-skill', 'logo', 'creative'],
+})
+assert.ok(quality.score >= 45, `Expected a useful initial quality score, received ${quality.score}`)
+assert.equal(quality.signals.model, 'v2')
+
+console.log('Submission discovery regression tests passed.')

--- a/supabase/migrations/20260818171711_fix_submission_discovery.sql
+++ b/supabase/migrations/20260818171711_fix_submission_discovery.sql
@@ -1,0 +1,216 @@
+-- Make newly reviewed skills immediately discoverable by exact and full-text
+-- search, and keep their quality score synchronized from the first insert.
+
+alter table public.skills
+  add column if not exists search_document tsvector
+  generated always as (
+    setweight(to_tsvector('simple'::regconfig, coalesce(slug, '')), 'A') ||
+    setweight(to_tsvector('simple'::regconfig, coalesce(name, '')), 'A') ||
+    setweight(to_tsvector('simple'::regconfig, coalesce(github_repo, '')), 'A') ||
+    setweight(to_tsvector('simple'::regconfig, coalesce(description, '')), 'B') ||
+    setweight(to_tsvector('simple'::regconfig, coalesce(tagline, '')), 'B') ||
+    setweight(to_tsvector('simple'::regconfig, coalesce(category, '')), 'B') ||
+    setweight(to_tsvector('simple'::regconfig, coalesce(long_description, '')), 'C') ||
+    setweight(to_tsvector('simple'::regconfig, coalesce(repository, '')), 'C')
+  ) stored;
+
+create index if not exists idx_skills_search_document
+  on public.skills using gin (search_document);
+
+create or replace function public.refresh_skill_quality_scores(p_slug text default null)
+returns integer
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_count integer := 0;
+begin
+  with base as (
+    select
+      s.id,
+      s.slug,
+      greatest(coalesce(s.github_stars, 0), 0) as github_stars,
+      s.github_repo,
+      s.verified,
+      s.tags,
+      s.ai_review_score,
+      s.ai_review_approved,
+      coalesce(s.github_last_pushed_at, s.last_synced_at, s.updated_at, s.created_at) as freshness_at,
+      coalesce(ss.total_calls, 0) as total_calls,
+      coalesce(ss.success_rate, 0) as success_rate
+    from public.skills s
+    left join public.skill_stats ss on ss.skill_slug = s.slug
+    where p_slug is null or s.slug = p_slug
+  ),
+  signals as (
+    select
+      id,
+      slug,
+      least(35, round((ln(github_stars + 1) / ln(10) * 7)::numeric, 2)) as star_score,
+      round(
+        least(
+          15,
+          greatest(
+            0,
+            case
+              when jsonb_typeof(ai_review_score->'total') = 'number'
+                and ai_review_score->>'source' = 'open-skill-submission'
+                then (ai_review_score->>'total')::numeric / 40 * 15
+              when jsonb_typeof(ai_review_score->'total') = 'number'
+                then (ai_review_score->>'total')::numeric / 100 * 15
+              when ai_review_approved then 10.5
+              else 0
+            end
+          )
+        ),
+        2
+      ) as review_score,
+      case
+        when freshness_at >= now() - interval '30 days' then 15::numeric
+        when freshness_at >= now() - interval '90 days' then 12::numeric
+        when freshness_at >= now() - interval '180 days' then 8::numeric
+        when freshness_at >= now() - interval '365 days' then 4::numeric
+        else 0::numeric
+      end as freshness_score,
+      case
+        when total_calls >= 20 then round(least(20, success_rate / 100 * 20)::numeric, 2)
+        when total_calls >= 5 then round(least(12, success_rate / 100 * 12)::numeric, 2)
+        when total_calls > 0 then 5::numeric
+        else 0::numeric
+      end as usage_score,
+      (
+        case when github_repo ~ '^[^/]+/[^/]+$' then 3 else 0 end
+        + case when coalesce(array_length(tags, 1), 0) >= 3 then 4 else 0 end
+        + case when verified then 8 else 0 end
+      )::numeric as metadata_score
+    from base
+  ),
+  scored as (
+    select
+      id,
+      least(100, round((star_score + review_score + freshness_score + usage_score + metadata_score)::numeric, 2)) as quality_score,
+      jsonb_build_object(
+        'star_score', star_score,
+        'review_score', review_score,
+        'freshness_score', freshness_score,
+        'usage_score', usage_score,
+        'metadata_score', metadata_score,
+        'model', 'v2'
+      ) as quality_signals
+    from signals
+  )
+  update public.skills s
+  set
+    quality_score = scored.quality_score,
+    quality_signals = scored.quality_signals,
+    updated_at = now()
+  from scored
+  where s.id = scored.id;
+
+  get diagnostics v_count = row_count;
+  return v_count;
+end;
+$$;
+
+revoke all on function public.refresh_skill_quality_scores(text) from public;
+revoke all on function public.refresh_skill_quality_scores(text) from anon, authenticated;
+grant execute on function public.refresh_skill_quality_scores(text) to service_role;
+
+create or replace function public.refresh_quality_after_skill_write()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  perform public.refresh_skill_quality_scores(new.slug);
+  return new;
+end;
+$$;
+
+revoke all on function public.refresh_quality_after_skill_write() from public;
+revoke all on function public.refresh_quality_after_skill_write() from anon, authenticated;
+
+drop trigger if exists skills_refresh_quality_after_insert on public.skills;
+create trigger skills_refresh_quality_after_insert
+  after insert on public.skills
+  for each row execute function public.refresh_quality_after_skill_write();
+
+drop trigger if exists skills_refresh_quality_after_metadata_update on public.skills;
+create trigger skills_refresh_quality_after_metadata_update
+  after update of github_stars, github_repo, verified, tags, ai_review_score,
+    ai_review_approved, github_last_pushed_at on public.skills
+  for each row execute function public.refresh_quality_after_skill_write();
+
+select public.refresh_skill_quality_scores();
+
+-- Repository metadata is deterministic. Remove only "missing license"
+-- feedback when a concrete license is already recorded; retain usage-rights
+-- and non-commercial warnings.
+with cleaned as (
+  select
+    id,
+    array(
+      select issue
+      from unnest(coalesce(ai_review_issues, '{}'::text[])) as issue
+      where issue !~* '(no explicit|missing|without|not (present|found|provided|declared|specified)).{0,80}licen[cs]e|licen[cs]e.{0,80}(missing|not (present|found|provided|declared|specified))'
+    ) as issues,
+    array(
+      select suggestion
+      from unnest(coalesce(ai_review_suggestions, '{}'::text[])) as suggestion
+      where suggestion !~* '(add|include|declare|provide|specify|choose).{0,100}licen[cs]e'
+    ) as suggestions
+  from public.skills
+  where lower(coalesce(license, '')) not in ('', 'unknown', 'noassertion', 'other', 'none')
+)
+update public.skills s
+set ai_review_issues = cleaned.issues,
+    ai_review_suggestions = cleaned.suggestions
+from cleaned
+where s.id = cleaned.id;
+
+with licensed_submissions as (
+  select ss.id, ss.ai_review_result
+  from public.skill_submissions ss
+  join public.skills s on s.id = ss.skill_id
+  where lower(coalesce(s.license, '')) not in ('', 'unknown', 'noassertion', 'other', 'none')
+), cleaned as (
+  select
+    id,
+    coalesce((
+      select jsonb_agg(value)
+      from jsonb_array_elements_text(coalesce(ai_review_result->'issues', '[]'::jsonb)) as value
+      where value !~* '(no explicit|missing|without|not (present|found|provided|declared|specified)).{0,80}licen[cs]e|licen[cs]e.{0,80}(missing|not (present|found|provided|declared|specified))'
+    ), '[]'::jsonb) as issues,
+    coalesce((
+      select jsonb_agg(value)
+      from jsonb_array_elements_text(coalesce(ai_review_result->'suggestions', '[]'::jsonb)) as value
+      where value !~* '(add|include|declare|provide|specify|choose).{0,100}licen[cs]e'
+    ), '[]'::jsonb) as suggestions,
+    coalesce((
+      select jsonb_agg(value)
+      from jsonb_array_elements_text(coalesce(ai_review_result->'policy'->'issues', '[]'::jsonb)) as value
+      where value !~* '(no explicit|missing|without|not (present|found|provided|declared|specified)).{0,80}licen[cs]e|licen[cs]e.{0,80}(missing|not (present|found|provided|declared|specified))'
+    ), '[]'::jsonb) as policy_issues,
+    coalesce((
+      select jsonb_agg(value)
+      from jsonb_array_elements_text(coalesce(ai_review_result->'policy'->'suggestions', '[]'::jsonb)) as value
+      where value !~* '(add|include|declare|provide|specify|choose).{0,100}licen[cs]e'
+    ), '[]'::jsonb) as policy_suggestions
+  from licensed_submissions
+)
+update public.skill_submissions ss
+set ai_review_result = ss.ai_review_result || jsonb_build_object(
+  'issues', cleaned.issues,
+  'suggestions', cleaned.suggestions,
+  'policy', coalesce(ss.ai_review_result->'policy', '{}'::jsonb) || jsonb_build_object(
+    'issues', cleaned.policy_issues,
+    'suggestions', cleaned.policy_suggestions
+  )
+)
+from cleaned
+where ss.id = cleaned.id;
+
+comment on column public.skills.search_document is
+  'Stored, weighted simple-language document used by public Skill search.';


### PR DESCRIPTION
## What changed

- prioritizes exact Skill name and slug matches before broad ranking
- adds a weighted Postgres full-text search document and GIN index
- assigns and refreshes quality scores as soon as a Skill is reviewed
- invalidates public directory/search caches after publication
- treats detected GitHub license metadata as authoritative over AI guesses
- shows the canonical public slug and URL on the submission receipt
- backfills current quality scores and removes false missing-license feedback

## Root cause

New submissions defaulted to a zero quality score, while production lacked the expected `search_document` column. The legacy search reduced `ip-as-logo` to the broad token `logo`, ranked by quality, and truncated the new Skill before application ranking. The AI prompt also did not surface GitHub's structured license value.

## Validation

- `pnpm test:submission-discovery`
- `pnpm test:submission`
- `pnpm exec tsc --noEmit`
- `pnpm lint` (existing warnings only)
- `pnpm build`
- production migration verified: quality 45.47, FTS match true, false MIT warning removed