### PR TITLE
Add clipboard fallback for skill actions

### DIFF
--- a/components/creator-badge-kit.tsx
+++ b/components/creator-badge-kit.tsx
@@ -5,6 +5,7 @@ import { Check, Copy, ExternalLink } from 'lucide-react'
 import { SkillDetailLink as Link } from '@/components/skill-detail-link'
 import { useI18n } from '@/lib/i18n/context'
 import { formatSkillDetailCopy } from '@/lib/i18n/skill-detail-copy'
+import { copyText } from '@/lib/copy-text'
 
 interface CreatorBadgeKitProps {
   skillSlug: string
@@ -27,7 +28,8 @@ export function CreatorBadgeKit({ skillSlug }: CreatorBadgeKitProps) {
 
   async function copyBadges() {
     try {
-      await navigator.clipboard.writeText(markdown)
+      const didCopy = await copyText(markdown)
+      if (!didCopy) throw new Error('Clipboard is unavailable')
       setCopied(true)
       window.setTimeout(() => setCopied(false), 1_800)
     } catch {

--- a/components/install-command.tsx
+++ b/components/install-command.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { trackSkillEvent } from '@/components/skill-event-tracker'
 import { useI18n } from '@/lib/i18n/context'
 import { formatSkillDetailCopy } from '@/lib/i18n/skill-detail-copy'
+import { copyText } from '@/lib/copy-text'
 
 interface InstallCommandProps {
   command: string
@@ -19,7 +20,8 @@ export function InstallCommand({ command, skillSlug, compact = false }: InstallC
 
   const copyToClipboard = async () => {
     try {
-      await navigator.clipboard.writeText(fullCommand)
+      const copied = await copyText(fullCommand)
+      if (!copied) throw new Error('Clipboard is unavailable')
       trackSkillEvent(skillSlug, 'install_copy', { command: fullCommand })
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)

--- a/components/skill-install-targets.tsx
+++ b/components/skill-install-targets.tsx
@@ -7,6 +7,7 @@ import { SkillDetailValue } from '@/components/skill-detail-text'
 import { useI18n } from '@/lib/i18n/context'
 import { formatSkillDetailCopy } from '@/lib/i18n/skill-detail-copy'
 import type { SkillInstallTarget } from '@/lib/install-targets'
+import { copyText } from '@/lib/copy-text'
 import { cn } from '@/lib/utils'
 
 interface SkillInstallTargetsProps {
@@ -25,7 +26,8 @@ export function SkillInstallTargets({ skillSlug, targets, compact = false }: Ski
 
   async function copyTarget(target: SkillInstallTarget) {
     try {
-      await navigator.clipboard.writeText(target.value)
+      const copied = await copyText(target.value)
+      if (!copied) throw new Error('Clipboard is unavailable')
       trackSkillEvent(skillSlug, 'install_copy', { target: target.id, kind: target.kind })
       setCopiedId(target.id)
       setTimeout(() => setCopiedId(null), 1800)

--- a/components/skill-share-button.tsx
+++ b/components/skill-share-button.tsx
@@ -4,6 +4,7 @@ import { Check, Share2 } from 'lucide-react'
 import { useState } from 'react'
 import { trackSkillEvent } from '@/components/skill-event-tracker'
 import { SkillDetailValue } from '@/components/skill-detail-text'
+import { copyText } from '@/lib/copy-text'
 
 export function SkillShareButton({
   skillSlug,
@@ -27,7 +28,8 @@ export function SkillShareButton({
           url,
         })
       } else {
-        await navigator.clipboard.writeText(url)
+        const copied = await copyText(url)
+        if (!copied) throw new Error('Clipboard is unavailable')
       }
 
       trackSkillEvent(skillSlug, 'share_copy', { placement: 'skill_hero' })

--- a/components/skill-x-share-panel.tsx
+++ b/components/skill-x-share-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Check, Copy, ExternalLink } from 'lucide-react'
 import { useI18n } from '@/lib/i18n/context'
 import { formatSkillDetailCopy } from '@/lib/i18n/skill-detail-copy'
+import { copyText } from '@/lib/copy-text'
 
 interface SkillXSharePanelProps {
   skillName: string
@@ -24,7 +25,8 @@ export function SkillXSharePanel({
   const [copied, setCopied] = useState<string | null>(null)
 
   async function copy(value: string, key: string) {
-    await navigator.clipboard.writeText(value)
+    const didCopy = await copyText(value)
+    if (!didCopy) return
     setCopied(key)
     window.setTimeout(() => setCopied(null), 1800)
   }

--- a/lib/copy-text.ts
+++ b/lib/copy-text.ts
@@ -1,0 +1,28 @@
+export async function copyText(text: string) {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // Fall through for embedded browsers and restricted clipboard policies.
+    }
+  }
+
+  if (typeof document === 'undefined') return false
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.left = '-9999px'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  textarea.setSelectionRange(0, textarea.value.length)
+
+  try {
+    return document.execCommand('copy')
+  } finally {
+    textarea.remove()
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared copy helper with a restricted-browser fallback
- use it for install prompts, README badges, share links, and X drafts
- preserve existing analytics and copied-state feedback

## Verification
- targeted ESLint
- pnpm run typecheck
- pnpm run build
- production browser verification will be repeated after merge