### PR TITLE
fix: restore X automation after secret rotation

### DIFF
--- a/app/api/x/status/route.ts
+++ b/app/api/x/status/route.ts
@@ -3,6 +3,7 @@ import { createPublicClient } from '@/lib/supabase/public'
 import { isAutomationAuthorized } from '@/lib/security/route-auth'
 import { getStoredXConnection } from '@/lib/x/poster'
 import { getCreatorOutreachStatus } from '@/lib/x/growth'
+import { classifyXConnectionError } from '@/lib/x/health'
 
 function hasEnv(name: string) {
   return Boolean((process.env[name] || '').trim())
@@ -18,7 +19,10 @@ async function getConnectionStatus() {
   if (!serverSecret) {
     return {
       authorized: false,
+      health: 'blocked',
       reason: 'Missing INDEXER_SECRET',
+      reauthorizationRequired: false,
+      action: 'Configure INDEXER_SECRET in the production environment.',
     }
   }
 
@@ -26,15 +30,21 @@ async function getConnectionStatus() {
     const connection = await getStoredXConnection(createPublicClient(), serverSecret)
     return {
       authorized: Boolean(connection),
+      health: connection ? 'ready' : 'disconnected',
       username: connection?.username || null,
       userIdPresent: Boolean(connection?.x_user_id),
       scopePresent: Boolean(connection?.scope),
       reason: connection ? undefined : 'No stored OAuth connection',
+      reauthorizationRequired: !connection,
+      action: connection ? undefined : 'Connect @openagentskill to enable automatic posting.',
+      actionUrl: connection ? undefined : '/api/x/auth',
     }
   } catch (error) {
+    const failure = classifyXConnectionError(error)
     return {
       authorized: false,
-      reason: error instanceof Error ? error.message : 'Failed to inspect X OAuth connection',
+      health: 'blocked',
+      ...failure,
     }
   }
 }

--- a/lib/x/health.ts
+++ b/lib/x/health.ts
@@ -1,0 +1,47 @@
+export type XConnectionErrorCode =
+  | 'secret_mismatch'
+  | 'reauthorization_required'
+  | 'connection_check_failed'
+
+export type XConnectionErrorStatus = {
+  code: XConnectionErrorCode
+  reason: string
+  reauthorizationRequired: boolean
+  action: string
+  actionUrl?: string
+}
+
+export function classifyXConnectionError(error: unknown): XConnectionErrorStatus {
+  const message = error instanceof Error ? error.message : String(error || '')
+  const normalized = message.toLowerCase()
+
+  if (normalized.includes('invalid server secret')) {
+    return {
+      code: 'secret_mismatch',
+      reason: 'The application and database automation secrets are out of sync.',
+      reauthorizationRequired: false,
+      action: 'Apply the latest database migrations before running X automation.',
+    }
+  }
+
+  if (
+    normalized.includes('wrong key or corrupt data') ||
+    normalized.includes('decrypt') ||
+    normalized.includes('pgp_sym_decrypt')
+  ) {
+    return {
+      code: 'reauthorization_required',
+      reason: 'The stored X OAuth token was encrypted with a previous automation secret.',
+      reauthorizationRequired: true,
+      action: 'Reconnect @openagentskill once to store fresh OAuth tokens.',
+      actionUrl: '/api/x/auth',
+    }
+  }
+
+  return {
+    code: 'connection_check_failed',
+    reason: 'The X OAuth connection could not be verified.',
+    reauthorizationRequired: false,
+    action: 'Inspect the X automation and database logs.',
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "test:submission-discovery": "node --experimental-strip-types scripts/test-submission-discovery.ts",
     "test:supabase-circuit": "node --experimental-strip-types scripts/test-supabase-circuit.ts",
     "test:security": "node --experimental-strip-types scripts/test-security-regressions.ts",
+    "test:x-automation": "node --experimental-strip-types scripts/test-x-automation-regressions.ts",
     "test:cli": "node packages/cli/openagentskill.mjs --help",
     "test:sdk": "node scripts/test-sdk.mjs",
     "test:links": "node scripts/check-repository-links.mjs",
     "test:links:external": "node scripts/check-repository-links.mjs --external",
-    "test": "pnpm run test:submission && pnpm run test:submission-discovery && pnpm run test:supabase-circuit && pnpm run test:security && pnpm run test:cli && pnpm run test:sdk",
+    "test": "pnpm run test:submission && pnpm run test:submission-discovery && pnpm run test:supabase-circuit && pnpm run test:security && pnpm run test:x-automation && pnpm run test:cli && pnpm run test:sdk",
     "typecheck": "next typegen && tsc --noEmit",
     "lint": "eslint ."
   },

--- a/scripts/006_controlled_public_write_rpcs.sql
+++ b/scripts/006_controlled_public_write_rpcs.sql
@@ -113,15 +113,10 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_expected_secret_hash constant text := '074705db488fc272fdd4913f06b11cf5ca05b79ceb8af005ecdb6e2479a0af01';
   v_skill public.skills%rowtype;
   v_submission public.skill_submissions%rowtype;
 begin
-  if p_server_secret is null
-    or encode(extensions.digest(p_server_secret, 'sha256'), 'hex') <> v_expected_secret_hash
-  then
-    raise exception 'Invalid server secret' using errcode = '28000';
-  end if;
+  perform public.assert_indexer_secret(p_server_secret);
 
   insert into public.skills (
     slug,

--- a/scripts/007_quality_scoring_and_indexer_rpcs.sql
+++ b/scripts/007_quality_scoring_and_indexer_rpcs.sql
@@ -147,15 +147,10 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_expected_secret_hash constant text := '074705db488fc272fdd4913f06b11cf5ca05b79ceb8af005ecdb6e2479a0af01';
   v_skill public.skills%rowtype;
   v_existing_id uuid;
 begin
-  if p_server_secret is null
-    or encode(extensions.digest(p_server_secret, 'sha256'), 'hex') <> v_expected_secret_hash
-  then
-    raise exception 'Invalid server secret' using errcode = '28000';
-  end if;
+  perform public.assert_indexer_secret(p_server_secret);
 
   select id into v_existing_id
   from public.skills
@@ -294,14 +289,9 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_expected_secret_hash constant text := '074705db488fc272fdd4913f06b11cf5ca05b79ceb8af005ecdb6e2479a0af01';
   v_skill public.skills%rowtype;
 begin
-  if p_server_secret is null
-    or encode(extensions.digest(p_server_secret, 'sha256'), 'hex') <> v_expected_secret_hash
-  then
-    raise exception 'Invalid server secret' using errcode = '28000';
-  end if;
+  perform public.assert_indexer_secret(p_server_secret);
 
   update public.skills
   set

--- a/scripts/008_indexer_run_logs.sql
+++ b/scripts/008_indexer_run_logs.sql
@@ -48,14 +48,9 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_expected_secret_hash constant text := '074705db488fc272fdd4913f06b11cf5ca05b79ceb8af005ecdb6e2479a0af01';
   v_run public.indexer_runs%rowtype;
 begin
-  if p_server_secret is null
-    or encode(extensions.digest(p_server_secret, 'sha256'), 'hex') <> v_expected_secret_hash
-  then
-    raise exception 'Invalid server secret' using errcode = '28000';
-  end if;
+  perform public.assert_indexer_secret(p_server_secret);
 
   insert into public.indexer_runs (
     mode,
@@ -113,14 +108,8 @@ language plpgsql
 security definer
 set search_path = public, pg_temp
 as $$
-declare
-  v_expected_secret_hash constant text := '074705db488fc272fdd4913f06b11cf5ca05b79ceb8af005ecdb6e2479a0af01';
 begin
-  if p_server_secret is null
-    or encode(extensions.digest(p_server_secret, 'sha256'), 'hex') <> v_expected_secret_hash
-  then
-    raise exception 'Invalid server secret' using errcode = '28000';
-  end if;
+  perform public.assert_indexer_secret(p_server_secret);
 
   return query
     select *

--- a/scripts/009_x_auto_posting.sql
+++ b/scripts/009_x_auto_posting.sql
@@ -67,7 +67,7 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_expected_secret_hash constant text := '074705db488fc272fdd4913f06b11cf5ca05b79ceb8af005ecdb6e2479a0af01';
+  v_expected_secret_hash constant text := '54fc1b0e14aa657fd820a882974e4fc64ae055448646a1f073b6a98e5366f43e';
 begin
   if p_server_secret is null
     or encode(extensions.digest(p_server_secret, 'sha256'), 'hex') <> v_expected_secret_hash
@@ -77,7 +77,7 @@ begin
 end;
 $$;
 
-revoke all on function public.assert_indexer_secret(text) from public;
+revoke all on function public.assert_indexer_secret(text) from public, anon, authenticated;
 
 create or replace function public.upsert_x_oauth_connection(
   p_server_secret text,

--- a/scripts/test-x-automation-regressions.ts
+++ b/scripts/test-x-automation-regressions.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// Node's type-stripping runner needs the explicit extension.
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
+import { classifyXConnectionError } from '../lib/x/health.ts'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const readProjectFile = (path: string) => readFileSync(`${root}/${path}`, 'utf8')
+
+assert.deepEqual(classifyXConnectionError(new Error('Invalid server secret')), {
+  code: 'secret_mismatch',
+  reason: 'The application and database automation secrets are out of sync.',
+  reauthorizationRequired: false,
+  action: 'Apply the latest database migrations before running X automation.',
+})
+
+assert.equal(
+  classifyXConnectionError(new Error('Wrong key or corrupt data')).reauthorizationRequired,
+  true
+)
+assert.equal(
+  classifyXConnectionError(new Error('Failed to load X OAuth connection')).code,
+  'connection_check_failed'
+)
+
+const guardedSetupScripts = [
+  'scripts/006_controlled_public_write_rpcs.sql',
+  'scripts/007_quality_scoring_and_indexer_rpcs.sql',
+  'scripts/008_indexer_run_logs.sql',
+]
+
+for (const path of guardedSetupScripts) {
+  const sql = readProjectFile(path)
+  assert.equal(
+    sql.includes('v_expected_secret_hash constant text'),
+    false,
+    `${path} must delegate secret validation to assert_indexer_secret`
+  )
+  assert.match(sql, /perform public\.assert_indexer_secret\(p_server_secret\);/)
+}
+
+const xSetup = readProjectFile('scripts/009_x_auto_posting.sql')
+assert.equal(
+  xSetup.includes('074705db488fc272fdd4913f06b11cf5ca05b79ceb8af005ecdb6e2479a0af01'),
+  false,
+  'the retired automation secret digest must not remain in active setup SQL'
+)
+
+const repairMigration = readProjectFile(
+  'supabase/migrations/20260823160820_unify_indexer_secret_and_restore_x_automation.sql'
+)
+assert.match(repairMigration, /v_rewritten_count <> 5/)
+assert.match(repairMigration, /revoke all on function public\.assert_indexer_secret/)
+
+const vercelConfig = JSON.parse(readProjectFile('vercel.json')) as {
+  crons?: Array<{ path: string; schedule: string }>
+}
+assert.equal(
+  vercelConfig.crons?.some(
+    (cron) => cron.path === '/api/x/post-daily' && cron.schedule === '30 15,19,23 * * *'
+  ),
+  true,
+  'the X daily publishing cron must remain configured'
+)
+
+console.log('X automation regression tests passed.')

--- a/supabase/migrations/20260819091500_rotate_indexer_secret.sql
+++ b/supabase/migrations/20260819091500_rotate_indexer_secret.sql
@@ -1,6 +1,24 @@
--- Rotate the protected indexer RPC secret after the previous Vercel values
--- became unreadable sensitive placeholders. Only the SHA-256 digest is stored
--- in source control and Postgres; the secret itself remains in Vercel.
+-- Rotate the shared automation secret. All guarded RPCs must delegate to this
+-- function so one rotation cannot split the indexer and X automation again.
+
+create or replace function public.assert_indexer_secret(p_server_secret text)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_expected_secret_hash constant text := '54fc1b0e14aa657fd820a882974e4fc64ae055448646a1f073b6a98e5366f43e';
+begin
+  if p_server_secret is null
+    or encode(extensions.digest(p_server_secret, 'sha256'), 'hex') <> v_expected_secret_hash
+  then
+    raise exception 'Invalid server secret' using errcode = '28000';
+  end if;
+end;
+$$;
+
+revoke all on function public.assert_indexer_secret(text) from public, anon, authenticated;
 
 create or replace function public.upsert_indexed_skill(
   p_server_secret text,
@@ -13,15 +31,10 @@ security definer
 set search_path = public, pg_temp
 as $$
 declare
-  v_expected_secret_hash constant text := '54fc1b0e14aa657fd820a882974e4fc64ae055448646a1f073b6a98e5366f43e';
   v_skill public.skills%rowtype;
   v_existing_id uuid;
 begin
-  if p_server_secret is null
-    or encode(extensions.digest(p_server_secret, 'sha256'), 'hex') <> v_expected_secret_hash
-  then
-    raise exception 'Invalid server secret' using errcode = '28000';
-  end if;
+  perform public.assert_indexer_secret(p_server_secret);
 
   select id into v_existing_id
   from public.skills

--- a/supabase/migrations/20260823160820_unify_indexer_secret_and_restore_x_automation.sql
+++ b/supabase/migrations/20260823160820_unify_indexer_secret_and_restore_x_automation.sql
@@ -1,0 +1,77 @@
+-- Restore X/indexer automation after INDEXER_SECRET was rotated in only one RPC.
+-- Keep the digest in one function and rewrite every legacy guarded RPC to call it.
+
+create or replace function public.assert_indexer_secret(p_server_secret text)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_expected_secret_hash constant text := '54fc1b0e14aa657fd820a882974e4fc64ae055448646a1f073b6a98e5366f43e';
+begin
+  if p_server_secret is null
+    or encode(extensions.digest(p_server_secret, 'sha256'), 'hex') <> v_expected_secret_hash
+  then
+    raise exception 'Invalid server secret' using errcode = '28000';
+  end if;
+end;
+$$;
+
+revoke all on function public.assert_indexer_secret(text) from public, anon, authenticated;
+
+do $migration$
+declare
+  v_function record;
+  v_definition text;
+  v_rewritten text;
+  v_rewritten_count integer := 0;
+begin
+  for v_function in
+    select p.oid, p.proname
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.proname in (
+        'list_indexer_runs',
+        'record_indexer_run',
+        'submit_reviewed_skill',
+        'update_skill_github_metadata',
+        'upsert_indexed_skill'
+      )
+      and p.prosrc ~ 'v_expected_secret_hash constant text'
+    order by p.proname
+  loop
+    v_definition := pg_get_functiondef(v_function.oid);
+    v_rewritten := regexp_replace(
+      v_definition,
+      E'\\n[[:space:]]*v_expected_secret_hash constant text := ''[0-9a-f]{64}'';',
+      '',
+      'n'
+    );
+    v_rewritten := regexp_replace(
+      v_rewritten,
+      E'  if p_server_secret is null\\n    or encode\\(extensions\\.digest\\(p_server_secret, ''sha256''\\), ''hex''\\) <> v_expected_secret_hash\\n  then\\n    raise exception ''Invalid server secret'' using errcode = ''28000'';\\n  end if;',
+      E'  perform public.assert_indexer_secret(p_server_secret);',
+      'n'
+    );
+
+    if v_rewritten = v_definition
+      or v_rewritten ~ 'v_expected_secret_hash constant text'
+      or position('encode(extensions.digest(p_server_secret' in v_rewritten) > 0
+    then
+      raise exception 'Could not centralize secret validation for %', v_function.proname;
+    end if;
+
+    execute v_rewritten;
+    v_rewritten_count := v_rewritten_count + 1;
+  end loop;
+
+  if v_rewritten_count <> 5 then
+    raise exception 'Expected to centralize 5 automation RPCs, updated %', v_rewritten_count;
+  end if;
+end;
+$migration$;
+
+comment on function public.assert_indexer_secret(text) is
+  'Single validation gate for INDEXER_SECRET-protected automation RPCs.';


### PR DESCRIPTION
## Summary
- centralize `INDEXER_SECRET` validation for all indexer and X automation RPCs
- repair production drift caused by the August 19 secret rotation
- classify X OAuth health failures and surface the one-time reauthorization action
- add regression coverage for the shared guard and Vercel X cron

## Production database
- applied `unify_indexer_secret_and_restore_x_automation`
- verified five legacy RPCs now delegate to `assert_indexer_secret`
- verified direct anon/authenticated execution of the guard is revoked

## Verification
- `pnpm test`
- `pnpm run lint` (0 errors; existing warnings only)
- `pnpm run typecheck`
- `pnpm run build`
- migration dry-run inside a rolled-back production transaction
- Supabase security and performance advisors reviewed