### PR TITLE
Fix skill detail date hydration

### DIFF
--- a/components/skill-detail-text.tsx
+++ b/components/skill-detail-text.tsx
@@ -46,5 +46,6 @@ export function SkillDetailDate({ value }: { value: string | null | undefined })
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   })}</>
 }


### PR DESCRIPTION
## Summary
- format localized skill dates in UTC so server and client render identical values
- remove the production hydration warning found during browser verification of the redesigned skill detail page

## Verification
- pnpm exec eslint components/skill-detail-text.tsx --quiet
- pnpm run typecheck
- pnpm run build