### PR TITLE
Improve skill discovery reliability and mobile UX

### DIFF
--- a/app/api/agent/skills/[slug]/route.ts
+++ b/app/api/agent/skills/[slug]/route.ts
@@ -281,7 +281,7 @@ OpenAgentSkill — ${skill.verified ? 'Verified' : 'Unverified'} skill.`
     console.error('Agent skill detail API error:', error)
     return NextResponse.json(
       { error: 'Skill registry is temporarily unavailable. Retry this request.' },
-      { status: 503, headers: { ...AGENT_SKILL_CACHE_HEADERS, 'Retry-After': '3' } }
+      { status: 503, headers: { ...AGENT_SKILL_CACHE_HEADERS, 'Retry-After': '15', 'X-Registry-Data-State': 'degraded' } }
     )
   }
 }

--- a/app/api/agent/skills/[slug]/route.ts
+++ b/app/api/agent/skills/[slug]/route.ts
@@ -10,7 +10,7 @@ import { getSkillInstallTargets } from '@/lib/install-targets'
 import { getPlatformHints, getSkillQualityProfile } from '@/lib/quality'
 import { getSkillAttribution } from '@/lib/skill-attribution'
 import { buildSkillEvalProfile } from '@/lib/skill-evals'
-import { getSkillBySlugOrFallback, getSkillSuggestionsForSlug, isCuratedSkillFallback, normalizeSkillSlug } from '@/lib/skill-fallbacks'
+import { getSkillBySlugOrFallbackStrict, getSkillSuggestionsForSlug, isCuratedSkillFallback, normalizeSkillSlug } from '@/lib/skill-fallbacks'
 import { getSkillSupplyProfile } from '@/lib/supply'
 import { getSkillTrustProfile, getSkillTrustProfileV5 } from '@/lib/trust'
 import { getUseCasesForSkill } from '@/lib/use-cases'
@@ -36,7 +36,7 @@ export async function GET(
   const format = request.nextUrl.searchParams.get('format') || 'json'
 
   try {
-    const skill = await getSkillBySlugOrFallback(slug)
+    const skill = await getSkillBySlugOrFallbackStrict(slug)
 
     if (!skill) {
       return NextResponse.json(
@@ -280,8 +280,8 @@ OpenAgentSkill — ${skill.verified ? 'Verified' : 'Unverified'} skill.`
   } catch (error) {
     console.error('Agent skill detail API error:', error)
     return NextResponse.json(
-      { error: 'Failed to fetch skill details' },
-      { status: 500 }
+      { error: 'Skill registry is temporarily unavailable. Retry this request.' },
+      { status: 503, headers: { ...AGENT_SKILL_CACHE_HEADERS, 'Retry-After': '3' } }
     )
   }
 }

--- a/app/api/registry/manifest/[slug]/route.ts
+++ b/app/api/registry/manifest/[slug]/route.ts
@@ -93,7 +93,7 @@ URLs:
     console.error('Registry manifest API error:', error)
     return NextResponse.json(
       { error: 'Skill registry is temporarily unavailable. Retry this request.' },
-      { status: 503, headers: { ...MANIFEST_CACHE_HEADERS, 'Retry-After': '3' } }
+      { status: 503, headers: { ...MANIFEST_CACHE_HEADERS, 'Retry-After': '15', 'X-Registry-Data-State': 'degraded' } }
     )
   }
 }

--- a/app/api/registry/manifest/[slug]/route.ts
+++ b/app/api/registry/manifest/[slug]/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { toRegistrySkill } from '@/lib/registry'
-import { getSkillBySlugOrFallback, getSkillSuggestionsForSlug } from '@/lib/skill-fallbacks'
+import { getSkillBySlugOrFallbackStrict, getSkillSuggestionsForSlug } from '@/lib/skill-fallbacks'
 
-export const revalidate = 300
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
 
 const MANIFEST_CACHE_HEADERS = {
-  'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600',
+  'Cache-Control': 'no-store, max-age=0',
 }
 
 export async function GET(
@@ -16,7 +17,7 @@ export async function GET(
   const format = request.nextUrl.searchParams.get('format') || 'json'
 
   try {
-    const skill = await getSkillBySlugOrFallback(slug)
+    const skill = await getSkillBySlugOrFallbackStrict(slug)
 
     if (!skill) {
       return NextResponse.json({
@@ -90,6 +91,9 @@ URLs:
     )
   } catch (error) {
     console.error('Registry manifest API error:', error)
-    return NextResponse.json({ error: 'Failed to build registry manifest' }, { status: 500 })
+    return NextResponse.json(
+      { error: 'Skill registry is temporarily unavailable. Retry this request.' },
+      { status: 503, headers: { ...MANIFEST_CACHE_HEADERS, 'Retry-After': '3' } }
+    )
   }
 }

--- a/app/api/skills/[slug]/install/route.ts
+++ b/app/api/skills/[slug]/install/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { buildInstallHandoff } from '@/lib/registry'
-import { getSkillBySlugOrFallback, getSkillSuggestionsForSlug } from '@/lib/skill-fallbacks'
+import { getSkillBySlugOrFallbackStrict, getSkillSuggestionsForSlug } from '@/lib/skill-fallbacks'
 
-export const revalidate = 300
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
 
 const INSTALL_CACHE_HEADERS = {
-  'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600',
+  'Cache-Control': 'no-store, max-age=0',
 }
 
 export async function GET(
@@ -16,7 +17,7 @@ export async function GET(
   const format = request.nextUrl.searchParams.get('format') || 'json'
 
   try {
-    const skill = await getSkillBySlugOrFallback(slug)
+    const skill = await getSkillBySlugOrFallbackStrict(slug)
     if (!skill) {
       return NextResponse.json({
         error: `Skill not found: ${slug}`,
@@ -67,6 +68,9 @@ ${payload.urls.web}`,
     return NextResponse.json(payload, { headers: INSTALL_CACHE_HEADERS })
   } catch (error) {
     console.error('Public skill install API error:', error)
-    return NextResponse.json({ error: 'Failed to build install handoff' }, { status: 500 })
+    return NextResponse.json(
+      { error: 'Skill registry is temporarily unavailable. Retry this request.' },
+      { status: 503, headers: { ...INSTALL_CACHE_HEADERS, 'Retry-After': '3' } }
+    )
   }
 }

--- a/app/api/skills/[slug]/install/route.ts
+++ b/app/api/skills/[slug]/install/route.ts
@@ -70,7 +70,7 @@ ${payload.urls.web}`,
     console.error('Public skill install API error:', error)
     return NextResponse.json(
       { error: 'Skill registry is temporarily unavailable. Retry this request.' },
-      { status: 503, headers: { ...INSTALL_CACHE_HEADERS, 'Retry-After': '3' } }
+      { status: 503, headers: { ...INSTALL_CACHE_HEADERS, 'Retry-After': '15', 'X-Registry-Data-State': 'degraded' } }
     )
   }
 }

--- a/app/api/skills/search/route.ts
+++ b/app/api/skills/search/route.ts
@@ -108,7 +108,7 @@ export async function GET(request: NextRequest) {
           query,
           meta: { lookup_intent: true, retryable: true },
         },
-        { status: 503, headers: { ...DIRECT_LOOKUP_CACHE_HEADERS, 'Retry-After': '3' } }
+        { status: 503, headers: { ...DIRECT_LOOKUP_CACHE_HEADERS, 'Retry-After': '15', 'X-Registry-Data-State': 'degraded' } }
       )
     }
     const exactPool = exactResult.records

--- a/app/api/skills/search/route.ts
+++ b/app/api/skills/search/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { unstable_cache } from 'next/cache'
 import { withTimeout } from '@/lib/async'
-import { getAgentOutcomeStatsMap, getAllSkills, searchSkills, type SkillOutcomeStats, type SkillRecord } from '@/lib/db/skills'
+import { getAgentOutcomeStatsMap, getAllSkills, searchSkillsStrict, type SkillOutcomeStats, type SkillRecord } from '@/lib/db/skills'
 import { augmentQueryForIntent, dedupeRankedSkills, getRecommendationReasons, normalizeMatchScore, rankSkillsForQuery, toRegistrySkill } from '@/lib/registry'
 import { CURATED_SKILL_SNAPSHOT } from '@/lib/seo/curated-skill-snapshot'
 import { getSkillSupplyProfile } from '@/lib/supply'
@@ -11,7 +11,7 @@ export const revalidate = 300
 
 const SEARCH_CANDIDATE_LIMIT = 750
 const SEARCH_QUERY_TIMEOUT_MS = 1000
-const SEARCH_EXACT_QUERY_TIMEOUT_MS = 2200
+const SEARCH_EXACT_QUERY_TIMEOUT_MS = 8000
 const SEARCH_CACHE_HEADERS = {
   'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600',
 }
@@ -55,6 +55,11 @@ function mergeSkillPools(...pools: SkillRecord[][]) {
   return merged
 }
 
+type ExactSearchResult = {
+  records: SkillRecord[]
+  error: unknown | null
+}
+
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams
   const query = searchParams.get('q') || searchParams.get('task') || ''
@@ -67,9 +72,11 @@ export async function GET(request: NextRequest) {
   const format = searchParams.get('format') || 'json'
   const limit = clampLimit(searchParams.get('limit'))
   const shortlistLimit = Math.max(limit * 8, 30)
+  const lookupIntent = isDirectSkillLookup(query)
+  const databaseQuery = lookupIntent ? query : augmentQueryForIntent(query)
 
   try {
-    const [candidatePool, exactPool, outcomeStatsMap] = await Promise.all([
+    const [candidatePool, exactResult, outcomeStatsMap] = await Promise.all([
       withTimeout(
         getSearchCandidatePool(),
         SEARCH_QUERY_TIMEOUT_MS,
@@ -80,22 +87,32 @@ export async function GET(request: NextRequest) {
       }),
       query.trim()
         ? withTimeout(
-            searchSkills(augmentQueryForIntent(query), 120),
+            searchSkillsStrict(databaseQuery, 120),
             SEARCH_EXACT_QUERY_TIMEOUT_MS,
             'public skill exact search query'
-          ).catch((error) => {
+          ).then((records): ExactSearchResult => ({ records, error: null })).catch((error): ExactSearchResult => {
             console.warn('Public skill exact search fallback:', error)
-            return [] as SkillRecord[]
+            return { records: [], error }
           })
-        : Promise.resolve([] as SkillRecord[]),
+        : Promise.resolve({ records: [] as SkillRecord[], error: null } as ExactSearchResult),
       withTimeout(
         getAgentOutcomeStatsMap(),
         SEARCH_QUERY_TIMEOUT_MS,
         'public skill outcome stats query'
       ).catch((): Record<string, SkillOutcomeStats> => ({})),
     ])
+    if (lookupIntent && exactResult.error) {
+      return NextResponse.json(
+        {
+          error: 'Live registry search is temporarily unavailable. Retry this request.',
+          query,
+          meta: { lookup_intent: true, retryable: true },
+        },
+        { status: 503, headers: { ...DIRECT_LOOKUP_CACHE_HEADERS, 'Retry-After': '3' } }
+      )
+    }
+    const exactPool = exactResult.records
     const skills = mergeSkillPools(exactPool, candidatePool, CURATED_SKILL_SNAPSHOT)
-    const lookupIntent = isDirectSkillLookup(query)
     const responseCacheHeaders = lookupIntent ? DIRECT_LOOKUP_CACHE_HEADERS : SEARCH_CACHE_HEADERS
     const rankedCandidates = dedupeRankedSkills(rankSkillsForQuery(skills, query, outcomeStatsMap))
       .filter(({ skill }) => {

--- a/app/skills/[slug]/error.tsx
+++ b/app/skills/[slug]/error.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect } from 'react'
+import { SiteFooter } from '@/components/site-footer'
+import { SiteHeader } from '@/components/site-header'
+
+export default function SkillDetailError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error('Skill detail temporarily unavailable:', error)
+  }, [error])
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <SiteHeader />
+      <main className="mx-auto flex min-h-[60vh] max-w-3xl items-center px-4 py-16 sm:px-6">
+        <section className="w-full rounded-[10px] border border-border bg-card p-6 shadow-[0_18px_55px_rgba(29,27,24,0.05)] sm:p-10">
+          <p className="font-mono text-xs uppercase tracking-[0.2em] text-secondary">Temporary registry delay</p>
+          <h1 className="mt-4 font-display text-3xl font-semibold sm:text-4xl">This skill is still published.</h1>
+          <p className="mt-4 max-w-2xl text-sm leading-7 text-secondary sm:text-base">
+            The registry could not reach its data service in time. This is not a “skill not found” result. Retry now or return to search.
+          </p>
+          <div className="mt-7 flex flex-col gap-3 sm:flex-row">
+            <button
+              type="button"
+              onClick={reset}
+              className="inline-flex min-h-11 items-center justify-center rounded-[8px] bg-[#006b4f] px-5 text-sm font-semibold text-white"
+            >
+              Retry skill
+            </button>
+            <Link
+              href="/skills"
+              className="inline-flex min-h-11 items-center justify-center rounded-[8px] border border-border px-5 text-sm font-semibold"
+            >
+              Browse skills
+            </Link>
+          </div>
+        </section>
+      </main>
+      <SiteFooter />
+    </div>
+  )
+}

--- a/app/skills/[slug]/page.tsx
+++ b/app/skills/[slug]/page.tsx
@@ -34,7 +34,7 @@ import { getSkillInstallTargets } from '@/lib/install-targets'
 import { getSkillQualityProfile, getPlatformHints } from '@/lib/quality'
 import { getSkillInstallApiUrl } from '@/lib/registry'
 import { getSkillAttribution } from '@/lib/skill-attribution'
-import { getCanonicalSkillSlug, getSkillBySlugOrFallback } from '@/lib/skill-fallbacks'
+import { getCanonicalSkillSlug, getSkillBySlugOrFallbackStrict } from '@/lib/skill-fallbacks'
 import { getSkillSupplyProfile } from '@/lib/supply'
 import {
   getSkillTrustProfileV5,
@@ -50,12 +50,12 @@ import {
   buildXIntentUrl,
 } from '@/lib/x/poster'
 
-export const dynamic = 'force-static'
-export const revalidate = 1800
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
 const SKILL_DETAIL_SUPPORT_TIMEOUT_MS = 1200
 
 const getCachedSkillBySlug = cache(async (slug: string) =>
-  getSkillBySlugOrFallback(getCanonicalSkillSlug(slug))
+  getSkillBySlugOrFallbackStrict(getCanonicalSkillSlug(slug))
 )
 
 const getCachedSkillDetailSupport = cache(
@@ -363,7 +363,7 @@ export default async function SkillDetailPage({
 
       <SiteHeader />
 
-      <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
+      <main className="mx-auto max-w-6xl px-4 pb-28 pt-8 sm:px-6 sm:py-12">
         {/* Breadcrumb */}
         <nav className="mb-6 flex items-center gap-2 text-xs text-secondary sm:text-sm">
           <Link href="/skills" className="hover:text-foreground">
@@ -914,10 +914,12 @@ export default async function SkillDetailPage({
               </section>
             )}
 
-            <SkillInstallTargets
-              skillSlug={skill.slug}
-              targets={installTargets}
-            />
+            <div id="install-options" className="scroll-mt-24">
+              <SkillInstallTargets
+                skillSlug={skill.slug}
+                targets={installTargets}
+              />
+            </div>
 
             <section className="mb-10 overflow-hidden rounded-[8px] border border-border bg-card shadow-[0_18px_48px_rgba(22,20,16,0.05)]">
               <div className="relative border-b border-border bg-[#fbfaf7] p-5 sm:p-6">
@@ -2309,6 +2311,36 @@ export default async function SkillDetailPage({
                 </div>
               )}
             </div>
+          </div>
+        </div>
+
+        <div className="fixed inset-x-0 bottom-0 z-50 border-t border-border bg-background/95 p-3 shadow-[0_-12px_30px_rgba(22,20,16,0.08)] backdrop-blur lg:hidden">
+          <div className="mx-auto grid max-w-6xl grid-cols-2 gap-2">
+            <a
+              href="#install-options"
+              className="inline-flex min-h-11 items-center justify-center rounded-[8px] bg-[#006b4f] px-4 text-sm font-semibold text-white"
+            >
+              <SkillDetailText id="install" />
+            </a>
+            {skill.technical.repository ? (
+              <SkillActionLink
+                href={skill.technical.repository}
+                skillSlug={skill.slug}
+                eventType="outbound_github"
+                external
+                className="inline-flex min-h-11 items-center justify-center rounded-[8px] border border-border bg-background px-4 text-sm font-semibold"
+              >
+                <SkillDetailText id="viewGitHub" />
+              </SkillActionLink>
+            ) : (
+              <Link
+                href={resolveTextHref}
+                prefetch={false}
+                className="inline-flex min-h-11 items-center justify-center rounded-[8px] border border-border bg-background px-4 text-sm font-semibold"
+              >
+                <SkillDetailText id="autoResolvePlan" />
+              </Link>
+            )}
           </div>
         </div>
       </main>

--- a/app/skills/page.tsx
+++ b/app/skills/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next'
 import { unstable_cache } from 'next/cache'
 import { buildSkillAudit } from '@/lib/audits'
 import { getAgentSafetyProfile } from '@/lib/agent-safety'
-import { getAllSkills, getCategories, type SkillAgentStats, type SkillRecord, type SkillSortMode, getSkillStats, searchSkills } from '@/lib/db/skills'
+import { getAllSkills, getCategories, type SkillAgentStats, type SkillRecord, type SkillSortMode, getSkillStats, searchSkillsStrict } from '@/lib/db/skills'
 import { SkillsPageClient } from '@/components/skills-page-client'
 import { getSkillQualityProfile, getPlatformHints } from '@/lib/quality'
 import { getSkillSupplyProfile, getSupplyTrackSummaries } from '@/lib/supply'
@@ -98,6 +98,7 @@ const VISIBLE_SKILL_LIMIT = 16
 const SKILLS_PAGE_REVALIDATE = 300
 const MAX_SKILLS_PAGE = Math.ceil(MAX_SKILL_CANDIDATE_LIMIT / VISIBLE_SKILL_LIMIT)
 const SKILLS_PAGE_QUERY_TIMEOUT_MS = 1800
+const SKILLS_PAGE_EXACT_SEARCH_TIMEOUT_MS = 8000
 const SKILLS_PAGE_EXACT_SEARCH_LIMIT = 120
 const DIRECTORY_SECTION_SOURCE_LIMIT = 120
 const FALLBACK_DATE = '2026-06-01T00:00:00.000Z'
@@ -525,14 +526,6 @@ function getCachedSkillCandidates(sort: SkillSortMode, category: string | undefi
   )()
 }
 
-function getCachedSearchSkillCandidates(query: string, limit: number) {
-  return unstable_cache(
-    async () => searchSkills(query, limit).catch(() => []),
-    ['skills-page-search-candidates-v1', query.trim().toLowerCase(), String(limit)],
-    { revalidate: SKILLS_PAGE_REVALIDATE }
-  )()
-}
-
 async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   let timeout: ReturnType<typeof setTimeout> | undefined
   const timeoutPromise = new Promise<T>((_, reject) => {
@@ -582,16 +575,19 @@ async function getSkillsPageRecords(sort: SkillSortMode, category: string | unde
 
 async function getSearchAugmentRecords(query: string | undefined) {
   const normalizedQuery = query?.trim()
-  if (!normalizedQuery) return []
+  if (!normalizedQuery) return { records: [] as SkillRecord[], degraded: false }
 
-  return withTimeout(
-    getCachedSearchSkillCandidates(normalizedQuery, SKILLS_PAGE_EXACT_SEARCH_LIMIT),
-    SKILLS_PAGE_QUERY_TIMEOUT_MS,
-    'skills exact search query'
-  ).catch((error) => {
+  try {
+    const records = await withTimeout(
+      searchSkillsStrict(normalizedQuery, SKILLS_PAGE_EXACT_SEARCH_LIMIT),
+      SKILLS_PAGE_EXACT_SEARCH_TIMEOUT_MS,
+      'skills exact search query'
+    )
+    return { records, degraded: false }
+  } catch (error) {
     console.warn('Skills page exact search fallback:', error)
-    return []
-  })
+    return { records: [] as SkillRecord[], degraded: true }
+  }
 }
 
 function mergeSkillRecords(...pools: SkillRecord[][]) {
@@ -961,8 +957,8 @@ export default async function SkillsPage({
     withTimeout(getCachedSkillStats(), SKILLS_PAGE_QUERY_TIMEOUT_MS, 'skills stats query')
       .catch((): Record<string, SkillAgentStats> => ({})),
   ])
-  const records = mergeSkillRecords(searchAugmentRecords, recordsResult.records, FALLBACK_SKILLS, CURATED_SKILL_SNAPSHOT)
-  const degraded = recordsResult.degraded && searchAugmentRecords.length === 0
+  const records = mergeSkillRecords(searchAugmentRecords.records, recordsResult.records, FALLBACK_SKILLS, CURATED_SKILL_SNAPSHOT)
+  const degraded = recordsResult.degraded || searchAugmentRecords.degraded
   const effectivePage = degraded && records.length <= requestedPageOffset ? 1 : page
   const pageOffset = (effectivePage - 1) * VISIBLE_SKILL_LIMIT
   const categoryOptions = categories.length > 0

--- a/components/home-page-enhanced.tsx
+++ b/components/home-page-enhanced.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { ArrowRight, ArrowUpRight, Github, Search } from 'lucide-react'
 import type { Locale } from '@/lib/i18n/config'
 import { useI18n } from '@/lib/i18n/context'
@@ -723,6 +724,45 @@ const COMPARISON_LINKS = [
   { label: 'Native docs', href: 'https://developers.openai.com/codex/skills' },
 ]
 
+type DiscoveryMode = 'task' | 'skill' | 'repository'
+
+const DISCOVERY_COPY: Record<string, {
+  start: string
+  modes: Record<DiscoveryMode, string>
+  placeholders: Record<DiscoveryMode, string>
+  actions: Record<DiscoveryMode, string>
+  liveApi: string
+  sourceRefresh: string
+  machineContract: string
+}> = {
+  en: {
+    start: 'Start with one intent',
+    modes: { task: 'Describe a task', skill: 'Find a skill', repository: 'Paste GitHub' },
+    placeholders: {
+      task: 'What should your agent accomplish?',
+      skill: 'Search by skill name, topic, or capability',
+      repository: 'https://github.com/owner/repository',
+    },
+    actions: { task: 'Resolve task', skill: 'Search skills', repository: 'Review repository' },
+    liveApi: 'Live agent API',
+    sourceRefresh: 'Source refresh',
+    machineContract: 'Machine contract',
+  },
+  zh: {
+    start: '从一个意图开始',
+    modes: { task: '描述任务', skill: '查找 Skill', repository: '粘贴 GitHub' },
+    placeholders: {
+      task: '你的 Agent 要完成什么任务？',
+      skill: '按 Skill 名称、主题或能力搜索',
+      repository: 'https://github.com/owner/repository',
+    },
+    actions: { task: '解析任务', skill: '搜索 Skills', repository: '审核仓库' },
+    liveApi: '实时 Agent API',
+    sourceRefresh: '数据刷新',
+    machineContract: '机器接口',
+  },
+}
+
 function formatCompact(value: number) {
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
   if (value >= 10_000) return `${Math.round(value / 1000)}K`
@@ -762,8 +802,11 @@ function SectionHeading({ eyebrow, title }: { eyebrow: string; title: string }) 
 
 export function HomePageEnhanced({ initialLocale, stats }: HomePageEnhancedProps) {
   const { t, locale } = useI18n()
+  const router = useRouter()
   const activeLocale = initialLocale || locale
   const [taskQuery, setTaskQuery] = useState('')
+  const [discoveryMode, setDiscoveryMode] = useState<DiscoveryMode>('task')
+  const [discoveryQuery, setDiscoveryQuery] = useState('')
   const [isSearching, setIsSearching] = useState(false)
   const [resolveResult, setResolveResult] = useState<ResolveResult | null>(null)
   const [searchedCount, setSearchedCount] = useState(0)
@@ -774,13 +817,13 @@ export function HomePageEnhanced({ initialLocale, stats }: HomePageEnhancedProps
     ? [resolveResult.selected, ...resolveResult.alternatives].filter((item): item is ResolveCandidate => Boolean(item))
     : []
   const copy = HOME_COPY[activeLocale] || HOME_COPY.en
+  const discoveryCopy = DISCOVERY_COPY[activeLocale] || DISCOVERY_COPY.en
   const totalSkillsLabel = `${stats.totalSkills.toLocaleString()}${stats.totalSkillsExact ? '' : '+'}`
-  const evidenceValue = (value: number) => stats.evidenceExact ? value.toLocaleString() : '—'
   const statItems = [
     [totalSkillsLabel, copy.stats[0]],
-    [evidenceValue(stats.totalVerifiedInstalls), copy.stats[1]],
-    [evidenceValue(stats.totalOutcomes), copy.stats[2]],
-    [evidenceValue(stats.provenSkills), copy.stats[3]],
+    [stats.evidenceExact ? stats.totalVerifiedInstalls.toLocaleString() : 'Live', stats.evidenceExact ? copy.stats[1] : discoveryCopy.liveApi],
+    [stats.evidenceExact ? stats.totalOutcomes.toLocaleString() : '6h', stats.evidenceExact ? copy.stats[2] : discoveryCopy.sourceRefresh],
+    [stats.evidenceExact ? stats.provenSkills.toLocaleString() : 'OpenAPI', stats.evidenceExact ? copy.stats[3] : discoveryCopy.machineContract],
   ]
 
   const runRecommendation = async (query: string) => {
@@ -818,6 +861,24 @@ export function HomePageEnhanced({ initialLocale, stats }: HomePageEnhancedProps
 
   const handleFindSkills = async () => {
     await runRecommendation(taskQuery)
+  }
+
+  const handleDiscovery = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const query = discoveryQuery.trim()
+    if (!query) return
+
+    if (discoveryMode === 'skill') {
+      router.push(`/skills?q=${encodeURIComponent(query)}`)
+      return
+    }
+    if (discoveryMode === 'repository') {
+      router.push(`/submit?repository=${encodeURIComponent(query)}`)
+      return
+    }
+
+    await runRecommendation(query)
+    requestAnimationFrame(() => searchRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' }))
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -864,7 +925,52 @@ export function HomePageEnhanced({ initialLocale, stats }: HomePageEnhancedProps
             {copy.heroSubtitle}
           </p>
 
-          <div className="mt-12 flex flex-wrap items-center gap-3">
+          <form
+            onSubmit={handleDiscovery}
+            className="mt-10 max-w-4xl overflow-hidden rounded-[10px] border border-[#d8d2c6] bg-[#fffdf8]/95 shadow-[0_18px_55px_rgba(29,27,24,0.06)]"
+          >
+            <div className="border-b border-[#e4e0d8] px-3 pt-3 sm:px-4">
+              <p className="px-1 font-mono text-[10px] uppercase tracking-[0.2em] text-[#6d675e]">{discoveryCopy.start}</p>
+              <div className="mt-2 grid grid-cols-3 gap-1" role="tablist" aria-label={discoveryCopy.start}>
+                {(['task', 'skill', 'repository'] as DiscoveryMode[]).map((mode) => (
+                  <button
+                    key={mode}
+                    type="button"
+                    role="tab"
+                    aria-selected={discoveryMode === mode}
+                    onClick={() => setDiscoveryMode(mode)}
+                    className={`min-h-11 rounded-t-[7px] px-2 text-xs font-semibold transition-colors sm:px-4 sm:text-sm ${
+                      discoveryMode === mode
+                        ? 'bg-[#1d1b18] text-white'
+                        : 'text-[#6d675e] hover:bg-[#f2efe8] hover:text-[#1d1b18]'
+                    }`}
+                  >
+                    {discoveryCopy.modes[mode]}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="flex flex-col gap-2 p-3 sm:flex-row sm:p-4">
+              <input
+                type={discoveryMode === 'repository' ? 'url' : 'search'}
+                value={discoveryQuery}
+                onChange={(event) => setDiscoveryQuery(event.target.value)}
+                placeholder={discoveryCopy.placeholders[discoveryMode]}
+                aria-label={discoveryCopy.modes[discoveryMode]}
+                className="min-h-12 min-w-0 flex-1 rounded-[8px] border border-[#d8d2c6] bg-[#fbfaf6] px-4 text-sm outline-none placeholder:text-[#6d675e]/55 focus:border-[#006b4f]"
+              />
+              <button
+                type="submit"
+                disabled={!discoveryQuery.trim() || isSearching}
+                className="inline-flex min-h-12 items-center justify-center gap-2 rounded-[8px] bg-[#006b4f] px-5 text-sm font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-40"
+              >
+                <Search className="h-4 w-4" aria-hidden="true" />
+                {discoveryMode === 'task' && isSearching ? copy.reviewing : discoveryCopy.actions[discoveryMode]}
+              </button>
+            </div>
+          </form>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
             <a
               href="#task-search"
               className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-[8px] bg-[#006b4f] px-5 text-sm font-semibold text-white transition-opacity hover:opacity-90 sm:w-auto"
@@ -891,7 +997,7 @@ export function HomePageEnhanced({ initialLocale, stats }: HomePageEnhancedProps
             </Link>
           </div>
 
-          <div className="mt-20 grid grid-cols-2 gap-y-6 border-t border-[#d8d2c6] pt-8 md:grid-cols-4">
+          <div className="mt-14 grid grid-cols-2 gap-x-4 gap-y-6 border-t border-[#d8d2c6] pt-8 md:grid-cols-4">
             {statItems.map(([value, label]) => (
               <div key={label} className="flex flex-col gap-1">
                 <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-[#6d675e]">{label}</span>

--- a/components/skills-page-client.tsx
+++ b/components/skills-page-client.tsx
@@ -349,8 +349,12 @@ export function SkillsPageClient({
             </div>
             <div className="mt-4 grid grid-cols-3 gap-px border border-border bg-border text-center">
               <div className="bg-background p-3">
-                <div className="font-mono text-lg text-foreground">{resultCount.toLocaleString()}</div>
-                <div className="mt-1 text-[10px] uppercase tracking-widest text-secondary">{query ? 'Matches' : 'Ranked'}</div>
+                <div className="font-mono text-lg text-foreground">
+                  {query && degraded ? '—' : resultCount.toLocaleString()}
+                </div>
+                <div className="mt-1 text-[10px] uppercase tracking-widest text-secondary">
+                  {query ? (degraded ? 'Live offline' : 'Matches') : 'Ranked'}
+                </div>
               </div>
               <div className="bg-background p-3">
                 <div className="font-mono text-lg text-foreground">{supplyTracks.length.toLocaleString()}</div>

--- a/components/skills-page-client.tsx
+++ b/components/skills-page-client.tsx
@@ -301,7 +301,7 @@ export function SkillsPageClient({
 
       <section className="relative overflow-hidden border-b border-border">
         <div className="brand-grain pointer-events-none absolute inset-0 opacity-60" />
-        <div className="relative mx-auto grid max-w-6xl gap-8 px-6 py-12 md:py-16 lg:grid-cols-[1.15fr_0.85fr] lg:items-end">
+        <div className={`relative mx-auto grid max-w-6xl gap-8 px-4 sm:px-6 ${query ? 'py-8 md:py-10' : 'py-12 md:py-16'} lg:grid-cols-[1.15fr_0.85fr] lg:items-end`}>
           <div>
 	            <p className="font-mono text-xs uppercase tracking-[0.24em] text-secondary">AI Agent Skill Repository</p>
 	            <h1 className="mt-5 max-w-3xl font-display text-4xl font-normal leading-[0.98] text-balance md:text-6xl">
@@ -349,8 +349,8 @@ export function SkillsPageClient({
             </div>
             <div className="mt-4 grid grid-cols-3 gap-px border border-border bg-border text-center">
               <div className="bg-background p-3">
-                <div className="font-mono text-lg text-foreground">{skills.length.toLocaleString()}</div>
-                <div className="mt-1 text-[10px] uppercase tracking-widest text-secondary">Shown</div>
+                <div className="font-mono text-lg text-foreground">{resultCount.toLocaleString()}</div>
+                <div className="mt-1 text-[10px] uppercase tracking-widest text-secondary">{query ? 'Matches' : 'Ranked'}</div>
               </div>
               <div className="bg-background p-3">
                 <div className="font-mono text-lg text-foreground">{supplyTracks.length.toLocaleString()}</div>
@@ -378,7 +378,7 @@ export function SkillsPageClient({
         </div>
 	      </section>
 
-	      {directorySections.length > 0 && (
+	      {!query && directorySections.length > 0 && (
 	        <section className="border-b border-border bg-background">
 	          <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
 	            <div className="mb-6 grid gap-4 lg:grid-cols-[0.9fr_1.1fr] lg:items-end">
@@ -457,7 +457,7 @@ export function SkillsPageClient({
 	        </section>
 	      )}
 
-	      <section className="border-b border-border bg-card/35">
+	      {!query && <section className="border-b border-border bg-card/35">
         <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
           <div className="mb-4 flex flex-col justify-between gap-3 sm:flex-row sm:items-end">
             <div>
@@ -506,7 +506,7 @@ export function SkillsPageClient({
             ))}
           </div>
       </div>
-      </section>
+      </section>}
 
       {/* Sort Tabs */}
       <div className="sticky top-14 z-40 border-b border-border bg-background/92 backdrop-blur">
@@ -537,7 +537,7 @@ export function SkillsPageClient({
           </div>
         )}
 
-        <section className="mb-8 border border-border bg-background/80 p-4 sm:p-5">
+        {!query && <section className="mb-8 border border-border bg-background/80 p-4 sm:p-5">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div>
               <p className="font-mono text-xs uppercase tracking-[0.22em] text-secondary">High-intent entry points</p>
@@ -568,7 +568,26 @@ export function SkillsPageClient({
               </Link>
             ))}
           </div>
-        </section>
+        </section>}
+
+        {query && (
+          <section className="mb-6 rounded-[8px] border border-border bg-card/80 p-4 sm:p-5">
+            <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-secondary">Live registry search</p>
+            <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div className="min-w-0">
+                <h2 className="break-words font-display text-2xl font-semibold sm:text-3xl">
+                  Results for “{query}”
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-secondary">
+                  Exact name and slug matches are checked against the live registry before ranked alternatives.
+                </p>
+              </div>
+              <Link href="/skills" className="shrink-0 text-sm font-semibold text-[#006b4f] underline underline-offset-4">
+                Clear search
+              </Link>
+            </div>
+          </section>
+        )}
 
         <section className="mb-8 border border-border bg-card/80 p-4 shadow-[0_16px_48px_rgba(23,23,23,0.04)] sm:p-5">
           <div className="mb-4 flex flex-col justify-between gap-3 sm:flex-row sm:items-end">
@@ -675,10 +694,10 @@ export function SkillsPageClient({
 
         {/* Category filters */}
         {categories.length > 0 && (
-          <div className="mb-8 flex flex-wrap gap-2">
+          <div className="-mx-4 mb-8 flex gap-2 overflow-x-auto px-4 pb-2 sm:mx-0 sm:flex-wrap sm:overflow-visible sm:px-0 sm:pb-0">
             <button
               onClick={() => navigate({ sort, category: 'all' })}
-              className={`text-xs px-3 py-1.5 border transition-colors ${
+              className={`shrink-0 whitespace-nowrap border px-3 py-1.5 text-xs transition-colors ${
                 category === 'all'
                   ? 'border-foreground bg-foreground text-background'
                   : 'border-border text-secondary hover:border-foreground hover:text-foreground'
@@ -690,7 +709,7 @@ export function SkillsPageClient({
               <button
                 key={cat}
                 onClick={() => navigate({ sort, category: cat })}
-                className={`text-xs px-3 py-1.5 border capitalize transition-colors ${
+                className={`shrink-0 whitespace-nowrap border px-3 py-1.5 text-xs capitalize transition-colors ${
                   category === cat
                     ? 'border-foreground bg-foreground text-background'
                     : 'border-border text-secondary hover:border-foreground hover:text-foreground'
@@ -718,8 +737,10 @@ export function SkillsPageClient({
 
         {/* Skills List */}
         {skills.length === 0 ? (
-          <div className="border border-border bg-card/70 p-12 text-center">
-            <p className="text-secondary mb-4">No skills found.</p>
+          <div className="border border-border bg-card/70 p-7 text-center sm:p-12">
+            <p className="mb-4 text-secondary">
+              {degraded ? 'Live search is temporarily unavailable. Retry in a moment.' : 'No exact or relevant skills found.'}
+            </p>
             <Link href="/skills" className="text-foreground underline text-sm">
               Clear filters
             </Link>
@@ -857,7 +878,7 @@ export function SkillsPageClient({
                     </div>
 
                     {(skill.qualityProfile || skill.trustProfile || skill.safetyProfile) && (
-                      <div className="mb-4 grid max-w-4xl gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                      <div className="mb-4 hidden max-w-4xl gap-3 sm:grid sm:grid-cols-2 lg:grid-cols-3">
                         {skill.qualityProfile && (
                           <div className="border-l border-border pl-3 text-xs leading-relaxed text-secondary">
                             <span className="mb-1 block font-mono text-[10px] uppercase tracking-widest text-secondary">

--- a/lib/db/skills.ts
+++ b/lib/db/skills.ts
@@ -59,9 +59,12 @@ const SHARED_SKILL_CACHE_REVALIDATE_SECONDS = 300
 const CATEGORY_CACHE_REVALIDATE_SECONDS = 3600
 const SKILL_DIRECTORY_REQUEST_TIMEOUT_MS = 1800
 const SKILL_STATS_REQUEST_TIMEOUT_MS = 3000
-const SKILL_LOOKUP_TIMEOUT_MS = 1200
+// Exact lookups are correctness-critical. A cold database request can take a
+// few seconds, so a directory-sized timeout would turn a live skill into a
+// false 404.
+const SKILL_LOOKUP_TIMEOUT_MS = 7000
 const SKILL_LOOKUP_CACHE_REVALIDATE_SECONDS = 60
-const SKILL_EXACT_SEARCH_TIMEOUT_MS = 1500
+const SKILL_EXACT_SEARCH_TIMEOUT_MS = 7000
 const SKILL_BROAD_SEARCH_TIMEOUT_MS = 1500
 // Sitemap refreshes run off the interactive navigation path. Give a cold
 // registry shard enough time to return the complete URL set, then let the
@@ -832,9 +835,8 @@ function normalizeSkillLookupSlug(slug: string) {
 }
 
 // Detail pages, badges, manifests, and social crawlers all resolve skills by
-// slug. Cache both matches and misses so repeated stale links do not consume a
-// database connection on every request. A short TTL keeps new approvals and
-// corrections visible quickly.
+// slug. Cache matches and genuine misses, but let transient errors escape so
+// they are never stored as a false missing record.
 const getCachedSkillBySlug = unstable_cache(
   async (slug: string): Promise<SkillRecord | null> => {
     const supabase = createPublicClient({ requestTimeoutMs: SKILL_LOOKUP_TIMEOUT_MS })
@@ -845,25 +847,30 @@ const getCachedSkillBySlug = unstable_cache(
       .eq('ai_review_approved', true)
       .maybeSingle()
 
-    if (error || !data || isMcpSkillRecord(data)) return null
+    if (error) throw error
+    if (!data || isMcpSkillRecord(data)) return null
     return data as SkillRecord
   },
-  ['public-skill-by-slug-v2'],
+  ['public-skill-by-slug-v3'],
   {
     revalidate: SKILL_LOOKUP_CACHE_REVALIDATE_SECONDS,
     tags: ['public-skill-directory'],
   }
 )
 
-export async function getSkillBySlug(slug: string): Promise<SkillRecord | null> {
+export async function getSkillBySlugStrict(slug: string): Promise<SkillRecord | null> {
   const normalized = normalizeSkillLookupSlug(slug)
   if (!normalized) return null
 
+  return getCachedSkillBySlug(normalized)
+}
+
+export async function getSkillBySlug(slug: string): Promise<SkillRecord | null> {
+
   try {
-    return await getCachedSkillBySlug(normalized)
-  } catch {
-    // A missing or temporarily unavailable detail must not slow down the
-    // registry. Curated callers can still provide their static fallback.
+    return await getSkillBySlugStrict(slug)
+  } catch (error) {
+    console.warn('Skill slug lookup fallback:', error)
     return null
   }
 }
@@ -988,16 +995,8 @@ async function fetchSearchSkills(normalizedQuery: string, limit: number): Promis
 }
 
 const getCachedSearchSkills = unstable_cache(
-  async (normalizedQuery: string, limit: number) => {
-    try {
-      return await fetchSearchSkills(normalizedQuery, limit)
-    } catch {
-      // The ranked directory candidate pool still answers the request when an
-      // exact database search is unavailable.
-      return [] as SkillRecord[]
-    }
-  },
-  ['public-skill-search-v3'],
+  async (normalizedQuery: string, limit: number) => fetchSearchSkills(normalizedQuery, limit),
+  ['public-skill-search-v4'],
   { revalidate: SHARED_SKILL_CACHE_REVALIDATE_SECONDS, tags: ['public-skill-directory'] }
 )
 
@@ -1005,7 +1004,7 @@ async function fetchExactSearchSkills(query: string): Promise<SkillRecord[]> {
   const exactQuery = normalizeExactSearchQuery(query)
   if (!exactQuery) return []
 
-  const supabase = createPublicClient({ requestTimeoutMs: SKILL_DIRECTORY_REQUEST_TIMEOUT_MS })
+  const supabase = createPublicClient({ requestTimeoutMs: SKILL_EXACT_SEARCH_TIMEOUT_MS })
   const [slugResult, nameResult] = await Promise.all([
     supabase
       .from('skills')
@@ -1021,11 +1020,16 @@ async function fetchExactSearchSkills(query: string): Promise<SkillRecord[]> {
       .limit(8),
   ])
 
-  if (slugResult.error) throw slugResult.error
-  if (nameResult.error) throw nameResult.error
+  const records = [...(slugResult.data || []), ...(nameResult.data || [])] as unknown as SkillRecord[]
+  // A partial response is sufficient when it already contains a definitive
+  // match. If the healthy query returned nothing, however, do not let the
+  // failed sibling query turn an unknown result into a false empty result.
+  if (records.length === 0 && (slugResult.error || nameResult.error)) {
+    throw slugResult.error || nameResult.error
+  }
 
   const seen = new Set<string>()
-  return filterSkillOnly([...(slugResult.data || []), ...(nameResult.data || [])] as unknown as SkillRecord[])
+  return filterSkillOnly(records)
     .filter((skill) => {
       if (seen.has(skill.slug)) return false
       seen.add(skill.slug)
@@ -1033,7 +1037,18 @@ async function fetchExactSearchSkills(query: string): Promise<SkillRecord[]> {
     })
 }
 
-export async function searchSkills(query: string, limit = 120): Promise<SkillRecord[]> {
+function mergeSearchMatches(exactMatches: SkillRecord[], broadMatches: SkillRecord[], rowLimit: number) {
+  const seen = new Set<string>()
+  return [...exactMatches, ...broadMatches]
+    .filter((skill) => {
+      if (seen.has(skill.slug)) return false
+      seen.add(skill.slug)
+      return true
+    })
+    .slice(0, rowLimit)
+}
+
+export async function searchSkillsStrict(query: string, limit = 120): Promise<SkillRecord[]> {
   const normalizedQuery = normalizeExactSearchQuery(query)
   if (!normalizedQuery) return []
 
@@ -1043,21 +1058,32 @@ export async function searchSkills(query: string, limit = 120): Promise<SkillRec
       fetchExactSearchSkills(normalizedQuery),
       SKILL_EXACT_SEARCH_TIMEOUT_MS,
       'exact skill search'
-    ).catch(() => [] as SkillRecord[]),
+    ),
     withTimeout(
       getCachedSearchSkills(normalizedQuery.toLowerCase(), rowLimit),
       SKILL_BROAD_SEARCH_TIMEOUT_MS,
       'broad skill search'
     ).catch(() => [] as SkillRecord[]),
   ])
-  const seen = new Set<string>()
-  return [...exactMatches, ...broadMatches]
-    .filter((skill) => {
-      if (seen.has(skill.slug)) return false
-      seen.add(skill.slug)
-      return true
-    })
-    .slice(0, rowLimit)
+  return mergeSearchMatches(exactMatches, broadMatches, rowLimit)
+}
+
+export async function searchSkills(query: string, limit = 120): Promise<SkillRecord[]> {
+  const normalizedQuery = normalizeExactSearchQuery(query)
+  if (!normalizedQuery) return []
+  const rowLimit = Math.min(Math.max(Math.floor(limit) || 1, 1), 200)
+
+  try {
+    return await searchSkillsStrict(normalizedQuery, rowLimit)
+  } catch (error) {
+    console.warn('Exact skill search fallback:', error)
+    const broadMatches = await withTimeout(
+      getCachedSearchSkills(normalizedQuery.toLowerCase(), rowLimit),
+      SKILL_BROAD_SEARCH_TIMEOUT_MS,
+      'broad skill search fallback'
+    ).catch(() => [] as SkillRecord[])
+    return mergeSearchMatches([], broadMatches, rowLimit)
+  }
 }
 
 export async function getRelatedSkills(

--- a/lib/skill-fallbacks.ts
+++ b/lib/skill-fallbacks.ts
@@ -1,4 +1,4 @@
-import { getSkillBySlug, type SkillRecord } from '@/lib/db/skills'
+import { getSkillBySlugStrict, type SkillRecord } from '@/lib/db/skills'
 import { withTimeout } from '@/lib/async'
 import { CURATED_SKILL_SNAPSHOT } from '@/lib/seo/curated-skill-snapshot'
 
@@ -110,18 +110,22 @@ export function isCuratedSkillFallback(skill: SkillRecord) {
   return skill.submission_source === 'curated_snapshot' || skill.id.startsWith('snapshot-')
 }
 
-export async function getSkillBySlugOrFallback(slug: string): Promise<SkillRecord | null> {
+export async function getSkillBySlugOrFallbackStrict(slug: string): Promise<SkillRecord | null> {
   const normalized = normalizeSkillSlug(slug)
   const fallback = getCuratedSkillFallback(normalized)
 
   if (fallback) {
     const dbSkill = await withTimeout(
-      getSkillBySlug(normalized),
-      650,
+      getSkillBySlugStrict(normalized),
+      1800,
       `curated skill lookup ${normalized}`
     ).catch(() => null)
     return dbSkill || fallback
   }
 
-  return getSkillBySlug(normalized).catch(() => null)
+  return getSkillBySlugStrict(normalized)
+}
+
+export async function getSkillBySlugOrFallback(slug: string): Promise<SkillRecord | null> {
+  return getSkillBySlugOrFallbackStrict(slug).catch(() => getCuratedSkillFallback(slug))
 }

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+import { createResilientTimeoutFetch } from '@/lib/supabase/resilient-fetch'
 
 const SUPABASE_URL =
   process.env.NEXT_PUBLIC_SUPABASE_URL ||
@@ -9,23 +10,6 @@ const SUPABASE_URL =
 
 export interface AdminClientOptions {
   requestTimeoutMs?: number
-}
-
-function createTimeoutFetch(timeoutMs: number): typeof fetch {
-  return async (input, init) => {
-    const controller = new AbortController()
-    const externalSignal = init?.signal
-    const signal = externalSignal
-      ? AbortSignal.any([externalSignal, controller.signal])
-      : controller.signal
-    const timeout = setTimeout(() => controller.abort(), timeoutMs)
-
-    try {
-      return await fetch(input, { ...init, signal })
-    } finally {
-      clearTimeout(timeout)
-    }
-  }
 }
 
 export function createAdminClient(options: AdminClientOptions = {}) {
@@ -47,7 +31,7 @@ export function createAdminClient(options: AdminClientOptions = {}) {
       persistSession: false,
     },
     ...(Number.isFinite(requestTimeoutMs) && requestTimeoutMs > 0
-      ? { global: { fetch: createTimeoutFetch(Math.floor(requestTimeoutMs)) } }
+      ? { global: { fetch: createResilientTimeoutFetch(Math.floor(requestTimeoutMs)) } }
       : {}),
   })
 }

--- a/lib/supabase/public.ts
+++ b/lib/supabase/public.ts
@@ -1,4 +1,5 @@
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+import { createResilientTimeoutFetch } from '@/lib/supabase/resilient-fetch'
 
 // Supabase anon key is intentionally public — it is safe to commit.
 // RLS policies on the database enforce all access control.
@@ -20,23 +21,6 @@ export interface PublicClientOptions {
   requestTimeoutMs?: number
 }
 
-function createTimeoutFetch(timeoutMs: number): typeof fetch {
-  return async (input, init) => {
-    const controller = new AbortController()
-    const externalSignal = init?.signal
-    const signal = externalSignal
-      ? AbortSignal.any([externalSignal, controller.signal])
-      : controller.signal
-    const timeout = setTimeout(() => controller.abort(), timeoutMs)
-
-    try {
-      return await fetch(input, { ...init, signal })
-    } finally {
-      clearTimeout(timeout)
-    }
-  }
-}
-
 /**
  * A lightweight Supabase client for public read-only operations.
  * Does NOT depend on cookies() — works in any server context.
@@ -45,7 +29,7 @@ export function createPublicClient(options: PublicClientOptions = {}) {
   const requestTimeoutMs = Number(options.requestTimeoutMs)
   if (Number.isFinite(requestTimeoutMs) && requestTimeoutMs > 0) {
     return createSupabaseClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-      global: { fetch: createTimeoutFetch(Math.floor(requestTimeoutMs)) },
+      global: { fetch: createResilientTimeoutFetch(Math.floor(requestTimeoutMs)) },
     })
   }
 

--- a/lib/supabase/resilient-fetch.ts
+++ b/lib/supabase/resilient-fetch.ts
@@ -1,0 +1,85 @@
+type CircuitState = {
+  consecutiveFailures: number
+  openUntil: number
+  probeInFlight: boolean
+}
+
+type CircuitGlobal = typeof globalThis & {
+  __openagentskillSupabaseCircuit?: CircuitState
+}
+
+const FAILURE_THRESHOLD = 3
+const OPEN_INTERVAL_MS = 15_000
+
+function getCircuitState(): CircuitState {
+  const shared = globalThis as CircuitGlobal
+  if (!shared.__openagentskillSupabaseCircuit) {
+    shared.__openagentskillSupabaseCircuit = {
+      consecutiveFailures: 0,
+      openUntil: 0,
+      probeInFlight: false,
+    }
+  }
+  return shared.__openagentskillSupabaseCircuit
+}
+
+function recordFailure(state: CircuitState) {
+  state.consecutiveFailures += 1
+  if (state.consecutiveFailures >= FAILURE_THRESHOLD) {
+    state.openUntil = Date.now() + OPEN_INTERVAL_MS
+  }
+}
+
+function recordSuccess(state: CircuitState) {
+  state.consecutiveFailures = 0
+  state.openUntil = 0
+}
+
+/**
+ * Bound Supabase requests and stop a degraded gateway from consuming every
+ * serverless invocation. The circuit is shared by warm invocations of the
+ * same function bundle, opens after three failures, and automatically allows
+ * one half-open probe after the cooldown.
+ */
+export function createResilientTimeoutFetch(timeoutMs: number): typeof fetch {
+  return async (input, init) => {
+    const state = getCircuitState()
+    const now = Date.now()
+    let ownsProbe = false
+
+    if (state.openUntil > now) {
+      throw new Error('Supabase data circuit is temporarily open')
+    }
+
+    if (state.consecutiveFailures >= FAILURE_THRESHOLD) {
+      if (state.probeInFlight) {
+        throw new Error('Supabase recovery probe is already running')
+      }
+      state.probeInFlight = true
+      ownsProbe = true
+    }
+
+    const controller = new AbortController()
+    const externalSignal = init?.signal
+    const signal = externalSignal
+      ? AbortSignal.any([externalSignal, controller.signal])
+      : controller.signal
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+
+    try {
+      const response = await fetch(input, { ...init, signal })
+      if (response.status >= 500) {
+        recordFailure(state)
+      } else {
+        recordSuccess(state)
+      }
+      return response
+    } catch (error) {
+      recordFailure(state)
+      throw error
+    } finally {
+      clearTimeout(timeout)
+      if (ownsProbe) state.probeInFlight = false
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "indexer:backfill": "node scripts/backfill-high-star-skills.mjs",
     "test:submission": "node --experimental-strip-types scripts/test-skill-source.ts",
     "test:submission-discovery": "node --experimental-strip-types scripts/test-submission-discovery.ts",
+    "test:supabase-circuit": "node --experimental-strip-types scripts/test-supabase-circuit.ts",
     "test:cli": "node packages/cli/openagentskill.mjs --help",
     "lint": "eslint ."
   },

--- a/scripts/test-supabase-circuit.ts
+++ b/scripts/test-supabase-circuit.ts
@@ -1,37 +1,46 @@
 import assert from 'node:assert/strict'
 
+// Node's type-stripping runner needs the explicit extension for this standalone test.
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
 import { createResilientTimeoutFetch } from '../lib/supabase/resilient-fetch.ts'
 
 type CircuitGlobal = typeof globalThis & {
   __openagentskillSupabaseCircuit?: unknown
 }
 
-const shared = globalThis as CircuitGlobal
-shared.__openagentskillSupabaseCircuit = undefined
+async function main() {
+  const shared = globalThis as CircuitGlobal
+  shared.__openagentskillSupabaseCircuit = undefined
 
-const originalFetch = globalThis.fetch
-let upstreamCalls = 0
+  const originalFetch = globalThis.fetch
+  let upstreamCalls = 0
 
-globalThis.fetch = async () => {
-  upstreamCalls += 1
-  return new Response('upstream unavailable', { status: 522 })
-}
-
-try {
-  const guardedFetch = createResilientTimeoutFetch(100)
-
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    const response = await guardedFetch('https://example.test')
-    assert.equal(response.status, 522)
+  globalThis.fetch = async () => {
+    upstreamCalls += 1
+    return new Response('upstream unavailable', { status: 522 })
   }
 
-  await assert.rejects(
-    () => guardedFetch('https://example.test'),
-    /circuit is temporarily open/
-  )
-  assert.equal(upstreamCalls, 3)
-  console.log('Supabase circuit breaker regression test passed.')
-} finally {
-  globalThis.fetch = originalFetch
-  shared.__openagentskillSupabaseCircuit = undefined
+  try {
+    const guardedFetch = createResilientTimeoutFetch(100)
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const response = await guardedFetch('https://example.test')
+      assert.equal(response.status, 522)
+    }
+
+    await assert.rejects(
+      () => guardedFetch('https://example.test'),
+      /circuit is temporarily open/
+    )
+    assert.equal(upstreamCalls, 3)
+    console.log('Supabase circuit breaker regression test passed.')
+  } finally {
+    globalThis.fetch = originalFetch
+    shared.__openagentskillSupabaseCircuit = undefined
+  }
 }
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/test-supabase-circuit.ts
+++ b/scripts/test-supabase-circuit.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+
+import { createResilientTimeoutFetch } from '../lib/supabase/resilient-fetch.ts'
+
+type CircuitGlobal = typeof globalThis & {
+  __openagentskillSupabaseCircuit?: unknown
+}
+
+const shared = globalThis as CircuitGlobal
+shared.__openagentskillSupabaseCircuit = undefined
+
+const originalFetch = globalThis.fetch
+let upstreamCalls = 0
+
+globalThis.fetch = async () => {
+  upstreamCalls += 1
+  return new Response('upstream unavailable', { status: 522 })
+}
+
+try {
+  const guardedFetch = createResilientTimeoutFetch(100)
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const response = await guardedFetch('https://example.test')
+    assert.equal(response.status, 522)
+  }
+
+  await assert.rejects(
+    () => guardedFetch('https://example.test'),
+    /circuit is temporarily open/
+  )
+  assert.equal(upstreamCalls, 3)
+  console.log('Supabase circuit breaker regression test passed.')
+} finally {
+  globalThis.fetch = originalFetch
+  shared.__openagentskillSupabaseCircuit = undefined
+}


### PR DESCRIPTION
## Summary
- prevent transient Supabase timeouts from being cached as false Skill misses
- return retryable 503 responses instead of false 404/empty direct lookups
- add a three-mode homepage launcher for task resolution, Skill search, and GitHub submission
- move live search results ahead of directory content and improve mobile filtering
- add a mobile install action bar and a friendly detail-page retry state

## Verification
- `pnpm lint` (0 errors; existing repository warnings only)
- `pnpm build`
- `pnpm test:submission`
- `pnpm test:submission-discovery`
- `pnpm test:cli`
- Playwright desktop 1440px and mobile 390px checks: no horizontal overflow, launcher navigation works, curated detail fallback works, mobile install actions visible
