### PR TITLE
feat: add GitHub popularity leaderboard

### DIFF
--- a/app/rankings/[slug]/page.tsx
+++ b/app/rankings/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { InstallCommand } from '@/components/install-command'
 import { getAgentProvenProfile } from '@/lib/agent-proven'
 import { SiteFooter } from '@/components/site-footer'
 import { SiteHeader } from '@/components/site-header'
+import { GitHubOwnerAvatar } from '@/components/github-owner-avatar'
+import { getGitHubOwner } from '@/lib/github-owner'
 import {
   convertSkillRecordToManifest,
   getAgentOutcomeStatsMap,
@@ -186,10 +188,14 @@ export default async function RankingDetailPage({
                   : null
                 const proven = getAgentProvenProfile(outcomeStats)
                 const movement = rankMovement.get(skill.slug) || 0
+                const githubOwner = getGitHubOwner(skill)
 
                 return (
                   <article key={skill.slug} className="grid gap-5 py-7 lg:grid-cols-[auto_1fr_auto]">
-                    <div className="font-mono text-2xl text-secondary tabular-nums">#{item.rank}</div>
+                    <div className="flex items-center gap-3 lg:flex-col lg:items-start">
+                      <div className="font-mono text-2xl text-secondary tabular-nums">#{item.rank}</div>
+                      <GitHubOwnerAvatar owner={githubOwner} label={skill.author_name} size="lg" />
+                    </div>
                     <div className="min-w-0">
                       <div className="mb-2 flex flex-wrap items-center gap-2">
                         <Link href={`/skills/${skill.slug}`} className="min-w-0">
@@ -206,6 +212,7 @@ export default async function RankingDetailPage({
                         <span className="border border-border px-2 py-0.5 text-xs font-mono text-secondary">
                           {quality.label} · {quality.score}
                         </span>
+                        {githubOwner ? <span className="font-mono text-xs text-secondary">@{githubOwner}</span> : null}
                         {ranking.kind === 'agent-usage' || ranking.kind === 'success-rate' || ranking.kind === 'safe-auto-install' ? (
                           <span className="border border-[#c8ded5] bg-[#eef7f2] px-2 py-0.5 text-xs font-mono text-[#006b4f]">
                             {proven.score}/100 proven

--- a/app/rankings/agent-proven/page.tsx
+++ b/app/rankings/agent-proven/page.tsx
@@ -25,6 +25,8 @@ import { getAgentProvenProfile } from '@/lib/agent-proven'
 import { formatCompactNumber, getSkillQualityProfile } from '@/lib/quality'
 import { getRankingCompareHref, getRankingDefinition, rankSkillsForDefinition } from '@/lib/rankings'
 import { getSkillTrustProfile } from '@/lib/trust'
+import { GitHubOwnerAvatar } from '@/components/github-owner-avatar'
+import { getGitHubOwner } from '@/lib/github-owner'
 
 export const dynamic = 'force-dynamic'
 
@@ -103,10 +105,14 @@ function SkillEvidenceRow({
   const trust = getSkillTrustProfile(skill, false, eventStats, stats)
   const proven = getAgentProvenProfile(stats)
   const hasOutcomeReports = Number(stats?.total_outcomes || 0) > 0
+  const githubOwner = getGitHubOwner(skill)
 
   return (
     <article className="grid gap-5 border-t border-border py-6 first:border-t-0 lg:grid-cols-[72px_1fr_290px]">
-      <div className="font-mono text-2xl text-secondary tabular-nums">#{rank}</div>
+      <div className="flex items-center gap-3 lg:flex-col lg:items-start">
+        <div className="font-mono text-2xl text-secondary tabular-nums">#{rank}</div>
+        <GitHubOwnerAvatar owner={githubOwner} label={skill.author_name} size="lg" />
+      </div>
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
           <Link href={`/skills/${skill.slug}`} className="min-w-0">
@@ -116,6 +122,7 @@ function SkillEvidenceRow({
           </Link>
           <EvidencePill>{proven.score}/100 proven</EvidencePill>
           <EvidencePill>{trust.score}/100 Trust</EvidencePill>
+          {githubOwner ? <span className="font-mono text-xs text-secondary">@{githubOwner}</span> : null}
         </div>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-secondary">{skill.description}</p>
         <p className="mt-3 max-w-3xl text-sm leading-6">{reason}</p>

--- a/app/rankings/page.tsx
+++ b/app/rankings/page.tsx
@@ -11,6 +11,7 @@ import {
 import { formatCompactNumber } from '@/lib/quality'
 import { CORE_RANKINGS, getRankingDefinitions, rankSkillsForDefinition, type RankingDefinition } from '@/lib/rankings'
 import { getLatestRankingSnapshot, RANKING_METHODOLOGY_VERSION } from '@/lib/ranking-snapshots'
+import { GitHubPopularityList } from '@/components/github-popularity-list'
 
 export const dynamic = 'force-dynamic'
 
@@ -46,6 +47,10 @@ export default async function RankingsPage() {
   ])
   const rankingDefinitions = getRankingDefinitions()
   const useCaseRankings = rankingDefinitions.filter((ranking) => ranking.kind === 'use-case')
+  const popularityRanking = CORE_RANKINGS.find((ranking) => ranking.kind === 'most-starred')
+  const popularSkills = popularityRanking
+    ? rankSkillsForDefinition(skills, popularityRanking, statsMap, 10)
+    : []
 
   return (
     <MarketingPageShell>
@@ -92,7 +97,67 @@ export default async function RankingsPage() {
           </div>
         </section>
 
-        <section className="grid gap-5 border-b border-border py-10 md:grid-cols-2 lg:grid-cols-3">
+        <section className="border-b border-border py-10">
+          <div className="mb-6 flex flex-col justify-between gap-5 md:flex-row md:items-end">
+            <div>
+              <p className="text-xs uppercase tracking-widest text-secondary">Default popularity ranking</p>
+              <h2 className="mt-3 font-display text-3xl font-semibold">Most-starred agent skill projects</h2>
+              <p className="mt-3 max-w-2xl text-sm leading-relaxed text-secondary">
+                GitHub stars are the clearest public popularity signal. We rank by stars here, while filtering out repositories that do not look like installable agent skills.
+              </p>
+            </div>
+            <Link
+              href="/rankings/most-starred-agent-skills"
+              className="shrink-0 text-sm text-secondary underline underline-offset-4 hover:text-foreground"
+            >
+              Open full popularity ranking
+            </Link>
+          </div>
+
+          <nav className="mb-6 flex gap-2 overflow-x-auto pb-1" aria-label="Ranking views">
+            {[
+              ['/rankings/most-starred-agent-skills', 'Most starred'],
+              ['/trending', 'Trending'],
+              ['/rankings/new-agent-skills-this-week', 'New this week'],
+              ['/rankings/highest-quality-agent-skills', 'Quality'],
+              ['/rankings/agent-proven', 'Agent proven'],
+            ].map(([href, label], index) => (
+              <Link
+                key={href}
+                href={href}
+                className={`shrink-0 rounded-full border px-3.5 py-2 text-xs font-semibold transition-colors ${
+                  index === 0
+                    ? 'border-[#006b4f] bg-[#006b4f] text-white'
+                    : 'border-border bg-background text-secondary hover:border-[#006b4f] hover:text-[#006b4f]'
+                }`}
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+
+          <GitHubPopularityList
+            items={popularSkills.map((item) => ({
+              rank: item.rank,
+              slug: item.skill.slug,
+              name: item.skill.name,
+              description: item.skill.description,
+              githubStars: item.skill.github_stars,
+              githubRepo: item.skill.github_repo,
+              authorName: item.skill.author_name,
+              badge: item.badge,
+              reason: item.reason,
+              category: item.skill.category,
+            }))}
+          />
+        </section>
+
+        <section className="border-b border-border py-10">
+          <div className="mb-6">
+            <p className="text-xs uppercase tracking-widest text-secondary">More ranking lenses</p>
+            <h2 className="mt-3 font-display text-2xl font-semibold">Popularity is the default, not the only decision signal.</h2>
+          </div>
+          <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
           {CORE_RANKINGS.map((ranking) => {
             const topSkills = rankSkillsForDefinition(
               skills,
@@ -129,6 +194,7 @@ export default async function RankingsPage() {
               </Link>
             )
           })}
+          </div>
         </section>
 
         <section className="grid gap-8 border-b border-border py-10 lg:grid-cols-[0.65fr_1.35fr]">

--- a/components/github-owner-avatar.tsx
+++ b/components/github-owner-avatar.tsx
@@ -1,0 +1,71 @@
+import { getGitHubAvatarUrl, getGitHubOwnerUrl } from '@/lib/github-owner'
+
+const AVATAR_SIZES = {
+  sm: 'h-8 w-8 text-[10px]',
+  md: 'h-10 w-10 text-xs',
+  lg: 'h-12 w-12 text-sm',
+} as const
+
+export function GitHubOwnerAvatar({
+  owner,
+  label,
+  size = 'md',
+  showLabel = false,
+  linked = true,
+  className = '',
+}: {
+  owner: string | null | undefined
+  label?: string | null
+  size?: keyof typeof AVATAR_SIZES
+  showLabel?: boolean
+  linked?: boolean
+  className?: string
+}) {
+  const normalizedOwner = (owner || '').trim()
+  const displayLabel = (label || normalizedOwner || 'GitHub').trim()
+  const avatar = (
+    <span
+      className={`relative grid shrink-0 place-items-center overflow-hidden rounded-full border border-border bg-card font-mono font-semibold uppercase text-secondary ${AVATAR_SIZES[size]}`}
+      aria-hidden="true"
+    >
+      <span>{displayLabel.slice(0, 1)}</span>
+      {normalizedOwner ? (
+        // GitHub serves a stable owner avatar or identicon from this URL.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={getGitHubAvatarUrl(normalizedOwner, size === 'lg' ? 96 : 80)}
+          alt=""
+          loading="lazy"
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+      ) : null}
+    </span>
+  )
+
+  const contents = (
+    <>
+      {avatar}
+      {showLabel ? (
+        <span className="min-w-0 truncate font-mono text-xs text-secondary">
+          @{normalizedOwner || displayLabel}
+        </span>
+      ) : null}
+    </>
+  )
+
+  if (!normalizedOwner || !linked) {
+    return <span className={`inline-flex min-w-0 items-center gap-2 ${className}`}>{contents}</span>
+  }
+
+  return (
+    <a
+      href={getGitHubOwnerUrl(normalizedOwner)}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`inline-flex min-w-0 items-center gap-2 transition-opacity hover:opacity-75 ${className}`}
+      aria-label={`Open ${normalizedOwner} on GitHub`}
+    >
+      {contents}
+    </a>
+  )
+}

--- a/components/github-popularity-list.tsx
+++ b/components/github-popularity-list.tsx
@@ -1,0 +1,90 @@
+import { ArrowRight } from 'lucide-react'
+import Link from 'next/link'
+import { GitHubOwnerAvatar } from '@/components/github-owner-avatar'
+import { getGitHubOwner } from '@/lib/github-owner'
+import { formatCompactNumber } from '@/lib/quality'
+
+export interface GitHubPopularityItem {
+  rank: number
+  slug: string
+  name: string
+  description: string
+  githubStars: number
+  githubRepo?: string | null
+  githubOwner?: string | null
+  authorName?: string | null
+  badge?: string | null
+  reason?: string | null
+  category?: string | null
+}
+
+export function GitHubPopularityList({
+  items,
+  compact = false,
+}: {
+  items: GitHubPopularityItem[]
+  compact?: boolean
+}) {
+  return (
+    <ol className="overflow-hidden rounded-[10px] border border-border bg-background">
+      {items.map((item) => {
+        const owner = item.githubOwner || getGitHubOwner({ github_repo: item.githubRepo })
+        const ownerLabel = owner || item.authorName || 'GitHub creator'
+
+        return (
+          <li
+            key={item.slug}
+            className="grid gap-4 border-t border-border px-4 py-5 first:border-t-0 sm:grid-cols-[44px_48px_minmax(0,1fr)_auto] sm:items-center sm:px-5"
+          >
+            <span
+              className={`grid h-9 w-9 place-items-center rounded-full font-mono text-xs font-semibold tabular-nums ${
+                item.rank <= 3 ? 'bg-[#006b4f] text-white' : 'border border-border text-secondary'
+              }`}
+            >
+              {item.rank}
+            </span>
+
+            <GitHubOwnerAvatar owner={owner} label={item.authorName || ownerLabel} size="lg" />
+
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <Link href={`/skills/${item.slug}`} className="min-w-0">
+                  <h3 className="truncate text-base font-semibold leading-tight transition-colors hover:text-[#006b4f] sm:text-lg">
+                    {item.name}
+                  </h3>
+                </Link>
+                <span className="font-mono text-[11px] text-secondary">@{ownerLabel}</span>
+                {item.category ? (
+                  <span className="rounded-full border border-border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-secondary">
+                    {item.category}
+                  </span>
+                ) : null}
+              </div>
+              {!compact ? (
+                <p className="mt-1 line-clamp-1 text-sm leading-6 text-secondary">
+                  {item.reason || item.description}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="col-span-2 flex items-center justify-between gap-4 pl-[60px] sm:col-span-1 sm:pl-0">
+              <div className="text-right">
+                <div className="font-mono text-lg font-semibold tabular-nums">
+                  {formatCompactNumber(item.githubStars || 0)}
+                </div>
+                <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-secondary">GitHub stars</div>
+              </div>
+              <Link
+                href={`/skills/${item.slug}`}
+                aria-label={`Open ${item.name}`}
+                className="grid h-9 w-9 place-items-center rounded-full border border-border text-secondary transition-colors hover:border-[#006b4f] hover:text-[#006b4f]"
+              >
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </div>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/components/growth-skill-list.tsx
+++ b/components/growth-skill-list.tsx
@@ -4,6 +4,8 @@ import { convertSkillRecordToManifest } from '@/lib/db/skills'
 import { formatCompactNumber, getPlatformHints, getSkillQualityProfile } from '@/lib/quality'
 import type { GrowthRankedSkill } from '@/lib/seo/growth-directories'
 import { getSkillTrustProfile } from '@/lib/trust'
+import { GitHubOwnerAvatar } from '@/components/github-owner-avatar'
+import { getGitHubOwner } from '@/lib/github-owner'
 
 function formatDate(value: string | null | undefined) {
   if (!value) return 'Unknown'
@@ -41,6 +43,7 @@ export function GrowthSkillList({
         const manifest = convertSkillRecordToManifest(skill)
         const quality = getSkillQualityProfile(skill)
         const trust = getSkillTrustProfile(skill)
+        const githubOwner = getGitHubOwner(skill)
         const platforms = [...new Set([...(skill.frameworks || []), ...getPlatformHints(skill)])]
         const compareSlugs = [
           skill.slug,
@@ -49,7 +52,10 @@ export function GrowthSkillList({
 
         return (
           <article key={skill.slug} className="grid gap-5 py-7 lg:grid-cols-[auto_1fr_280px]">
-            <div className="font-mono text-2xl text-secondary tabular-nums">#{item.rank}</div>
+            <div className="flex items-center gap-3 lg:flex-col lg:items-start">
+              <div className="font-mono text-2xl text-secondary tabular-nums">#{item.rank}</div>
+              <GitHubOwnerAvatar owner={githubOwner} label={skill.author_name} size="lg" />
+            </div>
             <div className="min-w-0">
               <div className="mb-2 flex flex-wrap items-center gap-2">
                 <Link href={`/skills/${skill.slug}`} className="min-w-0">
@@ -66,6 +72,9 @@ export function GrowthSkillList({
                 <span className="border border-border px-2 py-0.5 font-mono text-xs text-secondary">
                   {quality.label} {quality.score}
                 </span>
+                {githubOwner ? (
+                  <span className="font-mono text-xs text-secondary">@{githubOwner}</span>
+                ) : null}
               </div>
               <p className="max-w-3xl text-sm leading-relaxed text-secondary">{skill.description}</p>
               <p className="mt-3 max-w-3xl text-sm leading-relaxed">{item.reason}</p>

--- a/components/home-page-enhanced.tsx
+++ b/components/home-page-enhanced.tsx
@@ -8,6 +8,7 @@ import { useI18n } from '@/lib/i18n/context'
 import { USE_CASES } from '@/lib/use-cases'
 import { SiteFooter } from './site-footer'
 import { SiteHeader } from './site-header'
+import { GitHubPopularityList } from './github-popularity-list'
 
 interface HomePageEnhancedProps {
   initialLocale?: Locale
@@ -37,6 +38,9 @@ interface HomePageEnhancedProps {
     badge: string
     reason: string
     category: string
+    github_repo: string
+    github_owner: string
+    author_name: string | null
   }>
   rankingGeneratedAt: string | null
 }
@@ -933,15 +937,15 @@ export function HomePageEnhanced({ initialLocale, stats, featuredSkills, ranking
         <div className="mx-auto max-w-6xl">
           <div className="flex flex-col gap-5 md:flex-row md:items-end md:justify-between">
             <div>
-              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#6d675e]">Daily leaderboards</p>
+              <p className="font-mono text-xs uppercase tracking-[0.18em] text-[#6d675e]">GitHub popularity leaderboard</p>
               <h2
                 className="mt-3 text-3xl font-normal leading-tight tracking-normal md:text-5xl"
                 style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
               >
-                Skills moving now, ranked with evidence.
+                The most-starred agent skill projects.
               </h2>
               <p className="mt-4 max-w-2xl text-sm leading-relaxed text-[#5f5a52] md:text-base">
-                Daily snapshots combine capped activity signals, quality, trust, GitHub adoption, and real agent outcomes.
+                Popularity starts with GitHub stars, then OpenAgentSkill filters out weak skill matches and keeps trust signals visible before install.
               </p>
             </div>
             <div className="flex flex-wrap items-center gap-3">
@@ -968,10 +972,11 @@ export function HomePageEnhanced({ initialLocale, stats, featuredSkills, ranking
 
           <nav className="mt-7 flex gap-2 overflow-x-auto pb-1" aria-label="Leaderboard views">
             {[
+              ['/rankings/most-starred-agent-skills', 'Most starred'],
               ['/trending', 'Trending'],
-              ['/rankings/agent-proven', 'Agent proven'],
-              ['/rankings/safest-auto-install-skills', 'Safe install'],
               ['/rankings/new-agent-skills-this-week', 'New this week'],
+              ['/rankings/highest-quality-agent-skills', 'Quality'],
+              ['/rankings/agent-proven', 'Agent proven'],
             ].map(([href, label], index) => (
               <Link
                 key={href}
@@ -988,26 +993,23 @@ export function HomePageEnhanced({ initialLocale, stats, featuredSkills, ranking
           </nav>
 
           {featuredSkills.length > 0 ? (
-            <ol className="mt-6 grid gap-px overflow-hidden rounded-[10px] border border-[#d8d2c6] bg-[#d8d2c6] sm:grid-cols-2 lg:grid-cols-5">
-              {featuredSkills.map((skill) => (
-                <li key={skill.slug} className="min-w-0 bg-[#fffdf8]">
-                  <Link href={`/skills/${skill.slug}`} className="group flex h-full min-h-56 flex-col p-5 transition-colors hover:bg-[#f7f4ec]">
-                    <div className="flex items-center justify-between gap-3">
-                      <span className="grid h-8 w-8 place-items-center rounded-full bg-[#006b4f] font-mono text-xs font-semibold text-white">
-                        {skill.rank}
-                      </span>
-                      <span className="truncate font-mono text-[10px] uppercase tracking-[0.12em] text-[#6d675e]">{skill.category}</span>
-                    </div>
-                    <h3 className="mt-5 line-clamp-2 text-lg font-semibold leading-tight group-hover:text-[#006b4f]">{skill.name}</h3>
-                    <p className="mt-2 line-clamp-3 text-xs leading-relaxed text-[#5f5a52]">{skill.reason || skill.description}</p>
-                    <div className="mt-auto flex items-end justify-between gap-3 pt-5 font-mono text-[11px] text-[#6d675e]">
-                      <span>{formatCompact(skill.github_stars)} stars</span>
-                      <span className="max-w-[9rem] truncate text-right">{skill.badge}</span>
-                    </div>
-                  </Link>
-                </li>
-              ))}
-            </ol>
+            <div className="mt-6">
+              <GitHubPopularityList
+                items={featuredSkills.map((skill) => ({
+                  rank: skill.rank,
+                  slug: skill.slug,
+                  name: skill.name,
+                  description: skill.description,
+                  githubStars: skill.github_stars,
+                  githubRepo: skill.github_repo,
+                  githubOwner: skill.github_owner,
+                  authorName: skill.author_name,
+                  badge: skill.badge,
+                  reason: skill.reason,
+                  category: skill.category,
+                }))}
+              />
+            </div>
           ) : (
             <div className="mt-6 rounded-[10px] border border-dashed border-[#d8d2c6] bg-[#fffdf8] p-6 text-sm leading-relaxed text-[#5f5a52]">
               The first daily leaderboard snapshot is being generated. Browse the live rankings while the scheduled snapshot is prepared.

--- a/lib/github-owner.ts
+++ b/lib/github-owner.ts
@@ -1,0 +1,58 @@
+export interface GitHubOwnerSource {
+  github_repo?: string | null
+  repository?: string | null
+  publisher_github?: string | null
+  author_url?: string | null
+}
+
+const RESERVED_GITHUB_PATHS = new Set([
+  'about',
+  'apps',
+  'collections',
+  'enterprise',
+  'explore',
+  'features',
+  'marketplace',
+  'orgs',
+  'pricing',
+  'search',
+  'settings',
+  'site',
+  'sponsors',
+  'topics',
+])
+
+function normalizeOwnerCandidate(value: string | null | undefined, requireGithubUrl = false) {
+  const trimmed = (value || '').trim()
+  if (!trimmed) return ''
+  if (requireGithubUrl && !/^(?:https?:\/\/)?(?:www\.)?github\.com\//i.test(trimmed)) return ''
+
+  const normalized = trimmed
+    .replace(/^https?:\/\/(?:www\.)?github\.com\//i, '')
+    .replace(/^github\.com\//i, '')
+    .replace(/^@/, '')
+    .split(/[/?#]/)[0]
+    ?.trim()
+
+  if (!normalized || !/^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$/.test(normalized)) return ''
+  if (RESERVED_GITHUB_PATHS.has(normalized.toLowerCase())) return ''
+  return normalized
+}
+
+export function getGitHubOwner(source: GitHubOwnerSource) {
+  return (
+    normalizeOwnerCandidate(source.github_repo) ||
+    normalizeOwnerCandidate(source.repository, true) ||
+    normalizeOwnerCandidate(source.publisher_github) ||
+    normalizeOwnerCandidate(source.author_url, true)
+  )
+}
+
+export function getGitHubOwnerUrl(owner: string) {
+  return `https://github.com/${encodeURIComponent(owner)}`
+}
+
+export function getGitHubAvatarUrl(owner: string, size = 96) {
+  const normalizedSize = Math.min(460, Math.max(32, Math.round(size)))
+  return `${getGitHubOwnerUrl(owner)}.png?size=${normalizedSize}`
+}

--- a/lib/home-page-data.ts
+++ b/lib/home-page-data.ts
@@ -5,6 +5,7 @@ import {
 } from '@/lib/registry-stats'
 import { getAgentOutcomeStatsMapStrict } from '@/lib/db/skills'
 import { getLatestRankingSnapshot } from '@/lib/ranking-snapshots'
+import { getGitHubOwner } from '@/lib/github-owner'
 
 const HOME_STATS_SNAPSHOT = {
   // The last exact count observed before the registry stats cache was added.
@@ -77,11 +78,13 @@ const getCachedEvidenceStats = unstable_cache(
 )
 
 export async function getHomePageData() {
-  const [totalSkills, evidence, trendingSnapshot] = await Promise.all([
+  const [totalSkills, evidence, popularitySnapshot, trendingSnapshot] = await Promise.all([
     getCachedApprovedSkillCount(),
     getCachedEvidenceStats(),
+    getLatestRankingSnapshot('most-starred-agent-skills'),
     getLatestRankingSnapshot('trending'),
   ])
+  const leaderboardSnapshot = popularitySnapshot || trendingSnapshot
 
   return {
     stats: {
@@ -91,17 +94,23 @@ export async function getHomePageData() {
       totalSkillsExact: totalSkills.exact,
     },
     activities: [],
-    featuredSkills: (trendingSnapshot?.items || []).slice(0, 5).map((item) => ({
-      slug: item.slug,
-      name: item.name,
-      description: item.description,
-      github_stars: item.github_stars,
-      downloads: 0,
-      rank: item.rank,
-      badge: item.badge,
-      reason: item.reason,
-      category: item.category,
-    })),
-    rankingGeneratedAt: trendingSnapshot?.generated_at || null,
+    featuredSkills: [...(leaderboardSnapshot?.items || [])]
+      .sort((a, b) => Number(b.github_stars || 0) - Number(a.github_stars || 0))
+      .slice(0, 10)
+      .map((item, index) => ({
+        slug: item.slug,
+        name: item.name,
+        description: item.description,
+        github_stars: item.github_stars,
+        downloads: 0,
+        rank: index + 1,
+        badge: item.badge,
+        reason: item.reason,
+        category: item.category,
+        github_repo: item.repository,
+        github_owner: item.github_owner || getGitHubOwner({ repository: item.repository }),
+        author_name: item.author_name || null,
+      })),
+    rankingGeneratedAt: leaderboardSnapshot?.generated_at || null,
   }
 }

--- a/lib/ranking-snapshots.ts
+++ b/lib/ranking-snapshots.ts
@@ -20,10 +20,11 @@ import {
   type RankingDefinition,
 } from '@/lib/rankings'
 import { rankHotSkills, rankTrendingSkills, type GrowthRankedSkill } from '@/lib/seo/growth-directories'
+import { getGitHubOwner } from '@/lib/github-owner'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createPublicClient } from '@/lib/supabase/public'
 
-export const RANKING_METHODOLOGY_VERSION = 'ranking-v2-daily-2026-08'
+export const RANKING_METHODOLOGY_VERSION = 'ranking-v3-daily-2026-08'
 const SNAPSHOT_ITEM_LIMIT = 30
 const SNAPSHOT_RETENTION_DAYS = 90
 
@@ -42,6 +43,8 @@ export interface RankingSnapshotItem {
   install: string
   repository: string
   updated_at: string
+  github_owner?: string
+  author_name?: string
 }
 
 export interface RankingSnapshot {
@@ -84,6 +87,8 @@ function serializeRankedSkill(item: RankedSkill | GrowthRankedSkill): RankingSna
     install: item.skill.install_command || `npx skills add ${item.skill.github_repo}`,
     repository: item.skill.repository || `https://github.com/${item.skill.github_repo}`,
     updated_at: item.skill.github_last_pushed_at || item.skill.updated_at,
+    github_owner: getGitHubOwner(item.skill),
+    author_name: item.skill.author_name,
   }
 }
 

--- a/lib/rankings.ts
+++ b/lib/rankings.ts
@@ -60,7 +60,7 @@ export const CORE_RANKINGS: RankingDefinition[] = [
     shortTitle: 'Most starred',
     eyebrow: 'GitHub adoption',
     description:
-      'The highest-starred skill candidates in OpenAgentSkill, filtered to avoid MCP protocol-server projects.',
+      'Skill candidates ordered by public GitHub star count, after filtering repositories that do not look like installable agent skills.',
     kind: 'most-starred',
   },
   {
@@ -306,7 +306,10 @@ export function rankSkillsForDefinition(
         case 'most-starred':
           return {
             skill,
-            score: Number(skill.github_stars || 0) - skillSpecificPenalty * 10_000,
+            // Popularity is intentionally literal on this ranking. Repositories
+            // that fail the skill-likeness gate are filtered below; qualifying
+            // projects are then ordered by their public GitHub star count.
+            score: Number(skill.github_stars || 0),
             badge: compactStars(skill),
             reason: `${compactStars(skill)} and ${quality.label.toLowerCase()} quality signals.`,
           }

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     "test:supabase-circuit": "node --experimental-strip-types scripts/test-supabase-circuit.ts",
     "test:security": "node --experimental-strip-types scripts/test-security-regressions.ts",
     "test:x-automation": "node --experimental-strip-types scripts/test-x-automation-regressions.ts",
+    "test:github-owner": "node --experimental-strip-types scripts/test-github-owner.ts",
     "test:cli": "node packages/cli/openagentskill.mjs --help",
     "test:sdk": "node scripts/test-sdk.mjs",
     "test:links": "node scripts/check-repository-links.mjs",
     "test:links:external": "node scripts/check-repository-links.mjs --external",
-    "test": "pnpm run test:submission && pnpm run test:submission-discovery && pnpm run test:supabase-circuit && pnpm run test:security && pnpm run test:x-automation && pnpm run test:cli && pnpm run test:sdk",
+    "test": "pnpm run test:submission && pnpm run test:submission-discovery && pnpm run test:supabase-circuit && pnpm run test:security && pnpm run test:x-automation && pnpm run test:github-owner && pnpm run test:cli && pnpm run test:sdk",
     "typecheck": "next typegen && tsc --noEmit",
     "lint": "eslint ."
   },

--- a/scripts/test-github-owner.ts
+++ b/scripts/test-github-owner.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+// Node's type-stripping runner needs the explicit extension; the app compiler resolves the same module by alias.
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
+import { getGitHubAvatarUrl, getGitHubOwner, getGitHubOwnerUrl } from '../lib/github-owner.ts'
+
+assert.equal(getGitHubOwner({ github_repo: 'furkankly/zoetrope' }), 'furkankly')
+assert.equal(
+  getGitHubOwner({ repository: 'https://github.com/Leon-Drq/openagentskill/tree/main/skills/example' }),
+  'Leon-Drq'
+)
+assert.equal(getGitHubOwner({ publisher_github: '@openai' }), 'openai')
+assert.equal(getGitHubOwner({ author_url: 'https://x.com/openagentskill' }), '')
+assert.equal(getGitHubOwner({ github_repo: 'topics/agent-skills' }), '')
+assert.equal(getGitHubOwnerUrl('Leon-Drq'), 'https://github.com/Leon-Drq')
+assert.equal(getGitHubAvatarUrl('Leon-Drq', 12), 'https://github.com/Leon-Drq.png?size=32')
+
+console.log('GitHub owner identity tests passed')


### PR DESCRIPTION
## Summary
- make GitHub stars the default popularity ranking while preserving trend, freshness, quality, and outcome lenses
- replace the homepage ranking card grid with a single-column top-10 leaderboard
- add reusable GitHub owner avatars to trending, new, ranking, and agent-proven rows
- persist owner identity in daily ranking snapshots and add regression coverage

## Verification
- pnpm run test
- pnpm run typecheck
- pnpm run build
- targeted ESLint