### PR TITLE
Support composed Skill review and rotate indexer secret

### DIFF
--- a/lib/github/skill-source.ts
+++ b/lib/github/skill-source.ts
@@ -34,6 +34,10 @@ export interface DiscoveredGitHubSkill {
   frontmatter: SkillFrontmatter
 }
 
+export interface DelegatedGitHubSkill extends DiscoveredGitHubSkill {
+  delegatedName: string
+}
+
 export interface GitHubTreeItem {
   path: string
   type: 'blob' | 'tree'
@@ -210,6 +214,20 @@ export function parseSkillDocument(source: string): SkillFrontmatter | null {
   }
 }
 
+export function detectSkillDelegationName(source: string) {
+  const patterns = [
+    /\b(?:call|use|invoke)\s+the\s+skill\s+tool\s+(?:with\s+)?["'`]([a-z0-9][a-z0-9._-]{0,119})["'`]/i,
+    /\bdelegate(?:s|d)?\s+to\s+(?:the\s+)?["'`]([a-z0-9][a-z0-9._-]{0,119})["'`]\s+skill\b/i,
+  ]
+
+  for (const pattern of patterns) {
+    const match = source.match(pattern)
+    if (match?.[1]) return match[1]
+  }
+
+  return null
+}
+
 async function fetchRepositoryTree(owner: string, repo: string, ref: string) {
   const response = await fetch(
     `${GITHUB_API}/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}?recursive=1`,
@@ -288,6 +306,50 @@ export async function discoverGitHubSkills(
   ).filter((skill): skill is DiscoveredGitHubSkill => Boolean(skill))
 
   return { skills, truncated }
+}
+
+export async function fetchDelegatedGitHubSkill(
+  skill: DiscoveredGitHubSkill
+): Promise<DelegatedGitHubSkill | null> {
+  const delegatedName = detectSkillDelegationName(skill.document)
+  if (!delegatedName || delegatedName.toLowerCase() === skill.frontmatter.name.toLowerCase()) return null
+
+  const { tree } = await fetchRepositoryTree(skill.owner, skill.repo, skill.ref)
+  const parentDirectory = skill.directory.includes('/')
+    ? skill.directory.slice(0, skill.directory.lastIndexOf('/'))
+    : ''
+  const candidatePaths = [
+    parentDirectory ? `${parentDirectory}/${delegatedName}/SKILL.md` : `${delegatedName}/SKILL.md`,
+    `skills/${delegatedName}/SKILL.md`,
+    `.agents/skills/${delegatedName}/SKILL.md`,
+    `.claude/skills/${delegatedName}/SKILL.md`,
+  ]
+  const availablePaths = new Map(
+    tree
+      .filter((item) => item.type === 'blob' && /(^|\/)SKILL\.md$/i.test(item.path))
+      .map((item) => [item.path.toLowerCase(), item.path])
+  )
+  const path = candidatePaths
+    .map((candidate) => availablePaths.get(candidate.toLowerCase()))
+    .find((candidate): candidate is string => Boolean(candidate))
+  if (!path) return null
+
+  const document = await fetchRepositoryFile(skill.owner, skill.repo, skill.ref, path)
+  const frontmatter = parseSkillDocument(document)
+  if (!frontmatter || frontmatter.name.toLowerCase() !== delegatedName.toLowerCase()) return null
+
+  const directory = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : ''
+  return {
+    owner: skill.owner,
+    repo: skill.repo,
+    ref: skill.ref,
+    path,
+    directory,
+    sourceUrl: sourceUrl(skill.owner, skill.repo, skill.ref, path),
+    document,
+    frontmatter,
+    delegatedName,
+  }
 }
 
 const REVIEWABLE_EXTENSIONS = new Set([

--- a/lib/indexer/repository-skill-sync.ts
+++ b/lib/indexer/repository-skill-sync.ts
@@ -5,6 +5,7 @@ import { reviewSkill } from '@/lib/ai-review/reviewer'
 import { validateGitHubRepo } from '@/lib/github/api'
 import {
   discoverGitHubSkills,
+  fetchDelegatedGitHubSkill,
   fetchSkillPackageFiles,
   parseGitHubSkillReference,
   type DiscoveredGitHubSkill,
@@ -76,8 +77,8 @@ export function inferIndexedSkillCategory(skill: Pick<DiscoveredGitHubSkill, 'pa
   return 'automation'
 }
 
-function normalizeTags(skill: DiscoveredGitHubSkill) {
-  const source = [...skill.frontmatter.tags, 'agent-skill']
+function normalizeTags(skill: DiscoveredGitHubSkill, extraTags: string[] = []) {
+  const source = [...skill.frontmatter.tags, ...extraTags, 'agent-skill']
   const seen = new Set<string>()
   return source
     .map((value) => value.trim().toLowerCase().replace(/[^a-z0-9+#.-]+/g, '-').replace(/^-+|-+$/g, ''))
@@ -150,7 +151,20 @@ async function payloadForNew(
   repository: Awaited<ReturnType<typeof validateGitHubRepo>>,
   discoverySource: string
 ) {
-  const codeFiles = await fetchSkillPackageFiles(skill)
+  const delegatedSkill = await fetchDelegatedGitHubSkill(skill)
+  const packageGroups = await Promise.all([
+    fetchSkillPackageFiles(skill),
+    delegatedSkill ? fetchSkillPackageFiles(delegatedSkill) : Promise.resolve([]),
+  ])
+  const codeFiles = packageGroups.flat()
+  const reviewDocument = delegatedSkill
+    ? [
+        skill.document,
+        `## Delegated implementation: ${delegatedSkill.frontmatter.name}`,
+        `Source: ${delegatedSkill.sourceUrl}`,
+        delegatedSkill.document,
+      ].join('\n\n')
+    : skill.document
   const staticAnalysis = analyzeCode(codeFiles)
   if (!staticAnalysis.passed) {
     return {
@@ -161,7 +175,7 @@ async function payloadForNew(
 
   const review = await reviewSkill({
     repository: skill.sourceUrl,
-    readmeContent: skill.document,
+    readmeContent: reviewDocument,
     codeFiles,
     manifestData: skill.frontmatter,
     githubStats: {
@@ -187,7 +201,7 @@ async function payloadForNew(
   }
 
   const slug = buildIndexedSkillSlug(repository.owner, skill.frontmatter.name)
-  const tags = normalizeTags(skill)
+  const tags = normalizeTags(skill, delegatedSkill ? ['skill-alias', 'composed-skill'] : [])
   const quality = estimateSubmissionQuality({
     githubStars: repository.stars,
     githubRepo: repository.fullName,
@@ -202,7 +216,7 @@ async function payloadForNew(
       slug,
       name: skill.frontmatter.name,
       description: skill.frontmatter.description,
-      long_description: skill.document.slice(0, 12_000),
+      long_description: reviewDocument.slice(0, 12_000),
       tagline: skill.frontmatter.description.slice(0, 280),
       author_name: skill.frontmatter.author || repository.owner,
       author_url: `https://github.com/${repository.owner}`,
@@ -228,6 +242,13 @@ async function payloadForNew(
         source_url: skill.sourceUrl,
         source_ref: skill.ref,
         skill_path: skill.path,
+        ...(delegatedSkill
+          ? {
+              delegates_to: delegatedSkill.frontmatter.name,
+              delegated_skill_path: delegatedSkill.path,
+              delegated_source_url: delegatedSkill.sourceUrl,
+            }
+          : {}),
       },
       ai_review_approved: true,
       ai_review_issues: policy.issues,

--- a/scripts/test-skill-source.ts
+++ b/scripts/test-skill-source.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 // Node's type-stripping runner needs the explicit extension; the app compiler resolves the same module by alias.
 // @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
-import { parseGitHubSkillReference, parseSkillDocument, selectSkillDocumentPaths } from '../lib/github/skill-source.ts'
+import { detectSkillDelegationName, parseGitHubSkillReference, parseSkillDocument, selectSkillDocumentPaths } from '../lib/github/skill-source.ts'
 
 assert.deepEqual(parseGitHubSkillReference('Leon-Drq/openagentskill'), {
   owner: 'Leon-Drq',
@@ -47,6 +47,16 @@ frameworks: [Codex, Claude Code]
 )
 
 assert.equal(parseSkillDocument('# Missing frontmatter and useful description'), null)
+
+assert.equal(
+  detectSkillDelegationName('Call the Skill tool with "grilling".'),
+  'grilling'
+)
+assert.equal(
+  detectSkillDelegationName('Use the Skill tool with `taste-review` to continue.'),
+  'taste-review'
+)
+assert.equal(detectSkillDelegationName('This skill has complete standalone instructions.'), null)
 
 assert.deepEqual(
   selectSkillDocumentPaths([

--- a/supabase/migrations/20260819091500_rotate_indexer_secret.sql
+++ b/supabase/migrations/20260819091500_rotate_indexer_secret.sql
@@ -1,0 +1,147 @@
+-- Rotate the protected indexer RPC secret after the previous Vercel values
+-- became unreadable sensitive placeholders. Only the SHA-256 digest is stored
+-- in source control and Postgres; the secret itself remains in Vercel.
+
+create or replace function public.upsert_indexed_skill(
+  p_server_secret text,
+  p_skill jsonb,
+  p_activity jsonb default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_expected_secret_hash constant text := '54fc1b0e14aa657fd820a882974e4fc64ae055448646a1f073b6a98e5366f43e';
+  v_skill public.skills%rowtype;
+  v_existing_id uuid;
+begin
+  if p_server_secret is null
+    or encode(extensions.digest(p_server_secret, 'sha256'), 'hex') <> v_expected_secret_hash
+  then
+    raise exception 'Invalid server secret' using errcode = '28000';
+  end if;
+
+  select id into v_existing_id
+  from public.skills
+  where slug = p_skill->>'slug';
+
+  insert into public.skills (
+    slug,
+    name,
+    description,
+    long_description,
+    tagline,
+    author_name,
+    author_url,
+    repository,
+    github_repo,
+    github_stars,
+    github_forks,
+    github_language,
+    github_last_pushed_at,
+    category,
+    tags,
+    frameworks,
+    version,
+    license,
+    install_command,
+    verified,
+    submission_source,
+    submitted_by_agent,
+    ai_review_score,
+    ai_review_approved,
+    ai_review_issues,
+    ai_review_suggestions,
+    last_synced_at
+  )
+  values (
+    p_skill->>'slug',
+    p_skill->>'name',
+    p_skill->>'description',
+    p_skill->>'long_description',
+    p_skill->>'tagline',
+    p_skill->>'author_name',
+    p_skill->>'author_url',
+    p_skill->>'repository',
+    p_skill->>'github_repo',
+    coalesce((p_skill->>'github_stars')::integer, 0),
+    coalesce((p_skill->>'github_forks')::integer, 0),
+    nullif(p_skill->>'github_language', ''),
+    nullif(p_skill->>'github_last_pushed_at', '')::timestamptz,
+    p_skill->>'category',
+    coalesce(array(select jsonb_array_elements_text(coalesce(p_skill->'tags', '[]'::jsonb))), '{}'::text[]),
+    coalesce(array(select jsonb_array_elements_text(coalesce(p_skill->'frameworks', '[]'::jsonb))), '{}'::text[]),
+    coalesce(p_skill->>'version', '1.0.0'),
+    coalesce(p_skill->>'license', 'Unknown'),
+    p_skill->>'install_command',
+    coalesce((p_skill->>'verified')::boolean, false),
+    coalesce(p_skill->>'submission_source', 'auto-indexer'),
+    coalesce(p_skill->>'submitted_by_agent', 'open-agent-skill-indexer'),
+    coalesce(p_skill->'ai_review_score', '{}'::jsonb),
+    coalesce((p_skill->>'ai_review_approved')::boolean, true),
+    coalesce(array(select jsonb_array_elements_text(coalesce(p_skill->'ai_review_issues', '[]'::jsonb))), '{}'::text[]),
+    coalesce(array(select jsonb_array_elements_text(coalesce(p_skill->'ai_review_suggestions', '[]'::jsonb))), '{}'::text[]),
+    now()
+  )
+  on conflict (slug) do update set
+    name = excluded.name,
+    description = excluded.description,
+    long_description = excluded.long_description,
+    tagline = excluded.tagline,
+    author_name = excluded.author_name,
+    author_url = excluded.author_url,
+    repository = excluded.repository,
+    github_repo = excluded.github_repo,
+    github_stars = excluded.github_stars,
+    github_forks = excluded.github_forks,
+    github_language = excluded.github_language,
+    github_last_pushed_at = excluded.github_last_pushed_at,
+    category = excluded.category,
+    tags = excluded.tags,
+    frameworks = excluded.frameworks,
+    version = excluded.version,
+    license = excluded.license,
+    install_command = excluded.install_command,
+    verified = excluded.verified,
+    submission_source = excluded.submission_source,
+    submitted_by_agent = excluded.submitted_by_agent,
+    ai_review_score = excluded.ai_review_score,
+    ai_review_approved = excluded.ai_review_approved,
+    ai_review_issues = excluded.ai_review_issues,
+    ai_review_suggestions = excluded.ai_review_suggestions,
+    last_synced_at = now(),
+    updated_at = now()
+  returning * into v_skill;
+
+  perform public.refresh_skill_quality_scores(v_skill.slug);
+
+  if p_activity is not null and v_existing_id is null then
+    insert into public.activity_feed (
+      event_type,
+      skill_id,
+      actor_name,
+      actor_type,
+      description,
+      metadata
+    )
+    values (
+      coalesce(p_activity->>'event_type', 'skill_published'),
+      v_skill.id,
+      coalesce(p_activity->>'actor_name', 'Open Agent Skill Indexer'),
+      coalesce(p_activity->>'actor_type', 'agent'),
+      p_activity->>'description',
+      coalesce(p_activity->'metadata', '{}'::jsonb)
+    );
+  end if;
+
+  return jsonb_build_object(
+    'skill', to_jsonb(v_skill),
+    'created', v_existing_id is null
+  );
+end;
+$$;
+
+revoke all on function public.upsert_indexed_skill(text, jsonb, jsonb) from public;
+grant execute on function public.upsert_indexed_skill(text, jsonb, jsonb) to anon;


### PR DESCRIPTION
## Summary
- resolve same-repository Skill aliases before AI quality review
- scan delegated Skill packages and retain source-chain metadata
- rotate the protected indexer RPC secret hash

## Validation
- skill source parser tests
- submission discovery regression tests
- real GitHub alias resolution for mattpocock/grill-me -> grilling
- pnpm run lint (0 errors; existing warnings only)
- pnpm run build (441 static pages)