### PR TITLE
fix: refill X queue when publishing

### DIFF
--- a/app/api/x/post-daily/route.ts
+++ b/app/api/x/post-daily/route.ts
@@ -20,7 +20,7 @@ async function handlePost(request: NextRequest) {
     status: 'skipped' as const,
     reason: error instanceof Error ? error.message : 'Creator reply posting failed',
   }))
-  const result = await postNextQueuedSkillToX({ autoBuildQueue: false })
+  const result = await postNextQueuedSkillToX({ autoBuildQueue: true, buildLimit: 3 })
   const posted = result.status === 'posted' || creatorReply.status === 'posted'
 
   // Keep production cron logs actionable without exposing OAuth tokens or post text.

--- a/lib/x/growth.ts
+++ b/lib/x/growth.ts
@@ -732,7 +732,35 @@ export async function postNextQueuedSkillToX(
   await saveRefreshedXToken(supabase, serverSecret, token)
 
   let queueBuild: Pick<XQueueBuildResult, 'status' | 'queued' | 'skipped' | 'considered'> | null = null
-  if (options.autoBuildQueue === true) {
+  let item: XContentQueueItem | null = null
+  const skippedQueueItems: Array<{ skillSlug: string; reason: string }> = []
+  const queuePasses = options.autoBuildQueue === true ? 2 : 1
+
+  for (let queuePass = 0; queuePass < queuePasses; queuePass += 1) {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const candidateItem = await claimNextQueueItem(supabase, serverSecret)
+      if (!candidateItem) break
+
+      const skipReason = getQueuedSkillSkipReason(candidateItem)
+      if (skipReason) {
+        await completeQueueItem(supabase, serverSecret, candidateItem.id, 'skipped', {
+          error: `Skipped before posting: ${skipReason}`,
+          metadata: {
+            skipped_by: 'x_candidate_guard',
+            skip_reason: skipReason,
+            github_repo: candidateItem.skill?.github_repo || candidateItem.metadata?.github_repo || null,
+          },
+        })
+        skippedQueueItems.push({ skillSlug: candidateItem.skill_slug, reason: skipReason })
+        continue
+      }
+
+      item = candidateItem
+      break
+    }
+
+    if (item || queuePass > 0 || options.autoBuildQueue !== true) break
+
     try {
       const result = await enqueueXSkillPostQueue({ limit: options.buildLimit || 8 })
       queueBuild = {
@@ -743,31 +771,8 @@ export async function postNextQueuedSkillToX(
       }
     } catch (error) {
       console.warn('[x-growth] queue refill failed:', error)
+      break
     }
-  }
-
-  let item: XContentQueueItem | null = null
-  const skippedQueueItems: Array<{ skillSlug: string; reason: string }> = []
-  for (let attempt = 0; attempt < 5; attempt += 1) {
-    const candidateItem = await claimNextQueueItem(supabase, serverSecret)
-    if (!candidateItem) break
-
-    const skipReason = getQueuedSkillSkipReason(candidateItem)
-    if (skipReason) {
-      await completeQueueItem(supabase, serverSecret, candidateItem.id, 'skipped', {
-        error: `Skipped before posting: ${skipReason}`,
-        metadata: {
-          skipped_by: 'x_candidate_guard',
-          skip_reason: skipReason,
-          github_repo: candidateItem.skill?.github_repo || candidateItem.metadata?.github_repo || null,
-        },
-      })
-      skippedQueueItems.push({ skillSlug: candidateItem.skill_slug, reason: skipReason })
-      continue
-    }
-
-    item = candidateItem
-    break
   }
 
   if (!item) {

--- a/scripts/test-x-automation-regressions.ts
+++ b/scripts/test-x-automation-regressions.ts
@@ -65,4 +65,19 @@ assert.equal(
   'the X daily publishing cron must remain configured'
 )
 
+const postDailyRoute = readProjectFile('app/api/x/post-daily/route.ts')
+assert.match(
+  postDailyRoute,
+  /postNextQueuedSkillToX\(\{ autoBuildQueue: true, buildLimit: 3 \}\)/,
+  'the publishing cron must recover from an empty queue'
+)
+
+const growthSource = readProjectFile('lib/x/growth.ts')
+const postNextSource = growthSource.slice(growthSource.indexOf('export async function postNextQueuedSkillToX'))
+assert.ok(
+  postNextSource.indexOf('claimNextQueueItem(supabase, serverSecret)') <
+    postNextSource.indexOf('enqueueXSkillPostQueue({ limit:'),
+  'queue refill must happen only after the existing queue is exhausted'
+)
+
 console.log('X automation regression tests passed.')


### PR DESCRIPTION
## Summary
- refill the X content queue only when the publisher finds no postable item
- enable the daily publishing cron to self-heal after growth queue outages
- cap each recovery refill at three items to avoid queue accumulation
- extend X automation regression coverage

## Verification
- `pnpm test`
- `pnpm run lint` (0 errors; existing warnings only)
- `pnpm run typecheck`
- `pnpm run build`