### PR TITLE
fix: resolve CodeQL security findings

### DIFF
--- a/lib/schema/skill-schema.ts
+++ b/lib/schema/skill-schema.ts
@@ -1,5 +1,24 @@
 import { z } from 'zod'
 
+function isGitHubRepositoryUrl(value: string) {
+  try {
+    const url = new URL(value)
+    const hostname = url.hostname.toLowerCase()
+    const pathSegments = url.pathname.split('/').filter(Boolean)
+
+    return (
+      url.protocol === 'https:' &&
+      !url.username &&
+      !url.password &&
+      !url.port &&
+      (hostname === 'github.com' || hostname === 'www.github.com') &&
+      pathSegments.length >= 2
+    )
+  } catch {
+    return false
+  }
+}
+
 // Skill submission schema - for validating user/agent submissions
 export const SkillSubmissionSchema = z.object({
   // Basic info
@@ -10,8 +29,8 @@ export const SkillSubmissionSchema = z.object({
   
   // Repository
   repository: z.string().url().refine(
-    (url) => url.includes('github.com'),
-    { message: 'Must be a GitHub repository URL' }
+    isGitHubRepositoryUrl,
+    { message: 'Must be an HTTPS GitHub repository URL' }
   ),
   
   // Author info

--- a/lib/skill-fallbacks.ts
+++ b/lib/skill-fallbacks.ts
@@ -57,7 +57,14 @@ const SLUG_ALIASES: Record<string, string> = {
 }
 
 function normalizeRequestedSkillSlug(slug: string) {
-  return slug.trim().toLowerCase().replace(/^\/+|\/+$/g, '')
+  const normalized = slug.trim().toLowerCase()
+  let start = 0
+  let end = normalized.length
+
+  while (start < end && normalized.charCodeAt(start) === 47) start += 1
+  while (end > start && normalized.charCodeAt(end - 1) === 47) end -= 1
+
+  return normalized.slice(start, end)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "test:submission": "node --experimental-strip-types scripts/test-skill-source.ts",
     "test:submission-discovery": "node --experimental-strip-types scripts/test-submission-discovery.ts",
     "test:supabase-circuit": "node --experimental-strip-types scripts/test-supabase-circuit.ts",
+    "test:security": "node --experimental-strip-types scripts/test-security-regressions.ts",
     "test:cli": "node packages/cli/openagentskill.mjs --help",
     "test:sdk": "node scripts/test-sdk.mjs",
     "test:links": "node scripts/check-repository-links.mjs",
     "test:links:external": "node scripts/check-repository-links.mjs --external",
-    "test": "pnpm run test:submission && pnpm run test:submission-discovery && pnpm run test:supabase-circuit && pnpm run test:cli && pnpm run test:sdk",
+    "test": "pnpm run test:submission && pnpm run test:submission-discovery && pnpm run test:supabase-circuit && pnpm run test:security && pnpm run test:cli && pnpm run test:sdk",
     "typecheck": "next typegen && tsc --noEmit",
     "lint": "eslint ."
   },

--- a/scripts/check-repository-links.mjs
+++ b/scripts/check-repository-links.mjs
@@ -17,7 +17,6 @@ function githubAnchor(value) {
   return value
     .trim()
     .toLowerCase()
-    .replace(/<[^>]+>/g, '')
     .replace(/[^\p{L}\p{N}\s_-]/gu, '')
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')

--- a/scripts/test-security-regressions.ts
+++ b/scripts/test-security-regressions.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+
+// Node's type-stripping runner needs the explicit extension.
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
+import { SkillSubmissionSchema } from '../lib/schema/skill-schema.ts'
+
+const validSubmission = {
+  name: 'Secure repository skill',
+  version: '1.0.0',
+  description: 'A sufficiently detailed description for schema validation.',
+  repository: 'https://github.com/openagentskill/example-skill',
+  author: { name: 'OpenAgentSkill' },
+  category: 'security',
+  tags: ['security'],
+  license: 'MIT',
+  language: ['TypeScript'],
+  compatibility: [{ platform: 'Codex' }],
+  usage: { install: 'Install from the reviewed repository.' },
+}
+
+assert.equal(SkillSubmissionSchema.safeParse(validSubmission).success, true)
+
+for (const repository of [
+  'https://github.com.evil.example/owner/repo',
+  'https://evil.example/github.com/owner/repo',
+  'https://github.com@evil.example/owner/repo',
+  'http://github.com/owner/repo',
+  'https://github.com/owner',
+]) {
+  const result = SkillSubmissionSchema.safeParse({ ...validSubmission, repository })
+  assert.equal(result.success, false, `expected rejection for ${repository}`)
+}
+
+console.log('Security regression tests passed.')


### PR DESCRIPTION
## Summary

- validate GitHub repository URLs by parsed origin and HTTPS protocol
- replace the slug-trimming regex with a linear scan
- remove incomplete multi-character sanitization in the documentation link checker
- add malicious URL regression coverage

## Verification

- `pnpm audit --audit-level high`
- `pnpm run lint` (0 errors; existing warnings only)
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run test:links`
- `pnpm run build`

Closes the three CodeQL findings created after enabling code scanning.