### PR TITLE
Add recursive Skill discovery and exact search tiers

### DIFF
--- a/app/api/agent/discovery/route.ts
+++ b/app/api/agent/discovery/route.ts
@@ -505,7 +505,7 @@ export async function GET() {
       strategy:
         'Maintain a 20k+ skill registry with rotating, scenario-specific GitHub discovery, periodic social signals, MCP exclusion, trust metadata, eval metadata, and small high-quality hourly imports.',
       quality_gates: [
-        'GitHub stars threshold',
+        'GitHub stars threshold for repository-level discovery; explicit SKILL.md paths remain zero-star eligible',
         'archived and fork exclusion',
         'skill relevance scoring',
         'MCP-only exclusion',
@@ -519,10 +519,19 @@ export async function GET() {
     github_discovery: {
       status: 'active',
       source: 'github_search',
-      strategy: 'high-star, skills-only, cross-domain rotating discovery',
+      strategy: 'high-star repository discovery plus recursive, zero-star-eligible SKILL.md source sync',
       target_approved_skills: effectiveCoverageTarget,
       domain_count: HIGH_STAR_DISCOVERY_DOMAINS.length,
       domains: HIGH_STAR_DISCOVERY_DOMAINS,
+      recursive_skill_sources: {
+        status: 'active',
+        schedule: 'every 6 hours',
+        patterns: ['SKILL.md', 'skills/**/SKILL.md', '.agents/skills/**/SKILL.md', '**/SKILL.md'],
+        exact_source_urls_preserved_from_social_radar: true,
+        existing_repository_incremental_rescan: true,
+        zero_star_intake: true,
+        review_policy: 'static security analysis plus automated quality review before public approval',
+      },
       targeted_import: {
         supported: true,
         private_endpoint: '/api/indexer/run',
@@ -706,6 +715,7 @@ export async function GET() {
       private_refresh_stars: '/api/indexer/refresh-stars',
       private_logs: '/api/indexer/logs',
       private_skill_radar: '/api/cron/skill-radar',
+      private_skill_source_sync: '/api/cron/skill-source-sync',
       private_indexnow_submit: '/api/indexnow/submit',
       public_agent_outcomes: '/api/agent/outcome',
       public_agent_outcomes_text: '/api/agent/outcome?format=text',

--- a/app/api/cron/skill-source-sync/route.ts
+++ b/app/api/cron/skill-source-sync/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { HIGH_SIGNAL_SKILL_SOURCES } from '@/lib/indexer/discovery-seeds'
+import { syncRepositorySkills } from '@/lib/indexer/repository-skill-sync'
+import { isAutomationAuthorized } from '@/lib/security/route-auth'
+import { createPublicClient } from '@/lib/supabase/public'
+
+export const runtime = 'nodejs'
+export const maxDuration = 300
+
+interface SourceRequest {
+  sourceUrl: string
+  discoverySource: string
+}
+
+function normalizeRepositoryUrl(githubRepo: string) {
+  return `https://github.com/${githubRepo.trim().replace(/^\/+|\/+$/g, '')}`
+}
+
+function uniqueSources(sources: SourceRequest[]) {
+  const seen = new Set<string>()
+  return sources.filter((source) => {
+    const key = source.sourceUrl.trim().replace(/\/$/, '').toLowerCase()
+    if (!key || seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+async function staleIndexedRepositories(limit: number): Promise<SourceRequest[]> {
+  const { data, error } = await createPublicClient({ requestTimeoutMs: 12_000 })
+    .from('skills')
+    .select('github_repo,last_synced_at')
+    .eq('ai_review_approved', true)
+    .not('github_repo', 'is', null)
+    .order('last_synced_at', { ascending: true, nullsFirst: true })
+    .limit(Math.max(limit * 4, 20))
+
+  if (error) {
+    console.warn('[skill-source-sync] stale repository lookup failed:', error.message)
+    return []
+  }
+
+  const seen = new Set<string>()
+  return (data || [])
+    .map((row: { github_repo?: string | null }) => row.github_repo?.trim())
+    .filter((repo): repo is string => Boolean(repo) && /^[^/]+\/[^/]+$/.test(repo as string))
+    .filter((repo) => {
+      const key = repo.toLowerCase()
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+    .slice(0, limit)
+    .map((repo) => ({
+      sourceUrl: normalizeRepositoryUrl(repo),
+      discoverySource: 'incremental-repository-rescan',
+    }))
+}
+
+async function handleRun(request: NextRequest) {
+  if (!isAutomationAuthorized(request, ['CRON_SECRET', 'INDEXER_SECRET', 'INDEXER_TRIGGER_SECRET'])) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body = request.method === 'POST' ? await request.json().catch(() => ({})) : {}
+  const requestedLimit = Number(request.nextUrl.searchParams.get('limit') || body.limit || 8)
+  const limit = Math.min(Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 8, 1), 12)
+  const requestedSources = Array.isArray(body.sources)
+    ? body.sources
+        .map((value: unknown) => String(value || '').trim())
+        .filter(Boolean)
+        .map((sourceUrl: string) => ({ sourceUrl, discoverySource: 'manual-source-sync' }))
+    : []
+  const staleSources = await staleIndexedRepositories(Math.max(0, limit - HIGH_SIGNAL_SKILL_SOURCES.length))
+  const sources = uniqueSources([
+    ...requestedSources,
+    ...HIGH_SIGNAL_SKILL_SOURCES.map(({ sourceUrl, discoverySource }) => ({ sourceUrl, discoverySource })),
+    ...staleSources,
+  ]).slice(0, limit)
+
+  const results = []
+  for (const source of sources) {
+    try {
+      results.push(await syncRepositorySkills({
+        reference: source.sourceUrl,
+        discoverySource: source.discoverySource,
+        maxSkills: source.discoverySource === 'incremental-repository-rescan' ? 6 : 4,
+      }))
+    } catch (error) {
+      results.push({
+        repository: source.sourceUrl,
+        reference: source.sourceUrl,
+        discovered: 0,
+        processed: 0,
+        created: 0,
+        updated: 0,
+        rejected: 0,
+        errors: 1,
+        truncated: false,
+        entries: [],
+        error: error instanceof Error ? error.message : 'Unknown skill source sync error.',
+      })
+    }
+  }
+
+  const summary = results.reduce((total, result) => ({
+    sources: total.sources + 1,
+    discovered: total.discovered + Number(result.discovered || 0),
+    processed: total.processed + Number(result.processed || 0),
+    created: total.created + Number(result.created || 0),
+    updated: total.updated + Number(result.updated || 0),
+    rejected: total.rejected + Number(result.rejected || 0),
+    errors: total.errors + Number(result.errors || 0),
+  }), { sources: 0, discovered: 0, processed: 0, created: 0, updated: 0, rejected: 0, errors: 0 })
+
+  return NextResponse.json({
+    success: summary.errors === 0,
+    mode: 'recursive-skill-source-sync',
+    summary,
+    results,
+  }, { status: summary.errors > 0 && summary.created === 0 && summary.updated === 0 ? 500 : 200 })
+}
+
+export async function GET(request: NextRequest) {
+  return handleRun(request)
+}
+
+export async function POST(request: NextRequest) {
+  return handleRun(request)
+}

--- a/app/api/skills/search/route.ts
+++ b/app/api/skills/search/route.ts
@@ -5,6 +5,7 @@ import { getAgentOutcomeStatsMap, getAllSkills, searchSkills, type SkillOutcomeS
 import { augmentQueryForIntent, dedupeRankedSkills, getRecommendationReasons, normalizeMatchScore, rankSkillsForQuery, toRegistrySkill } from '@/lib/registry'
 import { CURATED_SKILL_SNAPSHOT } from '@/lib/seo/curated-skill-snapshot'
 import { getSkillSupplyProfile } from '@/lib/supply'
+import { classifySearchMatch, isDirectSkillLookup, type SearchMatchType } from '@/lib/search-match'
 
 export const revalidate = 300
 
@@ -91,6 +92,7 @@ export async function GET(request: NextRequest) {
       ).catch((): Record<string, SkillOutcomeStats> => ({})),
     ])
     const skills = mergeSkillPools(exactPool, candidatePool, CURATED_SKILL_SNAPSHOT)
+    const lookupIntent = isDirectSkillLookup(query)
     const rankedCandidates = dedupeRankedSkills(rankSkillsForQuery(skills, query, outcomeStatsMap))
       .filter(({ skill }) => {
         if (category && skill.category.toLowerCase() !== category.toLowerCase()) return false
@@ -107,14 +109,20 @@ export async function GET(request: NextRequest) {
         }
         return true
       })
+      .map((candidate) => ({
+        ...candidate,
+        matchType: classifySearchMatch(candidate.skill, query),
+      }))
+      .filter(({ matchType }) => !lookupIntent || matchType !== 'related')
       .slice(0, shortlistLimit)
     const topSearchScore = rankedCandidates[0]?.score || 0
     const ranked = rankedCandidates
-      .map(({ skill, score, semanticRelevance }) => ({
+      .map(({ skill, score, semanticRelevance, matchType }) => ({
         skill,
         score: normalizeMatchScore(score, topSearchScore, semanticRelevance),
         rawScore: score,
         semanticRelevance,
+        matchType,
         registrySkill: toRegistrySkill(skill, null, outcomeStatsMap[skill.slug] || null),
       }))
       .filter(({ registrySkill }) => {
@@ -125,8 +133,9 @@ export async function GET(request: NextRequest) {
       .slice(0, limit)
 
     if (format === 'text') {
-      const text = ranked.map(({ score, registrySkill: item }, index) => {
+      const text = ranked.map(({ score, matchType, registrySkill: item }, index) => {
         return `${index + 1}. ${item.name} (${item.slug})
+   Match type: ${matchType}
    Match score: ${score}
    ${item.description}
    Supply: ${item.supply_profile.track.shortLabel} | Scenario: ${item.supply_profile.scenario.label}
@@ -165,8 +174,9 @@ ${text}`,
           min_stars: Number.isFinite(minStars) ? minStars : 0,
         },
         total: ranked.length,
-        skills: ranked.map(({ skill, score, rawScore, semanticRelevance, registrySkill }, index) => ({
+        skills: ranked.map(({ skill, score, rawScore, semanticRelevance, matchType, registrySkill }, index) => ({
           rank: index + 1,
+          match_type: matchType,
           match_score: score,
           raw_match_score: rawScore,
           semantic_relevance: semanticRelevance,
@@ -176,6 +186,15 @@ ${text}`,
         meta: {
           endpoint: '/api/skills/search',
           canonical_agent_endpoint: '/api/agent/resolve',
+          lookup_intent: lookupIntent,
+          exact_match_found: ranked.some(({ matchType }) => matchType === 'exact'),
+          match_counts: ranked.reduce<Record<SearchMatchType, number>>((counts, item) => {
+            counts[item.matchType] += 1
+            return counts
+          }, { exact: 0, near: 0, related: 0 }),
+          no_match_message: lookupIntent && ranked.length === 0
+            ? 'No exact or near Skill listing was found. Related task recommendations are intentionally suppressed for direct name lookups.'
+            : null,
           safety_policy: 'Blocked candidates are excluded by default. Pass include_blocked=true only for manual audit workflows.',
           agent_friendly: true,
           api_version: '1.0',

--- a/lib/github/skill-source.ts
+++ b/lib/github/skill-source.ts
@@ -34,10 +34,28 @@ export interface DiscoveredGitHubSkill {
   frontmatter: SkillFrontmatter
 }
 
-interface GitHubTreeItem {
+export interface GitHubTreeItem {
   path: string
   type: 'blob' | 'tree'
   size?: number
+}
+
+export function selectSkillDocumentPaths(
+  tree: GitHubTreeItem[],
+  requestedPath?: string | null,
+  limit = MAX_DISCOVERED_SKILLS
+) {
+  const normalizedRequestedPath = normalizePath(requestedPath)
+  const prefix = normalizedRequestedPath
+    ? `${normalizedRequestedPath.replace(/\/$/, '')}/`.toLowerCase()
+    : null
+
+  return tree
+    .filter((item) => item.type === 'blob' && /(^|\/)SKILL\.md$/i.test(item.path))
+    .map((item) => item.path)
+    .filter((path) => !prefix || path.toLowerCase().startsWith(prefix))
+    .sort((left, right) => left.localeCompare(right))
+    .slice(0, Math.max(1, limit))
 }
 
 function githubHeaders() {
@@ -243,12 +261,7 @@ export async function discoverGitHubSkills(
   } else {
     const treeResult = await fetchRepositoryTree(reference.owner, reference.repo, ref)
     truncated = treeResult.truncated
-    const prefix = requestedPath ? `${requestedPath.replace(/\/$/, '')}/`.toLowerCase() : null
-    paths = treeResult.tree
-      .filter((item) => item.type === 'blob' && /(^|\/)SKILL\.md$/i.test(item.path))
-      .map((item) => item.path)
-      .filter((path) => !prefix || path.toLowerCase().startsWith(prefix))
-      .slice(0, MAX_DISCOVERED_SKILLS)
+    paths = selectSkillDocumentPaths(treeResult.tree, requestedPath, MAX_DISCOVERED_SKILLS)
   }
 
   const skills = (

--- a/lib/growth/skill-radar.ts
+++ b/lib/growth/skill-radar.ts
@@ -159,9 +159,11 @@ async function excludeExistingCandidates(candidates: CandidateRepo[]) {
     )
 
     return {
-      candidates: candidates.filter((candidate) => !existingSlugs.has(candidateSlug(candidate))),
-      existing: existingSlugs.size,
-      existingCandidates: candidates.filter((candidate) => existingSlugs.has(candidateSlug(candidate))),
+      // Exact tree/blob references may point to a newly added child Skill in
+      // an already indexed repository, so they must reach the recursive sync.
+      candidates: candidates.filter((candidate) => candidate.skillSourceUrl || !existingSlugs.has(candidateSlug(candidate))),
+      existing: candidates.filter((candidate) => !candidate.skillSourceUrl && existingSlugs.has(candidateSlug(candidate))).length,
+      existingCandidates: candidates.filter((candidate) => !candidate.skillSourceUrl && existingSlugs.has(candidateSlug(candidate))),
     }
   } catch (error) {
     // Keep discovery available when Supabase is under transient load. The
@@ -183,7 +185,10 @@ function summarizeProcessResults(results: ProcessResult[]) {
 
 function collectSlugs(results: ProcessResult[], statuses: ProcessResult['status'][]) {
   const statusSet = new Set(statuses)
-  return unique(results.map((result) => (result.slug && statusSet.has(result.status) ? result.slug : undefined)))
+  return unique(results.flatMap((result) => {
+    if (!statusSet.has(result.status)) return []
+    return result.slugs?.length ? result.slugs : [result.slug]
+  }))
 }
 
 function skippedXQueueResult(): XQueueBuildResult {
@@ -258,7 +263,7 @@ function mergeCandidates(
   const byRepo = new Map<string, CandidateRepo>()
 
   for (const candidate of [...xCandidates, ...githubCandidates]) {
-    const key = candidate.fullName.toLowerCase()
+    const key = (candidate.skillSourceUrl || candidate.fullName).toLowerCase()
     if (!byRepo.has(key)) byRepo.set(key, candidate)
   }
 
@@ -270,6 +275,10 @@ export async function runSkillRadarAutomation(options: SkillRadarOptions = {}): 
   const runKey = new Date().toISOString().replace(/[:.]/g, '-')
   const targetNew = Math.min(Math.max(options.targetNew ?? numberFromEnv('SKILL_RADAR_TARGET_NEW', 2), 1), 12)
   const minStars = Math.max(options.minStars ?? numberFromEnv('SKILL_RADAR_MIN_STARS', 10), 10)
+  const xMinStars = Math.max(
+    options.xMinStars ?? nonNegativeNumberFromEnv('SKILL_RADAR_X_MIN_STARS', 0),
+    0
+  )
   const seoPerRun = Math.min(
     Math.max(options.seoPerRun ?? 0, 0),
     5
@@ -283,7 +292,7 @@ export async function runSkillRadarAutomation(options: SkillRadarOptions = {}): 
     xMaxQueries > 0
       ? searchXSkillRadarRepos({
           limit: options.xLimit ?? numberFromEnv('SKILL_RADAR_X_LIMIT', 8),
-          minStars,
+          minStars: xMinStars,
           maxQueries: xMaxQueries,
           maxResultsPerQuery: options.xResultsPerQuery ?? numberFromEnv('SKILL_RADAR_X_RESULTS_PER_QUERY', 10),
           queryOffset: xRadarSchedule.queryOffset,

--- a/lib/indexer/discovery-seeds.ts
+++ b/lib/indexer/discovery-seeds.ts
@@ -1,0 +1,35 @@
+export interface SkillDiscoverySeed {
+  sourceUrl: string
+  discoverySource: string
+  note: string
+}
+
+// High-signal public references are explicit SKILL.md paths, not endorsements.
+// Each source still passes static analysis and the normal automated review gate.
+export const HIGH_SIGNAL_SKILL_SOURCES: readonly SkillDiscoverySeed[] = [
+  {
+    sourceUrl: 'https://github.com/mattpocock/skills/tree/main/skills/productivity/grill-me',
+    discoverySource: 'x-skill-radar',
+    note: 'High-signal X workflow recommendation, 2026-08-18',
+  },
+  {
+    sourceUrl: 'https://github.com/bholmesdev/skills/tree/main/skills/taste-review',
+    discoverySource: 'x-skill-radar',
+    note: 'High-signal X workflow recommendation, 2026-08-18',
+  },
+  {
+    sourceUrl: 'https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices',
+    discoverySource: 'x-skill-radar',
+    note: 'High-signal X workflow recommendation, 2026-08-18',
+  },
+  {
+    sourceUrl: 'https://github.com/bholmesdev/skills/tree/main/skills/simplify',
+    discoverySource: 'x-skill-radar',
+    note: 'High-signal X workflow recommendation, 2026-08-18',
+  },
+  {
+    sourceUrl: 'https://github.com/bholmesdev/hubble.md/tree/main/.agents/skills/test-desktop-app',
+    discoverySource: 'x-skill-radar',
+    note: 'High-signal X workflow recommendation, 2026-08-18',
+  },
+]

--- a/lib/indexer/github-search.ts
+++ b/lib/indexer/github-search.ts
@@ -52,6 +52,8 @@ export interface CandidateRepo {
   topics?: string[]
   updatedAt: string
   htmlUrl: string
+  /** Exact GitHub tree/blob URL when discovery points to one SKILL.md package. */
+  skillSourceUrl?: string
   /** Optional provenance retained through review so downstream growth flows can be selective. */
   discovery?: CandidateDiscovery
 }

--- a/lib/indexer/processor.ts
+++ b/lib/indexer/processor.ts
@@ -12,6 +12,7 @@ import { generateText } from 'ai'
 import type { CandidateRepo } from './github-search'
 import { evaluateSkillCandidate, isMcpCandidate } from './skill-filter'
 import { INDEXER_REVIEW_MODEL } from '@/lib/ai/models'
+import { syncRepositorySkills } from './repository-skill-sync'
 
 const GITHUB_REQUEST_TIMEOUT_MS = 12_000
 const GITHUB_RETRY_DELAYS_MS = [750, 1_750]
@@ -31,6 +32,9 @@ export interface ProcessResult {
   status: 'indexed' | 'rejected' | 'error' | 'skipped'
   reason?: string
   slug?: string
+  slugs?: string[]
+  indexedSkills?: number
+  updatedSkills?: number
   discoverySource?: string
 }
 
@@ -196,6 +200,65 @@ export async function processRepo(
     const serverSecret = process.env.INDEXER_SECRET
     if (!serverSecret) {
       throw new Error('Missing INDEXER_SECRET for controlled indexer writes.')
+    }
+
+    if (isMcpCandidate({
+      fullName: candidate.fullName,
+      name: candidate.repo,
+      description: candidate.description,
+      topics: candidate.topics || [],
+      language: candidate.language,
+    })) {
+      return { repo: repoRef, slug, discoverySource, status: 'skipped', reason: 'MCP projects are excluded from skill-only imports' }
+    }
+
+    // Explicit SKILL.md packages are the strongest intake signal. Split them
+    // into individual listings before applying repository-level star gates or
+    // duplicate checks. This keeps zero-star skills eligible and lets an
+    // already-known repository publish newly added nested skill directories.
+    const sourceSync = await syncRepositorySkills({
+      reference: candidate.skillSourceUrl || candidate.htmlUrl || `https://github.com/${repoRef}`,
+      discoverySource: discoverySource === 'x-radar' ? 'x-skill-radar' : 'recursive-skill-source-sync',
+      maxSkills: 8,
+    })
+    if (sourceSync.discovered > 0) {
+      const successfulEntries = sourceSync.entries.filter((entry) => entry.status === 'created' || entry.status === 'updated')
+      const slugs = successfulEntries.map((entry) => entry.slug)
+      const firstSlug = slugs[0] || slug
+
+      if (sourceSync.created > 0) {
+        return {
+          repo: repoRef,
+          slug: firstSlug,
+          slugs,
+          indexedSkills: sourceSync.created,
+          updatedSkills: sourceSync.updated,
+          discoverySource,
+          status: 'indexed',
+          reason: `Indexed ${sourceSync.created} new SKILL.md package(s); refreshed ${sourceSync.updated}.`,
+        }
+      }
+      if (sourceSync.updated > 0) {
+        return {
+          repo: repoRef,
+          slug: firstSlug,
+          slugs,
+          indexedSkills: 0,
+          updatedSkills: sourceSync.updated,
+          discoverySource,
+          status: 'skipped',
+          reason: `Refreshed ${sourceSync.updated} existing SKILL.md package(s).`,
+        }
+      }
+
+      const firstFailure = sourceSync.entries.find((entry) => entry.reason)?.reason
+      return {
+        repo: repoRef,
+        slug,
+        discoverySource,
+        status: sourceSync.errors > 0 && sourceSync.rejected === 0 ? 'error' : 'rejected',
+        reason: firstFailure || 'Explicit SKILL.md packages did not pass automated review.',
+      }
     }
 
     const supabase = createPublicClient({ requestTimeoutMs: INDEXER_DB_TIMEOUT_MS })

--- a/lib/indexer/repository-skill-sync.ts
+++ b/lib/indexer/repository-skill-sync.ts
@@ -1,0 +1,346 @@
+import 'server-only'
+
+import type { SkillRecord } from '@/lib/db/skills'
+import { reviewSkill } from '@/lib/ai-review/reviewer'
+import { validateGitHubRepo } from '@/lib/github/api'
+import {
+  discoverGitHubSkills,
+  fetchSkillPackageFiles,
+  parseGitHubSkillReference,
+  type DiscoveredGitHubSkill,
+} from '@/lib/github/skill-source'
+import { analyzeCode } from '@/lib/security/static-analysis'
+import { evaluateSkillSubmissionPolicy } from '@/lib/skills/submission-policy'
+import { estimateSubmissionQuality } from '@/lib/skills/submission-quality'
+import { createPublicClient } from '@/lib/supabase/public'
+
+const DEFAULT_MAX_SKILLS_PER_REPOSITORY = 8
+const MAX_SKILLS_PER_REPOSITORY = 20
+const DB_TIMEOUT_MS = 20_000
+
+export type RepositorySkillSyncEntryStatus = 'created' | 'updated' | 'rejected' | 'error'
+
+export interface RepositorySkillSyncEntry {
+  slug: string
+  name: string
+  path: string
+  sourceUrl: string
+  status: RepositorySkillSyncEntryStatus
+  reason?: string
+}
+
+export interface RepositorySkillSyncResult {
+  repository: string
+  reference: string
+  discovered: number
+  processed: number
+  created: number
+  updated: number
+  rejected: number
+  errors: number
+  truncated: boolean
+  entries: RepositorySkillSyncEntry[]
+}
+
+export interface RepositorySkillSyncOptions {
+  reference: string
+  discoverySource?: string
+  maxSkills?: number
+  refreshExisting?: boolean
+}
+
+function slugPart(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+}
+
+export function buildIndexedSkillSlug(owner: string, skillName: string) {
+  return `${slugPart(owner)}-${slugPart(skillName)}`.replace(/-+/g, '-').slice(0, 180)
+}
+
+export function inferIndexedSkillCategory(skill: Pick<DiscoveredGitHubSkill, 'path' | 'frontmatter'>) {
+  const declared = skill.frontmatter.category?.trim().toLowerCase()
+  if (declared) return declared
+
+  const text = `${skill.frontmatter.name} ${skill.frontmatter.description} ${skill.path}`.toLowerCase()
+  if (/security|audit|vulnerab|secret|compliance/.test(text)) return 'security'
+  if (/research|search|source|summari|interview|requirement|spec/.test(text)) return 'research'
+  if (/design|taste|image|video|creative|visual|ui|ux/.test(text)) return 'design-creative'
+  if (/data|csv|spreadsheet|analytics|chart/.test(text)) return 'data-analysis'
+  if (/react|code|developer|github|test|debug|desktop app/.test(text)) return 'coding-agents'
+  if (/business|marketing|sales|finance/.test(text)) return 'business'
+  if (/write|email|communication|social|simplif/.test(text)) return 'productivity'
+  return 'automation'
+}
+
+function normalizeTags(skill: DiscoveredGitHubSkill) {
+  const source = [...skill.frontmatter.tags, 'agent-skill']
+  const seen = new Set<string>()
+  return source
+    .map((value) => value.trim().toLowerCase().replace(/[^a-z0-9+#.-]+/g, '-').replace(/^-+|-+$/g, ''))
+    .filter((value) => value && !seen.has(value) && Boolean(seen.add(value)))
+    .slice(0, 10)
+}
+
+function normalizeVersion(value: string | undefined) {
+  return value && /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/.test(value) ? value : '1.0.0'
+}
+
+function normalizeSourceUrl(value: string | null | undefined) {
+  return (value || '').trim().replace(/\/$/, '').toLowerCase()
+}
+
+function sourceTail(value: string | null | undefined) {
+  const normalized = normalizeSourceUrl(value)
+  return normalized.split('/').filter(Boolean).at(-1) || ''
+}
+
+function findExistingSkill(existing: SkillRecord[], skill: DiscoveredGitHubSkill) {
+  const source = normalizeSourceUrl(skill.sourceUrl)
+  const pathTail = slugPart(skill.directory.split('/').filter(Boolean).at(-1) || skill.frontmatter.name)
+  const name = slugPart(skill.frontmatter.name)
+
+  return existing.find((record) => normalizeSourceUrl(record.repository) === source) ||
+    existing.find((record) => {
+      const existingTail = slugPart(sourceTail(record.repository))
+      return existingTail === pathTail || (existingTail === name && slugPart(record.name) === name)
+    })
+}
+
+function orderedSkills(skills: DiscoveredGitHubSkill[], existing: SkillRecord[], limit: number) {
+  return skills
+    .map((skill) => ({ skill, existing: findExistingSkill(existing, skill) }))
+    .sort((left, right) => Number(Boolean(left.existing)) - Number(Boolean(right.existing)))
+    .slice(0, limit)
+}
+
+function payloadForExisting(
+  existing: SkillRecord,
+  skill: DiscoveredGitHubSkill,
+  repository: Awaited<ReturnType<typeof validateGitHubRepo>>,
+  discoverySource: string
+) {
+  return {
+    ...existing,
+    repository: skill.sourceUrl,
+    github_repo: repository.fullName,
+    github_stars: repository.stars,
+    github_forks: repository.forks,
+    github_language: repository.language || existing.github_language || null,
+    github_last_pushed_at: repository.updatedAt,
+    long_description: skill.document.slice(0, 12_000),
+    version: normalizeVersion(skill.frontmatter.version || existing.version),
+    license: skill.frontmatter.license || repository.license || existing.license || 'Unknown',
+    submission_source: existing.submission_source || discoverySource,
+    ai_review_score: {
+      ...(existing.ai_review_score && typeof existing.ai_review_score === 'object' ? existing.ai_review_score : {}),
+      source_url: skill.sourceUrl,
+      source_ref: skill.ref,
+      skill_path: skill.path,
+      last_source_sync_at: new Date().toISOString(),
+    },
+  }
+}
+
+async function payloadForNew(
+  skill: DiscoveredGitHubSkill,
+  repository: Awaited<ReturnType<typeof validateGitHubRepo>>,
+  discoverySource: string
+) {
+  const codeFiles = await fetchSkillPackageFiles(skill)
+  const staticAnalysis = analyzeCode(codeFiles)
+  if (!staticAnalysis.passed) {
+    return {
+      payload: null,
+      reason: staticAnalysis.issues.slice(0, 2).join('; ') || 'Static security analysis rejected the skill.',
+    }
+  }
+
+  const review = await reviewSkill({
+    repository: skill.sourceUrl,
+    readmeContent: skill.document,
+    codeFiles,
+    manifestData: skill.frontmatter,
+    githubStats: {
+      stars: repository.stars,
+      forks: repository.forks,
+      lastUpdated: repository.updatedAt,
+      license: skill.frontmatter.license || repository.license,
+      language: repository.language,
+    },
+  })
+  const policy = evaluateSkillSubmissionPolicy({
+    stars: repository.stars,
+    hasReadme: repository.hasReadme,
+    hasSkillDocument: true,
+    staticAnalysis,
+    review,
+  })
+  if (!policy.approved) {
+    return {
+      payload: null,
+      reason: policy.issues.slice(0, 2).join('; ') || 'Automated review did not approve this skill.',
+    }
+  }
+
+  const slug = buildIndexedSkillSlug(repository.owner, skill.frontmatter.name)
+  const tags = normalizeTags(skill)
+  const quality = estimateSubmissionQuality({
+    githubStars: repository.stars,
+    githubRepo: repository.fullName,
+    githubUpdatedAt: repository.updatedAt,
+    reviewTotal: review.totalScore,
+    tags,
+  })
+
+  return {
+    reason: null,
+    payload: {
+      slug,
+      name: skill.frontmatter.name,
+      description: skill.frontmatter.description,
+      long_description: skill.document.slice(0, 12_000),
+      tagline: skill.frontmatter.description.slice(0, 280),
+      author_name: skill.frontmatter.author || repository.owner,
+      author_url: `https://github.com/${repository.owner}`,
+      repository: skill.sourceUrl,
+      github_repo: repository.fullName,
+      github_stars: repository.stars,
+      github_forks: repository.forks,
+      github_language: repository.language || null,
+      github_last_pushed_at: repository.updatedAt,
+      category: inferIndexedSkillCategory(skill),
+      tags,
+      frameworks: skill.frontmatter.frameworks,
+      version: normalizeVersion(skill.frontmatter.version),
+      license: skill.frontmatter.license || repository.license || 'Unknown',
+      install_command: `npx skills add ${repository.fullName} --skill ${skill.frontmatter.name}`,
+      verified: false,
+      submission_source: discoverySource,
+      submitted_by_agent: 'open-agent-skill-source-sync',
+      ai_review_score: {
+        ...review.scores,
+        total: review.totalScore,
+        source: 'recursive-skill-source-sync',
+        source_url: skill.sourceUrl,
+        source_ref: skill.ref,
+        skill_path: skill.path,
+      },
+      ai_review_approved: true,
+      ai_review_issues: policy.issues,
+      ai_review_suggestions: policy.suggestions,
+      quality_score: quality.score,
+      quality_signals: quality.signals,
+    },
+  }
+}
+
+export async function syncRepositorySkills(
+  options: RepositorySkillSyncOptions
+): Promise<RepositorySkillSyncResult> {
+  const reference = parseGitHubSkillReference(options.reference)
+  if (!reference) throw new Error(`Invalid GitHub skill source: ${options.reference}`)
+
+  const serverSecret = (process.env.INDEXER_SECRET || '').trim()
+  if (!serverSecret) throw new Error('Missing INDEXER_SECRET for recursive skill source sync.')
+
+  const repository = await validateGitHubRepo(`${reference.owner}/${reference.repo}`, {
+    checkReadme: true,
+    checkSkillJson: false,
+  })
+  const discovery = await discoverGitHubSkills(reference, repository)
+  const supabase = createPublicClient({ requestTimeoutMs: DB_TIMEOUT_MS })
+  const { data: existingData, error: existingError } = await supabase
+    .from('skills')
+    .select('*')
+    .eq('github_repo', repository.fullName)
+  if (existingError) throw new Error(`Existing skill lookup failed: ${existingError.message}`)
+
+  const existing = (existingData || []) as SkillRecord[]
+  const maxSkills = Math.min(
+    Math.max(Math.floor(options.maxSkills || DEFAULT_MAX_SKILLS_PER_REPOSITORY), 1),
+    MAX_SKILLS_PER_REPOSITORY
+  )
+  const selected = orderedSkills(discovery.skills, existing, maxSkills)
+  const entries: RepositorySkillSyncEntry[] = []
+  const discoverySource = options.discoverySource || 'recursive-skill-source-sync'
+
+  for (const item of selected) {
+    const { skill, existing: existingSkill } = item
+    const fallbackSlug = existingSkill?.slug || buildIndexedSkillSlug(repository.owner, skill.frontmatter.name)
+
+    if (existingSkill && options.refreshExisting === false) {
+      continue
+    }
+
+    try {
+      const result = existingSkill
+        ? { payload: payloadForExisting(existingSkill, skill, repository, discoverySource), reason: null }
+        : await payloadForNew(skill, repository, discoverySource)
+
+      if (!result.payload) {
+        entries.push({
+          slug: fallbackSlug,
+          name: skill.frontmatter.name,
+          path: skill.path,
+          sourceUrl: skill.sourceUrl,
+          status: 'rejected',
+          reason: result.reason || 'Automated review rejected the skill.',
+        })
+        continue
+      }
+
+      const { data, error } = await supabase.rpc('upsert_indexed_skill', {
+        p_server_secret: serverSecret,
+        p_skill: result.payload,
+        p_activity: {
+          event_type: 'skill_published',
+          actor_name: 'OpenAgentSkill Source Sync',
+          actor_type: 'agent',
+          description: `Indexed ${skill.frontmatter.name} from an explicit SKILL.md path.`,
+          metadata: {
+            source: discoverySource,
+            source_repo: repository.fullName,
+            source_ref: skill.ref,
+            source_path: skill.path,
+            source_url: skill.sourceUrl,
+          },
+        },
+      })
+      if (error) throw new Error(error.message)
+
+      entries.push({
+        slug: String(result.payload.slug || fallbackSlug),
+        name: skill.frontmatter.name,
+        path: skill.path,
+        sourceUrl: skill.sourceUrl,
+        status: data?.created ? 'created' : 'updated',
+      })
+    } catch (error) {
+      entries.push({
+        slug: fallbackSlug,
+        name: skill.frontmatter.name,
+        path: skill.path,
+        sourceUrl: skill.sourceUrl,
+        status: 'error',
+        reason: error instanceof Error ? error.message : 'Unknown recursive skill sync error.',
+      })
+    }
+  }
+
+  return {
+    repository: repository.fullName,
+    reference: options.reference,
+    discovered: discovery.skills.length,
+    processed: entries.length,
+    created: entries.filter((entry) => entry.status === 'created').length,
+    updated: entries.filter((entry) => entry.status === 'updated').length,
+    rejected: entries.filter((entry) => entry.status === 'rejected').length,
+    errors: entries.filter((entry) => entry.status === 'error').length,
+    truncated: discovery.truncated || discovery.skills.length > maxSkills,
+    entries,
+  }
+}

--- a/lib/indexer/x-skill-radar.ts
+++ b/lib/indexer/x-skill-radar.ts
@@ -156,6 +156,7 @@ export function parseGitHubRepoFromUrl(raw: string) {
     owner,
     repo,
     fullName: `${owner}/${repo}`,
+    sourceUrl: normalized.replace(/[),.;]+$/, ''),
   }
 }
 
@@ -173,7 +174,7 @@ function extractGitHubRepos(tweet: XRecentTweet) {
 
   return Array.from(urls)
     .map(parseGitHubRepoFromUrl)
-    .filter((repo): repo is { owner: string; repo: string; fullName: string } => Boolean(repo))
+    .filter((repo): repo is { owner: string; repo: string; fullName: string; sourceUrl: string } => Boolean(repo))
 }
 
 function engagementScore(tweet: XRecentTweet) {
@@ -237,6 +238,7 @@ async function fetchGitHubRepo(owner: string, repo: string) {
 
 function toCandidate(
   repo: GitHubRepoResponse,
+  skillSourceUrl: string,
   tweet: XRecentTweet,
   query: string,
   score: number,
@@ -268,6 +270,7 @@ function toCandidate(
     topics: repo.topics || [],
     updatedAt: repo.updated_at || repo.pushed_at || new Date().toISOString(),
     htmlUrl: repo.html_url,
+    skillSourceUrl,
     discovery: {
       source: 'x-radar',
       x: {
@@ -281,7 +284,7 @@ function toCandidate(
 
 export async function searchXSkillRadarRepos(options: XSkillRadarOptions = {}): Promise<XSkillRadarResult> {
   const token = xBearerToken()
-  const minStars = Math.max(Math.floor(options.minStars || 10), 10)
+  const minStars = Math.max(Math.floor(options.minStars ?? 0), 0)
   const limit = Math.min(Math.max(options.limit || 8, 1), 80)
   const maxQueries = Math.min(Math.max(options.maxQueries || 1, 1), X_SKILL_RADAR_QUERIES.length)
   const maxResultsPerQuery = Math.min(Math.max(options.maxResultsPerQuery || 10, 10), 50)
@@ -318,7 +321,8 @@ export async function searchXSkillRadarRepos(options: XSkillRadarOptions = {}): 
         extractedRepos += repos.length
 
         for (const parsed of repos) {
-          if (candidates.has(parsed.fullName.toLowerCase())) continue
+          const candidateKey = parsed.sourceUrl.toLowerCase()
+          if (candidates.has(candidateKey)) continue
           if (isGenericFoundationRepoName(parsed.fullName)) continue
 
           const repo = await fetchGitHubRepo(parsed.owner, parsed.repo)
@@ -346,8 +350,8 @@ export async function searchXSkillRadarRepos(options: XSkillRadarOptions = {}): 
 
           const score = radarScore(repo, tweet, evaluation.score)
           candidates.set(
-            repo.full_name.toLowerCase(),
-            toCandidate(repo, tweet, query, score, authorsById.get(tweet.author_id || ''))
+            candidateKey,
+            toCandidate(repo, parsed.sourceUrl, tweet, query, score, authorsById.get(tweet.author_id || ''))
           )
           if (candidates.size >= limit * 2) break
         }

--- a/lib/search-match.ts
+++ b/lib/search-match.ts
@@ -1,0 +1,53 @@
+import type { SkillRecord } from '@/lib/db/skills'
+
+export type SearchMatchType = 'exact' | 'near' | 'related'
+
+function normalized(value: string | null | undefined) {
+  return (value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function sourceSegments(skill: SkillRecord) {
+  const values = [skill.slug, skill.name, skill.github_repo, skill.repository, skill.install_command]
+  return values
+    .flatMap((value) => (value || '').split(/[\s/]+/))
+    .map(normalized)
+    .filter(Boolean)
+}
+
+export function isDirectSkillLookup(query: string) {
+  const value = query.trim()
+  return value.length > 0 && value.length <= 120 && /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/i.test(value)
+}
+
+export function classifySearchMatch(skill: SkillRecord, query: string): SearchMatchType {
+  const lookup = normalized(query)
+  if (!lookup) return 'related'
+
+  const exactValues = new Set([
+    normalized(skill.slug),
+    normalized(skill.name),
+    ...sourceSegments(skill),
+  ])
+  if (exactValues.has(lookup)) return 'exact'
+
+  const tokens = lookup.split('-').filter((token) => token.length >= 2)
+  const searchable = normalized([
+    skill.slug,
+    skill.name,
+    skill.github_repo,
+    skill.repository,
+    skill.install_command,
+  ].filter(Boolean).join(' '))
+  if (
+    searchable.includes(lookup) ||
+    (tokens.length > 1 && tokens.every((token) => searchable.includes(token)))
+  ) {
+    return 'near'
+  }
+
+  return 'related'
+}

--- a/scripts/test-skill-source.ts
+++ b/scripts/test-skill-source.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 // Node's type-stripping runner needs the explicit extension; the app compiler resolves the same module by alias.
 // @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
-import { parseGitHubSkillReference, parseSkillDocument } from '../lib/github/skill-source.ts'
+import { parseGitHubSkillReference, parseSkillDocument, selectSkillDocumentPaths } from '../lib/github/skill-source.ts'
 
 assert.deepEqual(parseGitHubSkillReference('Leon-Drq/openagentskill'), {
   owner: 'Leon-Drq',
@@ -47,5 +47,31 @@ frameworks: [Codex, Claude Code]
 )
 
 assert.equal(parseSkillDocument('# Missing frontmatter and useful description'), null)
+
+assert.deepEqual(
+  selectSkillDocumentPaths([
+    { path: 'README.md', type: 'blob' },
+    { path: 'skills/research/SKILL.md', type: 'blob' },
+    { path: 'skills/productivity/grill-me/SKILL.md', type: 'blob' },
+    { path: '.agents/skills/test-desktop-app/SKILL.md', type: 'blob' },
+    { path: 'nested/skill.md', type: 'blob' },
+    { path: 'skills/folder/SKILL.md', type: 'tree' },
+  ]),
+  [
+    '.agents/skills/test-desktop-app/SKILL.md',
+    'nested/skill.md',
+    'skills/productivity/grill-me/SKILL.md',
+    'skills/research/SKILL.md',
+  ]
+)
+
+assert.deepEqual(
+  selectSkillDocumentPaths([
+    { path: 'skills/taste-review/SKILL.md', type: 'blob' },
+    { path: 'skills/simplify/SKILL.md', type: 'blob' },
+    { path: '.agents/skills/test-desktop-app/SKILL.md', type: 'blob' },
+  ], '.agents/skills/test-desktop-app'),
+  ['.agents/skills/test-desktop-app/SKILL.md']
+)
 
 console.log('skill source parser tests passed')

--- a/scripts/test-submission-discovery.ts
+++ b/scripts/test-submission-discovery.ts
@@ -6,6 +6,9 @@ import { getSearchTerms, normalizeExactSearchQuery } from '../lib/search-query.t
 import { reconcileLicenseReviewFeedback } from '../lib/skills/license-review.ts'
 // @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
 import { estimateSubmissionQuality } from '../lib/skills/submission-quality.ts'
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
+import { classifySearchMatch, isDirectSkillLookup } from '../lib/search-match.ts'
+import type { SkillRecord } from '../lib/db/skills.ts'
 
 assert.deepEqual(getSearchTerms('ip-as-logo'), ['ip', 'logo'])
 assert.equal(normalizeExactSearchQuery('  ip-as-logo  '), 'ip-as-logo')
@@ -33,5 +36,19 @@ const quality = estimateSubmissionQuality({
 })
 assert.ok(quality.score >= 45, `Expected a useful initial quality score, received ${quality.score}`)
 assert.equal(quality.signals.model, 'v2')
+
+const searchSkill = {
+  slug: 'bholmesdev-test-desktop-app',
+  name: 'test-desktop-app',
+  github_repo: 'bholmesdev/hubble.md',
+  repository: 'https://github.com/bholmesdev/hubble.md/tree/main/.agents/skills/test-desktop-app',
+  install_command: 'npx skills add bholmesdev/hubble.md --skill test-desktop-app',
+} as unknown as SkillRecord
+
+assert.equal(isDirectSkillLookup('test-desktop-app'), true)
+assert.equal(isDirectSkillLookup('find a desktop testing skill'), false)
+assert.equal(classifySearchMatch(searchSkill, 'test-desktop-app'), 'exact')
+assert.equal(classifySearchMatch(searchSkill, 'desktop-app'), 'near')
+assert.equal(classifySearchMatch(searchSkill, 'react-best-practices'), 'related')
 
 console.log('Submission discovery regression tests passed.')

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
       "schedule": "35 * * * *"
     },
     {
+      "path": "/api/cron/skill-source-sync",
+      "schedule": "50 */6 * * *"
+    },
+    {
       "path": "/api/cron/official-frontend-skills",
       "schedule": "15 4 * * *"
     },


### PR DESCRIPTION
## What changed
- recursively discovers individual `SKILL.md` packages, including `skills/**` and `.agents/skills/**`
- preserves exact GitHub tree/blob paths from X radar and allows zero-star explicit Skill intake
- adds six-hour incremental source synchronization for known and stale repositories
- separates exact/near name lookup from related task recommendations
- seeds and verifies the five high-signal Skill sources from the referenced X workflow

## Why
The automatic indexer treated one repository as one Skill, applied star gates before inspecting nested Skill packages, and discarded exact social source paths. That caused new nested Skills and low-star Skill repositories to be missed.

## Validation
- `node --experimental-strip-types scripts/test-skill-source.ts`
- `node --experimental-strip-types scripts/test-submission-discovery.ts`
- real GitHub discovery checks for all five source paths
- `pnpm run lint` (0 errors; existing warnings only)
- `pnpm run build`