### PR TITLE
feat: ingest trending skills from X

### DIFF
--- a/lib/indexer/github-search.ts
+++ b/lib/indexer/github-search.ts
@@ -54,6 +54,8 @@ export interface CandidateRepo {
   htmlUrl: string
   /** Exact GitHub tree/blob URL when discovery points to one SKILL.md package. */
   skillSourceUrl?: string
+  /** Exact skill name inferred from a marketplace URL such as skills.sh. */
+  requestedSkillName?: string
   /** Optional provenance retained through review so downstream growth flows can be selective. */
   discovery?: CandidateDiscovery
 }

--- a/lib/indexer/processor.ts
+++ b/lib/indexer/processor.ts
@@ -219,6 +219,8 @@ export async function processRepo(
     const sourceSync = await syncRepositorySkills({
       reference: candidate.skillSourceUrl || candidate.htmlUrl || `https://github.com/${repoRef}`,
       discoverySource: discoverySource === 'x-radar' ? 'x-skill-radar' : 'recursive-skill-source-sync',
+      ...(candidate.discovery?.x ? { discoveryMetadata: { x_signal: candidate.discovery.x } } : {}),
+      ...(candidate.requestedSkillName ? { skillNames: [candidate.requestedSkillName] } : {}),
       maxSkills: 8,
     })
     if (sourceSync.discovered > 0) {
@@ -258,6 +260,15 @@ export async function processRepo(
         discoverySource,
         status: sourceSync.errors > 0 && sourceSync.rejected === 0 ? 'error' : 'rejected',
         reason: firstFailure || 'Explicit SKILL.md packages did not pass automated review.',
+      }
+    }
+    if (candidate.requestedSkillName) {
+      return {
+        repo: repoRef,
+        slug,
+        discoverySource,
+        status: 'skipped',
+        reason: `Requested skill ${candidate.requestedSkillName} was not found in the repository.`,
       }
     }
 

--- a/lib/indexer/repository-skill-sync.ts
+++ b/lib/indexer/repository-skill-sync.ts
@@ -46,6 +46,8 @@ export interface RepositorySkillSyncResult {
 export interface RepositorySkillSyncOptions {
   reference: string
   discoverySource?: string
+  discoveryMetadata?: Record<string, unknown>
+  skillNames?: string[]
   maxSkills?: number
   refreshExisting?: boolean
 }
@@ -122,7 +124,8 @@ function payloadForExisting(
   existing: SkillRecord,
   skill: DiscoveredGitHubSkill,
   repository: Awaited<ReturnType<typeof validateGitHubRepo>>,
-  discoverySource: string
+  discoverySource: string,
+  discoveryMetadata?: Record<string, unknown>
 ) {
   return {
     ...existing,
@@ -142,6 +145,7 @@ function payloadForExisting(
       source_ref: skill.ref,
       skill_path: skill.path,
       last_source_sync_at: new Date().toISOString(),
+      ...(discoveryMetadata || {}),
     },
   }
 }
@@ -149,7 +153,8 @@ function payloadForExisting(
 async function payloadForNew(
   skill: DiscoveredGitHubSkill,
   repository: Awaited<ReturnType<typeof validateGitHubRepo>>,
-  discoverySource: string
+  discoverySource: string,
+  discoveryMetadata?: Record<string, unknown>
 ) {
   const delegatedSkill = await fetchDelegatedGitHubSkill(skill)
   const packageGroups = await Promise.all([
@@ -242,6 +247,7 @@ async function payloadForNew(
         source_url: skill.sourceUrl,
         source_ref: skill.ref,
         skill_path: skill.path,
+        ...(discoveryMetadata || {}),
         ...(delegatedSkill
           ? {
               delegates_to: delegatedSkill.frontmatter.name,
@@ -285,7 +291,15 @@ export async function syncRepositorySkills(
     Math.max(Math.floor(options.maxSkills || DEFAULT_MAX_SKILLS_PER_REPOSITORY), 1),
     MAX_SKILLS_PER_REPOSITORY
   )
-  const selected = orderedSkills(discovery.skills, existing, maxSkills)
+  const requestedNames = new Set((options.skillNames || []).map(slugPart).filter(Boolean))
+  const matchedSkills = requestedNames.size
+    ? discovery.skills.filter((skill) => {
+        const name = slugPart(skill.frontmatter.name)
+        const directory = slugPart(skill.directory.split('/').filter(Boolean).at(-1) || '')
+        return requestedNames.has(name) || requestedNames.has(directory)
+      })
+    : discovery.skills
+  const selected = orderedSkills(matchedSkills, existing, maxSkills)
   const entries: RepositorySkillSyncEntry[] = []
   const discoverySource = options.discoverySource || 'recursive-skill-source-sync'
 
@@ -299,8 +313,8 @@ export async function syncRepositorySkills(
 
     try {
       const result = existingSkill
-        ? { payload: payloadForExisting(existingSkill, skill, repository, discoverySource), reason: null }
-        : await payloadForNew(skill, repository, discoverySource)
+        ? { payload: payloadForExisting(existingSkill, skill, repository, discoverySource, options.discoveryMetadata), reason: null }
+        : await payloadForNew(skill, repository, discoverySource, options.discoveryMetadata)
 
       if (!result.payload) {
         entries.push({
@@ -355,13 +369,13 @@ export async function syncRepositorySkills(
   return {
     repository: repository.fullName,
     reference: options.reference,
-    discovered: discovery.skills.length,
+    discovered: matchedSkills.length,
     processed: entries.length,
     created: entries.filter((entry) => entry.status === 'created').length,
     updated: entries.filter((entry) => entry.status === 'updated').length,
     rejected: entries.filter((entry) => entry.status === 'rejected').length,
     errors: entries.filter((entry) => entry.status === 'error').length,
-    truncated: discovery.truncated || discovery.skills.length > maxSkills,
+    truncated: discovery.truncated || matchedSkills.length > maxSkills,
     entries,
   }
 }

--- a/lib/indexer/skill-source-url.ts
+++ b/lib/indexer/skill-source-url.ts
@@ -1,0 +1,58 @@
+export interface ParsedSkillSource {
+  owner: string
+  repo: string
+  fullName: string
+  sourceUrl: string
+  directoryUrl: string
+  skillName?: string
+}
+
+function normalizeSourceUrl(raw: string) {
+  const trimmed = raw.trim().replace(/[),.;]+$/, '')
+  if (!trimmed) return ''
+  if (/^(?:www\.)?(?:github\.com|skills\.sh)\//i.test(trimmed)) return `https://${trimmed}`
+  return trimmed
+}
+
+function validRepoParts(owner: string, repo: string) {
+  if (!owner || !repo) return false
+  if (['topics', 'features', 'marketplace', 'orgs', 'collections'].includes(owner.toLowerCase())) return false
+  if (['issues', 'pull', 'pulls', 'tree', 'blob', 'discussions', 'releases'].includes(repo.toLowerCase())) return false
+  return true
+}
+
+export function parseSkillSourceUrl(raw: string): ParsedSkillSource | null {
+  const normalized = normalizeSourceUrl(raw)
+
+  const githubMatch = normalized.match(/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)/i)
+  if (githubMatch) {
+    const owner = githubMatch[1]
+    const repo = githubMatch[2].replace(/\.git$/i, '')
+    if (!validRepoParts(owner, repo)) return null
+
+    return {
+      owner,
+      repo,
+      fullName: `${owner}/${repo}`,
+      sourceUrl: normalized,
+      directoryUrl: `https://github.com/${owner}/${repo}`,
+    }
+  }
+
+  const skillsMatch = normalized.match(/skills\.sh\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)(?:\/([A-Za-z0-9_.-]+))?/i)
+  if (!skillsMatch) return null
+
+  const owner = skillsMatch[1]
+  const repo = skillsMatch[2]
+  const skillName = skillsMatch[3]
+  if (!validRepoParts(owner, repo)) return null
+
+  return {
+    owner,
+    repo,
+    fullName: `${owner}/${repo}`,
+    sourceUrl: normalized,
+    directoryUrl: `https://github.com/${owner}/${repo}`,
+    ...(skillName ? { skillName } : {}),
+  }
+}

--- a/lib/indexer/x-skill-radar.ts
+++ b/lib/indexer/x-skill-radar.ts
@@ -1,5 +1,6 @@
 import { isGenericFoundationRepoName } from '@/lib/x/candidates'
 import { evaluateSkillCandidate } from './skill-filter'
+import { parseSkillSourceUrl } from './skill-source-url'
 import type { CandidateRepo } from './github-search'
 
 interface XUrlEntity {
@@ -99,16 +100,16 @@ const X_RECENT_SEARCH_URL = 'https://api.x.com/2/tweets/search/recent'
 const GITHUB_API_BASE = 'https://api.github.com'
 
 const X_SKILL_RADAR_QUERIES = [
-  '("agent skill" OR "AI agent skill" OR "Codex skill" OR "Claude Code skill" OR "Cursor skill") (github.com OR "GitHub") has:links -is:retweet',
-  '("skill" "Claude Code" OR "skill" "Codex" OR "skill" "Cursor") (github.com OR "GitHub") has:links -is:retweet',
-  '("PPT skill" OR "pptx skill" OR "presentation skill" OR "slide deck skill") (github.com OR "GitHub") has:links -is:retweet',
-  '("stock analysis skill" OR "trading skill" OR "quant skill" OR "finance agent skill") (github.com OR "GitHub") has:links -is:retweet',
-  '("research skill" OR "last30days-skill" OR "deep research skill") (github.com OR "GitHub") has:links -is:retweet',
-  '("web scraping skill" OR "browser automation skill" OR "crawler skill") (github.com OR "GitHub") has:links -is:retweet',
-  '("World Cup" "skill" OR "football analytics" "skill" OR "sports analytics" "agent") (github.com OR "GitHub") has:links -is:retweet',
-  '("design skill" OR "video skill" OR "creative agent skill") (github.com OR "GitHub") has:links -is:retweet',
-  '("marketing skill" OR "SEO skill" OR "growth skill" OR "content skill") (github.com OR "GitHub") has:links -is:retweet',
-  '("data analysis skill" OR "spreadsheet skill" OR "SQL skill" OR "legal skill" OR "education skill") (github.com OR "GitHub") has:links -is:retweet',
+  '("agent skill" OR "AI agent skill" OR "Codex skill" OR "Claude Code skill" OR "Cursor skill") (github.com OR skills.sh OR "GitHub") has:links -is:retweet',
+  '("skill" "Claude Code" OR "skill" "Codex" OR "skill" "Cursor") (github.com OR skills.sh OR "GitHub") has:links -is:retweet',
+  '("PPT skill" OR "pptx skill" OR "presentation skill" OR "slide deck skill") (github.com OR skills.sh OR "GitHub") has:links -is:retweet',
+  '("stock analysis skill" OR "trading skill" OR "quant skill" OR "finance agent skill") (github.com OR skills.sh OR "GitHub") has:links -is:retweet',
+  '("research skill" OR "last30days-skill" OR "deep research skill") (github.com OR skills.sh OR "GitHub") has:links -is:retweet',
+  '("web scraping skill" OR "browser automation skill" OR "crawler skill") (github.com OR skills.sh OR "GitHub") has:links -is:retweet',
+  '("World Cup" "skill" OR "football analytics" "skill" OR "sports analytics" "agent") (github.com OR skills.sh OR "GitHub") has:links -is:retweet',
+  '("design skill" OR "video skill" OR "creative agent skill") (github.com OR skills.sh OR "GitHub") has:links -is:retweet',
+  '("marketing skill" OR "SEO skill" OR "growth skill" OR "content skill") (github.com OR skills.sh OR "GitHub") has:links -is:retweet',
+  '("data analysis skill" OR "spreadsheet skill" OR "SQL skill" OR "legal skill" OR "education skill") (github.com OR skills.sh OR "GitHub") has:links -is:retweet',
 ]
 
 const WORKFLOW_SIGNAL = /\b(agent[-_\s]?skill|skill\.md|skills?|codex|claude code|cursor|gemini cli|agent workflow|installable|workflow|automation|ppt|pptx|powerpoint|slides?|presentation|deck|stock|trading|finance|quant|backtest|research|last30|web scraping|crawler|browser automation|rag|pdf|document|seo|design|video|world cup|football|soccer|sports analytics)\b/i
@@ -142,39 +143,25 @@ function normalizeGithubUrl(raw: string) {
 }
 
 export function parseGitHubRepoFromUrl(raw: string) {
-  const normalized = normalizeGithubUrl(raw)
-  const match = normalized.match(/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)/i)
-  if (!match) return null
-
-  const owner = match[1]
-  const repo = match[2].replace(/\.git$/i, '')
-  if (!owner || !repo) return null
-  if (['topics', 'features', 'marketplace', 'orgs', 'collections'].includes(owner.toLowerCase())) return null
-  if (['issues', 'pull', 'pulls', 'tree', 'blob', 'discussions', 'releases'].includes(repo.toLowerCase())) return null
-
-  return {
-    owner,
-    repo,
-    fullName: `${owner}/${repo}`,
-    sourceUrl: normalized.replace(/[),.;]+$/, ''),
-  }
+  const parsed = parseSkillSourceUrl(normalizeGithubUrl(raw))
+  return parsed && /github\.com\//i.test(parsed.sourceUrl) ? parsed : null
 }
 
-function extractGitHubRepos(tweet: XRecentTweet) {
+function extractSkillRepos(tweet: XRecentTweet) {
   const urls = new Set<string>()
-  const textUrls = tweet.text.match(/https?:\/\/(?:www\.)?github\.com\/[^\s)]+/gi) || []
+  const textUrls = tweet.text.match(/https?:\/\/(?:www\.)?(?:github\.com|skills\.sh)\/[^\s)]+/gi) || []
   for (const url of textUrls) urls.add(url)
 
   for (const entity of tweet.entities?.urls || []) {
     for (const value of [entity.unwound_url, entity.expanded_url, entity.display_url, entity.url]) {
       if (!value) continue
-      if (/github\.com\//i.test(value)) urls.add(value)
+      if (/(?:github\.com|skills\.sh)\//i.test(value)) urls.add(value)
     }
   }
 
   return Array.from(urls)
-    .map(parseGitHubRepoFromUrl)
-    .filter((repo): repo is { owner: string; repo: string; fullName: string; sourceUrl: string } => Boolean(repo))
+    .map(parseSkillSourceUrl)
+    .filter((repo): repo is NonNullable<ReturnType<typeof parseSkillSourceUrl>> => Boolean(repo))
 }
 
 function engagementScore(tweet: XRecentTweet) {
@@ -239,6 +226,7 @@ async function fetchGitHubRepo(owner: string, repo: string) {
 function toCandidate(
   repo: GitHubRepoResponse,
   skillSourceUrl: string,
+  requestedSkillName: string | undefined,
   tweet: XRecentTweet,
   query: string,
   score: number,
@@ -271,6 +259,7 @@ function toCandidate(
     updatedAt: repo.updated_at || repo.pushed_at || new Date().toISOString(),
     htmlUrl: repo.html_url,
     skillSourceUrl,
+    ...(requestedSkillName ? { requestedSkillName } : {}),
     discovery: {
       source: 'x-radar',
       x: {
@@ -317,11 +306,11 @@ export async function searchXSkillRadarRepos(options: XSkillRadarOptions = {}): 
       )
       for (const tweet of response.data || []) {
         inspectedTweets += 1
-        const repos = extractGitHubRepos(tweet)
+        const repos = extractSkillRepos(tweet)
         extractedRepos += repos.length
 
         for (const parsed of repos) {
-          const candidateKey = parsed.sourceUrl.toLowerCase()
+          const candidateKey = `${parsed.fullName}/${parsed.skillName || ''}`.toLowerCase()
           if (candidates.has(candidateKey)) continue
           if (isGenericFoundationRepoName(parsed.fullName)) continue
 
@@ -351,7 +340,7 @@ export async function searchXSkillRadarRepos(options: XSkillRadarOptions = {}): 
           const score = radarScore(repo, tweet, evaluation.score)
           candidates.set(
             candidateKey,
-            toCandidate(repo, parsed.sourceUrl, tweet, query, score, authorsById.get(tweet.author_id || ''))
+            toCandidate(repo, parsed.directoryUrl, parsed.skillName, tweet, query, score, authorsById.get(tweet.author_id || ''))
           )
           if (candidates.size >= limit * 2) break
         }

--- a/lib/x/candidates.ts
+++ b/lib/x/candidates.ts
@@ -140,6 +140,21 @@ function hasGenericFoundationSignals(text: string) {
   return /\b(deep[-_\s]?learning framework|machine[-_\s]?learning framework|container orchestration|operating system|programming language|frontend framework|javascript framework|runtime|database engine|distributed system|web framework|ui library)\b/.test(text)
 }
 
+export function hasXTrendOverride(skill: SkillRecord) {
+  const asRecord = (value: unknown): Record<string, unknown> =>
+    value !== null && typeof value === 'object' ? value as Record<string, unknown> : {}
+  const review = skill.ai_review_score && typeof skill.ai_review_score === 'object'
+    ? skill.ai_review_score as Record<string, unknown>
+    : {}
+  const signal = asRecord(review.x_signal)
+  const metrics = asRecord(signal.metrics)
+
+  return Number(metrics.impression_count || 0) >= 100_000 ||
+    Number(metrics.bookmark_count || 0) >= 500 ||
+    Number(metrics.like_count || 0) >= 1_000 ||
+    Number(signal.engagementScore || 0) >= 100
+}
+
 export function getXCandidateDecision(skill: SkillRecord, minStars = 500): XCandidateDecision {
   const lane = getXContentLane(skill)
   const text = getSkillShareText(skill, {
@@ -161,11 +176,12 @@ export function getXCandidateDecision(skill: SkillRecord, minStars = 500): XCand
     category: skill.category,
     stars: skill.github_stars,
   })
+  const trendOverride = hasXTrendOverride(skill)
 
   if (!skill.ai_review_approved) {
     return { eligible: false, reason: 'not-approved', lane, signals }
   }
-  if (Number(skill.github_stars || 0) < minStars) {
+  if (Number(skill.github_stars || 0) < minStars && !trendOverride) {
     return { eligible: false, reason: 'below-star-threshold', lane, signals }
   }
   if (Number(skill.quality_score || 0) < 45) {
@@ -200,9 +216,9 @@ export function getXCandidateDecision(skill: SkillRecord, minStars = 500): XCand
 
   return {
     eligible: true,
-    reason: `skill-like-${likeness.score}`,
+    reason: `${trendOverride && Number(skill.github_stars || 0) < minStars ? 'trend-' : ''}skill-like-${likeness.score}`,
     lane,
-    signals: [...new Set([...signals, ...likeness.signals])],
+    signals: [...new Set([...signals, ...likeness.signals, ...(trendOverride ? ['x-trend-override'] : [])])],
   }
 }
 

--- a/scripts/import-skill-sources.ts
+++ b/scripts/import-skill-sources.ts
@@ -1,0 +1,28 @@
+import { syncRepositorySkills } from '../lib/indexer/repository-skill-sync'
+
+async function main() {
+  const references = process.argv.slice(2).filter((value) => /^https:\/\/github\.com\//i.test(value))
+
+  if (!references.length) {
+    throw new Error('Pass one or more exact GitHub SKILL.md URLs.')
+  }
+
+  for (const reference of references) {
+    const result = await syncRepositorySkills({
+      reference,
+      discoverySource: 'x-skill-radar',
+      maxSkills: 1,
+      refreshExisting: true,
+    })
+
+    const entry = result.entries[0]
+    console.log(JSON.stringify({
+      reference,
+      status: entry?.status || 'skipped',
+      slug: entry?.slug || null,
+      reason: entry?.reason || null,
+    }))
+  }
+}
+
+void main()

--- a/scripts/publish-x-trend-roundup.ts
+++ b/scripts/publish-x-trend-roundup.ts
@@ -1,0 +1,55 @@
+import { createPublicClient } from '../lib/supabase/public'
+import { enqueueXSkillPostQueueForSlugs, postNextQueuedSkillToX } from '../lib/x/growth'
+
+async function main() {
+  const serverSecret = (process.env.INDEXER_SECRET || '').trim()
+  const postText = (process.env.X_TREND_POST_TEXT || '').trim()
+  const roundupSlug = (process.env.X_TREND_SLUG || '').trim()
+  const sourceUrl = (process.env.X_TREND_SOURCE_URL || '').trim()
+  const followupSlugs = (process.env.X_FOLLOWUP_SKILL_SLUGS || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+
+  if (!serverSecret) throw new Error('Missing INDEXER_SECRET.')
+  if (!postText || postText.length > 280) throw new Error('X_TREND_POST_TEXT must contain 1-280 characters.')
+  if (!roundupSlug) throw new Error('Missing X_TREND_SLUG.')
+
+  const supabase = createPublicClient()
+  const { data: queuedRoundup, error: queueError } = await supabase.rpc('enqueue_x_content_queue_item', {
+    p_server_secret: serverSecret,
+    p_item: {
+      skill_id: null,
+      skill_slug: roundupSlug,
+      content_type: 'launch_update',
+      campaign: 'x_trend_roundup',
+      status: 'queued',
+      priority: 1000,
+      scheduled_for: new Date().toISOString(),
+      post_text: postText,
+      reply_text: null,
+      source: 'x_trend_editorial',
+      metadata: {
+        generated_by: 'x_growth_os',
+        source_url: sourceUrl || null,
+        content_format: 'trend_roundup',
+        followup_skill_slugs: followupSlugs,
+      },
+    },
+  })
+  if (queueError) throw new Error(`Failed to queue trend roundup: ${queueError.message}`)
+
+  const published = await postNextQueuedSkillToX({ autoBuildQueue: false })
+  const followups = followupSlugs.length
+    ? await enqueueXSkillPostQueueForSlugs({
+        slugs: followupSlugs,
+        minStars: 500,
+        campaign: 'anti_slop_followup',
+        limit: followupSlugs.length,
+      })
+    : null
+
+  console.log(JSON.stringify({ queuedRoundup, published, followups }))
+}
+
+void main()

--- a/scripts/test-x-automation-regressions.ts
+++ b/scripts/test-x-automation-regressions.ts
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url'
 // Node's type-stripping runner needs the explicit extension.
 // @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
 import { classifyXConnectionError } from '../lib/x/health.ts'
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
+import { parseSkillSourceUrl } from '../lib/indexer/skill-source-url.ts'
 
 const root = fileURLToPath(new URL('..', import.meta.url))
 const readProjectFile = (path: string) => readFileSync(`${root}/${path}`, 'utf8')
@@ -24,6 +26,23 @@ assert.equal(
   classifyXConnectionError(new Error('Failed to load X OAuth connection')).code,
   'connection_check_failed'
 )
+
+assert.deepEqual(parseSkillSourceUrl('https://www.skills.sh/petergyang/no-ai-slop/no-ai-slop'), {
+  owner: 'petergyang',
+  repo: 'no-ai-slop',
+  fullName: 'petergyang/no-ai-slop',
+  sourceUrl: 'https://www.skills.sh/petergyang/no-ai-slop/no-ai-slop',
+  directoryUrl: 'https://github.com/petergyang/no-ai-slop',
+  skillName: 'no-ai-slop',
+})
+assert.deepEqual(parseSkillSourceUrl('skills.sh/cursor/plugins/unslop'), {
+  owner: 'cursor',
+  repo: 'plugins',
+  fullName: 'cursor/plugins',
+  sourceUrl: 'https://skills.sh/cursor/plugins/unslop',
+  directoryUrl: 'https://github.com/cursor/plugins',
+  skillName: 'unslop',
+})
 
 const guardedSetupScripts = [
   'scripts/006_controlled_public_write_rpcs.sql',
@@ -79,5 +98,17 @@ assert.ok(
     postNextSource.indexOf('enqueueXSkillPostQueue({ limit:'),
   'queue refill must happen only after the existing queue is exhausted'
 )
+
+const radarSource = readProjectFile('lib/indexer/x-skill-radar.ts')
+assert.match(radarSource, /github\.com OR skills\.sh OR "GitHub"/)
+assert.match(radarSource, /function extractSkillRepos/)
+assert.match(radarSource, /requestedSkillName/)
+
+const candidateSource = readProjectFile('lib/x/candidates.ts')
+assert.match(candidateSource, /x-trend-override/)
+assert.match(candidateSource, /impression_count \|\| 0\) >= 100_000/)
+
+const processorSource = readProjectFile('lib/indexer/processor.ts')
+assert.match(processorSource, /skillNames: \[candidate\.requestedSkillName\]/)
 
 console.log('X automation regression tests passed.')


### PR DESCRIPTION
## Summary
- discover exact skills.sh and GitHub skill URLs from X trends
- preserve X engagement metadata and apply trend-aware queue eligibility
- import exact requested skills from multi-skill repositories
- add operational import and X roundup publishing scripts

## Verification
- pnpm run test
- pnpm run typecheck
- pnpm run build
- targeted ESLint