### PR TITLE
fix: normalize rankings and harden resolver fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ node_modules/
 tsconfig.tsbuildinfo
 .env*.local
 .DS_Store
+.codex-tmp/
 .vercel
 supabase/.temp/

--- a/app/api/agent/rankings/route.ts
+++ b/app/api/agent/rankings/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getAgentProvenProfile } from '@/lib/agent-proven'
 import { getAgentOutcomeStatsMap, getAllSkills, getSkillStats } from '@/lib/db/skills'
-import { getRankingDefinition, getRankingDefinitions, rankSkillsForDefinition, type RankingDefinition } from '@/lib/rankings'
+import { getRankingDefinition, getRankingDefinitions, normalizeRankingText, rankSkillsForDefinition, type RankingDefinition } from '@/lib/rankings'
 import { getLatestRankingSnapshot, RANKING_METHODOLOGY_VERSION } from '@/lib/ranking-snapshots'
+
+const JSON_UTF8_HEADERS = { 'Content-Type': 'application/json; charset=utf-8' }
 
 function clampLimit(value: string | null) {
   const parsed = Number(value || 10)
@@ -10,7 +12,7 @@ function clampLimit(value: string | null) {
 }
 
 function usesOutcomeStats(definition: RankingDefinition) {
-  return definition.kind === 'agent-usage' || definition.kind === 'success-rate' || definition.kind === 'safe-auto-install'
+  return ['highest-quality', 'agent-usage', 'success-rate', 'safe-auto-install', 'agent-platform'].includes(definition.kind)
 }
 
 export async function GET(request: NextRequest) {
@@ -29,7 +31,7 @@ export async function GET(request: NextRequest) {
           title: ranking.title,
           url: `https://www.openagentskill.com/rankings/${ranking.slug}`,
         })),
-      }, { status: 404 })
+      }, { status: 404, headers: JSON_UTF8_HEADERS })
     }
 
     const [skills, statsMap, latestSnapshot] = await Promise.all([
@@ -45,8 +47,8 @@ export async function GET(request: NextRequest) {
           const stats = statsMap[item.skill.slug]
           const proven = stats && 'total_outcomes' in stats ? getAgentProvenProfile(stats) : null
           return (
-        `${item.rank}. ${item.skill.name} (${item.skill.slug})\n` +
-        `   ${item.reason}\n` +
+        `${item.rank}. ${normalizeRankingText(item.skill.name)} (${item.skill.slug})\n` +
+        `   ${normalizeRankingText(item.reason)}\n` +
         (proven ? `   Agent Proven: ${proven.score}/100 ${proven.label} | Outcomes: ${proven.metrics.totalOutcomes} | Success: ${proven.metrics.successRate === null ? 'No data' : `${Math.round(proven.metrics.successRate)}%`}\n` : '') +
         `   Stars: ${item.skill.github_stars} | Quality: ${Math.round(Number(item.skill.quality_score || 0))}\n` +
         `   Install: ${item.skill.install_command || `npx skills add ${item.skill.github_repo}`}\n` +
@@ -56,7 +58,7 @@ export async function GET(request: NextRequest) {
       )).join('\n---\n')
 
       return new NextResponse(
-        `OpenAgentSkill Ranking\n${definition.title}\n${definition.description}\nMethod: ${latestSnapshot?.methodology_version || RANKING_METHODOLOGY_VERSION}\nDaily snapshot: ${latestSnapshot?.generated_at || 'pending'}\n---\n${text}`,
+        `OpenAgentSkill Ranking\n${definition.title}\n${definition.description}\nMethod: ${RANKING_METHODOLOGY_VERSION}\nDaily snapshot: ${latestSnapshot?.generated_at || 'pending'}\n---\n${text}`,
         {
           headers: {
             'Content-Type': 'text/plain; charset=utf-8',
@@ -78,12 +80,13 @@ export async function GET(request: NextRequest) {
         return {
           rank: item.rank,
           score: Math.round(item.score * 100) / 100,
-          badge: item.badge,
-          reason: item.reason,
+          dimensions: item.dimensions,
+          badge: normalizeRankingText(item.badge),
+          reason: normalizeRankingText(item.reason),
           slug: item.skill.slug,
-          name: item.skill.name,
-          description: item.skill.description,
-          category: item.skill.category,
+          name: normalizeRankingText(item.skill.name),
+          description: normalizeRankingText(item.skill.description),
+          category: normalizeRankingText(item.skill.category),
           stars: item.skill.github_stars,
           quality_score: Number(item.skill.quality_score || 0),
           agent_proven: proven,
@@ -100,15 +103,16 @@ export async function GET(request: NextRequest) {
       meta: {
         live_generated_at: new Date().toISOString(),
         daily_snapshot_at: latestSnapshot?.generated_at || null,
-        methodology_version: latestSnapshot?.methodology_version || RANKING_METHODOLOGY_VERSION,
+        methodology_version: RANKING_METHODOLOGY_VERSION,
+        snapshot_methodology_version: latestSnapshot?.methodology_version || null,
         update_cadence: 'daily at 02:55 UTC',
       },
-    })
+    }, { headers: JSON_UTF8_HEADERS })
   } catch (error) {
     console.error('Agent rankings API error:', error)
     return NextResponse.json(
       { error: 'Failed to fetch rankings' },
-      { status: 500 }
+      { status: 500, headers: JSON_UTF8_HEADERS }
     )
   }
 }

--- a/app/rankings/[slug]/page.tsx
+++ b/app/rankings/[slug]/page.tsx
@@ -21,6 +21,7 @@ import {
   getRankingCompareHref,
   getRankingDefinition,
   getRankingDefinitions,
+  normalizeRankingText,
   rankSkillsForDefinition,
 } from '@/lib/rankings'
 
@@ -72,7 +73,7 @@ export default async function RankingDetailPage({
   const ranking = getRankingDefinition(slug)
   if (!ranking) notFound()
 
-  const usesOutcomeStats = ranking.kind === 'agent-usage' || ranking.kind === 'success-rate' || ranking.kind === 'safe-auto-install'
+  const usesOutcomeStats = ['highest-quality', 'agent-usage', 'success-rate', 'safe-auto-install', 'agent-platform'].includes(ranking.kind)
   const [skills, statsMap, latestSnapshot, snapshotHistory] = await Promise.all([
     getAllSkills('quality', undefined, 1200).catch(() => []),
     usesOutcomeStats
@@ -162,7 +163,7 @@ export default async function RankingDetailPage({
             </div>
             <div className="bg-background p-4">
               <div className="font-mono text-2xl">
-                {rankedSkills[0] ? Math.round(getSkillQualityProfile(rankedSkills[0].skill).score) : 0}
+                {rankedSkills[0] ? Math.round(rankedSkills[0].score) : 0}
               </div>
               <div className="mt-1 text-xs uppercase tracking-widest text-secondary">Top score</div>
             </div>
@@ -189,6 +190,8 @@ export default async function RankingDetailPage({
                 const proven = getAgentProvenProfile(outcomeStats)
                 const movement = rankMovement.get(skill.slug) || 0
                 const githubOwner = getGitHubOwner(skill)
+                const displayName = normalizeRankingText(skill.name)
+                const displayDescription = normalizeRankingText(skill.description)
 
                 return (
                   <article key={skill.slug} className="grid gap-5 py-7 lg:grid-cols-[auto_1fr_auto]">
@@ -200,17 +203,17 @@ export default async function RankingDetailPage({
                       <div className="mb-2 flex flex-wrap items-center gap-2">
                         <Link href={`/skills/${skill.slug}`} className="min-w-0">
                           <h2 className="font-display text-2xl font-semibold leading-tight hover:text-secondary">
-                            {skill.name}
+                            {displayName}
                           </h2>
                         </Link>
                         <span className="border border-border px-2 py-0.5 text-xs font-mono text-secondary">
-                          {item.badge}
+                          {normalizeRankingText(item.badge)}
                         </span>
                         <span className="border border-border px-2 py-0.5 text-xs font-mono text-secondary">
                           {snapshotHistory.length < 2 ? 'Baseline' : movement > 0 ? `↑ ${movement}` : movement < 0 ? `↓ ${Math.abs(movement)}` : '— stable'}
                         </span>
                         <span className="border border-border px-2 py-0.5 text-xs font-mono text-secondary">
-                          {quality.label} · {quality.score}
+                          {quality.label} | {quality.score}
                         </span>
                         {githubOwner ? <span className="font-mono text-xs text-secondary">@{githubOwner}</span> : null}
                         {ranking.kind === 'agent-usage' || ranking.kind === 'success-rate' || ranking.kind === 'safe-auto-install' ? (
@@ -219,13 +222,23 @@ export default async function RankingDetailPage({
                           </span>
                         ) : null}
                       </div>
-                      <p className="max-w-3xl text-sm leading-relaxed text-secondary">{skill.description}</p>
-                      <p className="mt-3 max-w-3xl text-sm leading-relaxed">{item.reason}</p>
+                      <p className="max-w-3xl text-sm leading-relaxed text-secondary">{displayDescription}</p>
+                      <p className="mt-3 max-w-3xl text-sm leading-relaxed">{normalizeRankingText(item.reason)}</p>
+                      <div className="mt-3 flex flex-wrap gap-2 text-[11px] font-mono text-secondary">
+                        <span>ranking {Math.round(item.score)}/100</span>
+                        <span>quality {Math.round(item.dimensions.quality)}</span>
+                        <span>popularity {Math.round(item.dimensions.popularity)}</span>
+                        <span>freshness {Math.round(item.dimensions.freshness)}</span>
+                        <span>evidence {Math.round(item.dimensions.agentEvidence)}</span>
+                        <span>confidence {Math.round(item.dimensions.evidenceConfidence)}</span>
+                        <span>install {Math.round(item.dimensions.installReadiness)}</span>
+                        {item.dimensions.fit !== null ? <span>fit {Math.round(item.dimensions.fit)}</span> : null}
+                      </div>
                       <div className="mt-4 flex flex-wrap gap-4 text-xs font-mono text-secondary">
                         <span>{formatCompactNumber(skill.github_stars || 0)} stars</span>
                         <span>{formatCompactNumber(skill.github_forks || 0)} forks</span>
                         <span>{formatDate(skill.github_last_pushed_at || skill.updated_at)} push</span>
-                        <span>{skill.category}</span>
+                        <span>{normalizeRankingText(skill.category)}</span>
                         {(ranking.kind === 'agent-usage' || ranking.kind === 'success-rate' || ranking.kind === 'safe-auto-install') && (
                           <>
                             <span>{proven.metrics.totalOutcomes.toLocaleString()} outcomes</span>

--- a/app/rankings/page.tsx
+++ b/app/rankings/page.tsx
@@ -9,7 +9,7 @@ import {
   type SkillOutcomeStats,
 } from '@/lib/db/skills'
 import { formatCompactNumber } from '@/lib/quality'
-import { CORE_RANKINGS, getRankingDefinitions, rankSkillsForDefinition, type RankingDefinition } from '@/lib/rankings'
+import { CORE_RANKINGS, getRankingDefinitions, normalizeRankingText, rankSkillsForDefinition, type RankingDefinition } from '@/lib/rankings'
 import { getLatestRankingSnapshot, RANKING_METHODOLOGY_VERSION } from '@/lib/ranking-snapshots'
 import { GitHubPopularityList } from '@/components/github-popularity-list'
 
@@ -35,7 +35,7 @@ function formatNumber(value: number) {
 }
 
 function usesOutcomeStats(ranking: RankingDefinition) {
-  return ranking.kind === 'agent-usage' || ranking.kind === 'success-rate' || ranking.kind === 'safe-auto-install'
+  return ['highest-quality', 'agent-usage', 'success-rate', 'safe-auto-install', 'agent-platform'].includes(ranking.kind)
 }
 
 export default async function RankingsPage() {
@@ -93,7 +93,7 @@ export default async function RankingsPage() {
           </div>
           <div className="bg-background p-5">
             <p className="text-xs uppercase tracking-widest text-secondary">Methodology</p>
-            <p className="mt-2 font-mono text-sm">{latestSnapshot?.methodology_version || RANKING_METHODOLOGY_VERSION}</p>
+            <p className="mt-2 font-mono text-sm">{RANKING_METHODOLOGY_VERSION}</p>
           </div>
         </section>
 
@@ -140,14 +140,14 @@ export default async function RankingsPage() {
             items={popularSkills.map((item) => ({
               rank: item.rank,
               slug: item.skill.slug,
-              name: item.skill.name,
-              description: item.skill.description,
+              name: normalizeRankingText(item.skill.name),
+              description: normalizeRankingText(item.skill.description),
               githubStars: item.skill.github_stars,
               githubRepo: item.skill.github_repo,
               authorName: item.skill.author_name,
-              badge: item.badge,
-              reason: item.reason,
-              category: item.skill.category,
+              badge: normalizeRankingText(item.badge),
+              reason: normalizeRankingText(item.reason),
+              category: normalizeRankingText(item.skill.category),
             }))}
           />
         </section>
@@ -185,8 +185,8 @@ export default async function RankingsPage() {
                   <div className="space-y-2">
                     {topSkills.map((item) => (
                       <div key={item.skill.slug} className="flex items-center justify-between gap-3 text-sm">
-                        <span className="truncate">{item.skill.name}</span>
-                        <span className="shrink-0 font-mono text-xs text-secondary">{item.badge}</span>
+                        <span className="truncate">{normalizeRankingText(item.skill.name)}</span>
+                        <span className="shrink-0 font-mono text-xs text-secondary">{normalizeRankingText(item.badge)}</span>
                       </div>
                     ))}
                   </div>
@@ -203,10 +203,10 @@ export default async function RankingsPage() {
             <h2 className="mt-3 font-display text-2xl font-semibold">No pay-to-rank. No single-metric winners.</h2>
           </div>
           <div className="grid gap-4 text-sm leading-relaxed text-secondary sm:grid-cols-2">
-            <p><span className="font-semibold text-foreground">Trending</span> uses capped seven-day activity, logarithmic weighting, active-day breadth, quality, trust, adoption, and real agent outcomes.</p>
-            <p><span className="font-semibold text-foreground">Agent proven</span> requires reported outcomes. Safety lists penalize risk blocks, setup friction, unclear install paths, and weak Skill-format evidence.</p>
-            <p><span className="font-semibold text-foreground">Fresh and new</span> let recently maintained or indexed skills surface without needing years of accumulated GitHub stars.</p>
-            <p><span className="font-semibold text-foreground">Daily snapshots</span> make every published leaderboard reproducible for the day and expose when the data was generated.</p>
+            <p><span className="font-semibold text-foreground">Bounded scores</span> normalize every public ranking score to 0–100. Raw stars or timestamps can order their dedicated lists but are never exposed as a score.</p>
+            <p><span className="font-semibold text-foreground">Independent dimensions</span> separate popularity, quality, freshness, agent evidence, evidence confidence, install readiness, and task fit.</p>
+            <p><span className="font-semibold text-foreground">Evidence-aware ranking</span> prevents one reported success from outranking broader multi-agent evidence and clearly marks skills that still need a first run.</p>
+            <p><span className="font-semibold text-foreground">Daily snapshots</span> use a versioned methodology so published leaderboards remain reproducible and auditable.</p>
           </div>
         </section>
 
@@ -236,7 +236,7 @@ export default async function RankingsPage() {
                   <p className="mt-2 line-clamp-3 text-sm leading-relaxed text-secondary">{ranking.description}</p>
                   {topSkill && (
                     <p className="mt-5 border-t border-border pt-4 text-xs text-secondary">
-                      Leading pick: <span className="text-foreground">{topSkill.skill.name}</span>
+                      Leading pick: <span className="text-foreground">{normalizeRankingText(topSkill.skill.name)}</span>
                     </p>
                   )}
                 </Link>

--- a/lib/agent-resolve.ts
+++ b/lib/agent-resolve.ts
@@ -26,473 +26,13 @@ import { augmentQueryForIntent, dedupeRankedSkills, getRecommendationReasons, no
 import { getSkillSupplyProfile, type SkillSupplyProfile } from '@/lib/supply'
 import { getSkillTrustProfile, getSkillTrustProfileV5, type SkillTrustProfile, type SkillTrustProfileV5 } from '@/lib/trust'
 import { getUseCasesForSkill } from '@/lib/use-cases'
-import { CURATED_SKILL_SNAPSHOT } from '@/lib/seo/curated-skill-snapshot'
+import { TRUSTED_RESOLVE_FALLBACKS } from '@/lib/resolve-fallbacks'
 
 const SITE_URL = 'https://www.openagentskill.com'
 const RESOLVE_CANDIDATE_POOL_SIZE = 750
 const RESOLVE_CACHE_REVALIDATE = 300
 const RESOLVE_QUERY_TIMEOUT_MS = 1800
 const RESOLVE_EXACT_QUERY_TIMEOUT_MS = 2200
-const FALLBACK_DATE = '2026-06-01T00:00:00.000Z'
-
-function fallbackSkill(input: {
-  slug: string
-  name: string
-  description: string
-  repo: string
-  category: string
-  tags: string[]
-  frameworks: string[]
-  stars: number
-  forks?: number
-  quality: number
-  license?: string
-  lastPushedAt?: string
-  repository?: string
-  installCommand?: string
-}): SkillRecord {
-  return {
-    id: `fallback-${input.slug}`,
-    slug: input.slug,
-    name: input.name,
-    description: input.description,
-    long_description: input.description,
-    tagline: input.description,
-    author_name: input.repo.split('/')[0],
-    author_email: null,
-    author_url: `https://github.com/${input.repo.split('/')[0]}`,
-    repository: input.repository || `https://github.com/${input.repo}`,
-    github_repo: input.repo,
-    github_stars: input.stars,
-    github_forks: input.forks || 0,
-    category: input.category,
-    tags: input.tags,
-    frameworks: input.frameworks,
-    version: '1.0.0',
-    license: input.license || 'Unknown',
-    install_command: input.installCommand || `npx skills add ${input.repo}`,
-    npm_package: null,
-    verified: false,
-    submission_source: 'fallback',
-    submitted_by_agent: null,
-    ai_review_score: null,
-    ai_review_approved: true,
-    ai_review_issues: [],
-    ai_review_suggestions: [],
-    // Curated fallbacks provide relevance coverage, not synthetic adoption.
-    downloads: 0,
-    used_by: 0,
-    rating: 0,
-    review_count: 0,
-    quality_score: input.quality,
-    quality_signals: null,
-    github_language: null,
-    github_last_pushed_at: input.lastPushedAt || FALLBACK_DATE,
-    created_at: FALLBACK_DATE,
-    updated_at: FALLBACK_DATE,
-  }
-}
-
-const RESOLVE_FALLBACK_SKILLS: SkillRecord[] = [
-  fallbackSkill({
-    slug: 'crawl4ai',
-    name: 'Crawl4AI',
-    description: 'Open-source LLM-friendly web crawler and scraper for agent workflows.',
-    repo: 'unclecode/crawl4ai',
-    category: 'Web Scraping',
-    tags: ['web scraping', 'crawler', 'research'],
-    frameworks: ['Codex', 'Claude Code', 'Cursor'],
-    stars: 66_000,
-    quality: 96,
-    license: 'Apache-2.0',
-  }),
-  fallbackSkill({
-    slug: 'firecrawl',
-    name: 'Firecrawl',
-    description: 'Turn websites into clean markdown or structured data for retrieval and agents.',
-    repo: 'mendableai/firecrawl',
-    category: 'Web Scraping',
-    tags: ['crawler', 'markdown', 'rag'],
-    frameworks: ['Codex', 'Claude Code', 'Cursor'],
-    stars: 34_000,
-    quality: 94,
-    license: 'AGPL-3.0',
-  }),
-  fallbackSkill({
-    slug: 'n8n',
-    name: 'n8n',
-    description: 'Workflow automation for connecting agents to repeated operational tasks.',
-    repo: 'n8n-io/n8n',
-    category: 'Workflow Automation',
-    tags: ['automation', 'workflow', 'integration'],
-    frameworks: ['API', 'CLI', 'Agent workflow'],
-    stars: 190_000,
-    quality: 92,
-  }),
-  fallbackSkill({
-    slug: 'markitdown',
-    name: 'MarkItDown',
-    description: 'Convert PDFs, Office documents, and web files into clean markdown for agents.',
-    repo: 'microsoft/markitdown',
-    category: 'Research',
-    tags: ['pdf', 'markdown', 'documents'],
-    frameworks: ['Codex', 'Claude Code', 'Cursor'],
-    stars: 80_000,
-    quality: 93,
-    license: 'MIT',
-  }),
-  fallbackSkill({
-    slug: 'hugohe3-ppt-master',
-    name: 'Ppt Master',
-    description:
-      'Generate real editable PowerPoint decks from documents, briefs, templates, and speaker-note workflows.',
-    repo: 'hugohe3/ppt-master',
-    category: 'Design',
-    tags: ['presentation', 'ppt', 'pptx', 'powerpoint', 'slides', 'speaker notes'],
-    frameworks: ['Codex', 'Claude Code', 'PowerPoint'],
-    stars: 31_000,
-    quality: 95,
-    license: 'MIT',
-  }),
-  fallbackSkill({
-    slug: 'op7418-guizang-ppt-skill',
-    name: 'Guizang Ppt Skill',
-    description:
-      'AI-agent skill for polished HTML slide decks with editorial layouts, visual prompts, and web presentation runtime.',
-    repo: 'op7418/guizang-ppt-skill',
-    category: 'Design',
-    tags: ['presentation', 'ppt', 'slides', 'html slides', 'deck', 'design'],
-    frameworks: ['Codex', 'Claude Code', 'HTML'],
-    stars: 15_000,
-    quality: 94,
-    license: 'MIT',
-  }),
-  fallbackSkill({
-    slug: 'zarazhangrui-frontend-slides',
-    name: 'Frontend Slides',
-    description: "Create beautiful web-based slides using a coding agent's frontend and design skills.",
-    repo: 'zarazhangrui/frontend-slides',
-    category: 'Design',
-    tags: ['presentation', 'slides', 'html slides', 'frontend', 'deck'],
-    frameworks: ['Codex', 'Claude Code', 'Cursor'],
-    stars: 23_000,
-    quality: 93,
-    license: 'MIT',
-  }),
-  fallbackSkill({
-    slug: 'emilkowalski-apple-design',
-    name: 'Apple Design',
-    description:
-      "Apple's interface design and fluid-motion principles translated into practical web guidance for gestures, springs, momentum, typography, and reduced motion.",
-    repo: 'emilkowalski/skills',
-    repository: 'https://github.com/emilkowalski/skills/tree/main/skills/apple-design',
-    installCommand: 'npx skills@latest add emilkowalski/skills',
-    category: 'design-creative',
-    tags: ['agent-skill', 'apple-design', 'interface-design', 'motion', 'animation', 'gestures', 'springs'],
-    frameworks: ['Claude Code', 'Codex', 'Cursor'],
-    stars: 7_906,
-    quality: 96,
-    license: 'MIT',
-    lastPushedAt: '2026-07-09T15:12:54.000Z',
-  }),
-  fallbackSkill({
-    slug: 'emilkowalski-emil-design-eng',
-    name: 'Emil Design Engineering',
-    description:
-      'Design-engineering guidance for polished UI components, animation decisions, interaction details, and interfaces that feel intentional.',
-    repo: 'emilkowalski/skills',
-    repository: 'https://github.com/emilkowalski/skills/tree/main/skills/emil-design-eng',
-    installCommand: 'npx skills@latest add emilkowalski/skills',
-    category: 'design-creative',
-    tags: ['agent-skill', 'design-engineering', 'ui', 'animation', 'frontend', 'interaction-design'],
-    frameworks: ['Claude Code', 'Codex', 'Cursor'],
-    stars: 7_906,
-    quality: 96,
-    license: 'MIT',
-    lastPushedAt: '2026-07-09T15:12:54.000Z',
-  }),
-  fallbackSkill({
-    slug: 'emilkowalski-review-animations',
-    name: 'Review Animations',
-    description:
-      'Review animation and motion code against a strict design-engineering craft bar, with focused findings for timing, easing, continuity, and interaction quality.',
-    repo: 'emilkowalski/skills',
-    repository: 'https://github.com/emilkowalski/skills/tree/main/skills/review-animations',
-    installCommand: 'npx skills@latest add emilkowalski/skills',
-    category: 'design-creative',
-    tags: ['agent-skill', 'animation-review', 'code-review', 'motion', 'frontend', 'easing'],
-    frameworks: ['Claude Code', 'Codex', 'Cursor'],
-    stars: 7_906,
-    quality: 94,
-    license: 'MIT',
-    lastPushedAt: '2026-07-09T15:12:54.000Z',
-  }),
-  fallbackSkill({
-    slug: 'emilkowalski-animation-vocabulary',
-    name: 'Animation Vocabulary',
-    description:
-      'Reverse-lookup animation glossary that turns a vague motion description into the precise design term an agent or designer can act on.',
-    repo: 'emilkowalski/skills',
-    repository: 'https://github.com/emilkowalski/skills/tree/main/skills/animation-vocabulary',
-    installCommand: 'npx skills@latest add emilkowalski/skills',
-    category: 'design-creative',
-    tags: ['agent-skill', 'animation', 'motion', 'design-language', 'prompting', 'vocabulary'],
-    frameworks: ['Claude Code', 'Codex', 'Cursor'],
-    stars: 7_906,
-    quality: 93,
-    license: 'MIT',
-    lastPushedAt: '2026-07-09T15:12:54.000Z',
-  }),
-  fallbackSkill({
-    slug: 'mattpocock-grill-with-docs',
-    name: 'Grill With Docs',
-    description:
-      'Pressure-test a plan against the live codebase, domain glossary, and architectural decisions before implementation starts.',
-    repo: 'mattpocock/skills',
-    repository: 'https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs',
-    installCommand: 'npx skills add mattpocock/skills --skill grill-with-docs',
-    category: 'coding-agents',
-    tags: ['agent-skill', 'planning', 'domain-modeling', 'adr', 'context', 'coding-agents'],
-    frameworks: ['Claude Code', 'Codex', 'Cursor'],
-    stars: 164_079,
-    forks: 14_116,
-    quality: 94,
-    license: 'MIT',
-    lastPushedAt: '2026-07-10T13:15:20.000Z',
-  }),
-  fallbackSkill({
-    slug: 'mattpocock-to-spec',
-    name: 'To Spec',
-    description:
-      'Synthesize the current conversation and codebase context into a behavior-focused engineering spec.',
-    repo: 'mattpocock/skills',
-    repository: 'https://github.com/mattpocock/skills/tree/main/skills/engineering/to-spec',
-    installCommand: 'npx skills add mattpocock/skills --skill to-spec',
-    category: 'coding-agents',
-    tags: ['agent-skill', 'spec', 'prd', 'issue-tracker', 'planning', 'coding-agents'],
-    frameworks: ['Claude Code', 'Codex', 'Cursor'],
-    stars: 164_079,
-    forks: 14_116,
-    quality: 92,
-    license: 'MIT',
-    lastPushedAt: '2026-07-10T13:15:20.000Z',
-  }),
-  fallbackSkill({
-    slug: 'mattpocock-to-tickets',
-    name: 'To Tickets',
-    description:
-      'Break an approved plan or spec into independently actionable vertical-slice tickets with explicit blocking relationships.',
-    repo: 'mattpocock/skills',
-    repository: 'https://github.com/mattpocock/skills/tree/main/skills/engineering/to-tickets',
-    installCommand: 'npx skills add mattpocock/skills --skill to-tickets',
-    category: 'coding-agents',
-    tags: ['agent-skill', 'tickets', 'issues', 'vertical-slices', 'planning', 'coding-agents'],
-    frameworks: ['Claude Code', 'Codex', 'Cursor'],
-    stars: 164_079,
-    forks: 14_116,
-    quality: 91,
-    license: 'MIT',
-    lastPushedAt: '2026-07-10T13:15:20.000Z',
-  }),
-  fallbackSkill({
-    slug: 'mattpocock-implement',
-    name: 'Implement',
-    description:
-      'Implement approved engineering work with focused tests, full verification, code review, and a commit on the current branch.',
-    repo: 'mattpocock/skills',
-    repository: 'https://github.com/mattpocock/skills/tree/main/skills/engineering/implement',
-    installCommand: 'npx skills add mattpocock/skills --skill implement',
-    category: 'coding-agents',
-    tags: ['agent-skill', 'implementation', 'tdd', 'testing', 'commit', 'coding-agents'],
-    frameworks: ['Claude Code', 'Codex', 'Cursor'],
-    stars: 164_079,
-    forks: 14_116,
-    quality: 88,
-    license: 'MIT',
-    lastPushedAt: '2026-07-10T13:15:20.000Z',
-  }),
-  fallbackSkill({
-    slug: 'mattpocock-code-review',
-    name: 'Code Review',
-    description:
-      'Review a branch or diff independently against repository standards and the originating specification.',
-    repo: 'mattpocock/skills',
-    repository: 'https://github.com/mattpocock/skills/tree/main/skills/engineering/code-review',
-    installCommand: 'npx skills add mattpocock/skills --skill code-review',
-    category: 'coding-agents',
-    tags: ['agent-skill', 'code-review', 'git-diff', 'standards', 'spec', 'coding-agents'],
-    frameworks: ['Claude Code', 'Codex', 'Cursor'],
-    stars: 164_079,
-    forks: 14_116,
-    quality: 94,
-    license: 'MIT',
-    lastPushedAt: '2026-07-10T13:15:20.000Z',
-  }),
-  fallbackSkill({
-    slug: 'llamaindex',
-    name: 'LlamaIndex',
-    description: 'Data framework for building RAG and knowledge workflows around agent tasks.',
-    repo: 'run-llama/llama_index',
-    category: 'RAG',
-    tags: ['rag', 'knowledge', 'retrieval'],
-    frameworks: ['Python', 'Codex', 'Claude Code'],
-    stars: 42_000,
-    quality: 91,
-    license: 'MIT',
-  }),
-  fallbackSkill({
-    slug: 'openbb',
-    name: 'OpenBB',
-    description: 'Open-source investment research platform for financial analysis agents.',
-    repo: 'OpenBB-finance/OpenBB',
-    category: 'Finance',
-    tags: ['finance', 'stocks', 'research'],
-    frameworks: ['Python', 'Codex', 'Claude Code'],
-    stars: 46_000,
-    quality: 90,
-  }),
-  fallbackSkill({
-    slug: 'browser-use',
-    name: 'Browser Use',
-    description: 'Browser automation layer for agents that need to interact with websites.',
-    repo: 'browser-use/browser-use',
-    category: 'Browser Automation',
-    tags: ['browser', 'automation', 'agent'],
-    frameworks: ['Python', 'Browser', 'Agent workflow'],
-    stars: 75_000,
-    quality: 90,
-  }),
-  fallbackSkill({
-    slug: 'playwright',
-    name: 'Playwright',
-    description: 'Reliable browser automation and testing engine for web agent tasks.',
-    repo: 'microsoft/playwright',
-    category: 'Browser Automation',
-    tags: ['browser', 'testing', 'automation'],
-    frameworks: ['Node.js', 'Python', 'Codex'],
-    stars: 76_000,
-    quality: 89,
-    license: 'Apache-2.0',
-  }),
-  fallbackSkill({
-    slug: 'last30days-skill',
-    name: 'Last30days Skill',
-    description: 'Research recent cross-source changes across Reddit, X, YouTube, Hacker News, and the web.',
-    repo: 'mvanhorn/last30days-skill',
-    category: 'Research',
-    tags: ['research', 'recent events', 'briefing'],
-    frameworks: ['Codex', 'Claude Code'],
-    stars: 42_500,
-    quality: 88,
-  }),
-  fallbackSkill({
-    slug: 'addyosmani-agent-skills',
-    name: 'Agent Skills',
-    description: 'Production-grade engineering skills for AI coding agents across spec, planning, build, test, review, and shipping workflows.',
-    repo: 'addyosmani/agent-skills',
-    category: 'Coding Agents',
-    tags: ['agent-skills', 'coding-agents', 'engineering', 'quality-gates', 'claude-code', 'cursor'],
-    frameworks: ['Claude Code', 'Cursor', 'Gemini CLI', 'Codex'],
-    stars: 61_800,
-    quality: 94,
-    license: 'MIT',
-  }),
-  fallbackSkill({
-    slug: 'davidondrej-skills',
-    name: 'David Ondrej Skills',
-    description:
-      'Reusable SKILL.md workflows for coding agents, research, docs, ops, orchestration, and skill-authoring.',
-    repo: 'davidondrej/skills',
-    category: 'Agent Skills',
-    tags: [
-      'agent-skills',
-      'coding-agents',
-      'research-agents',
-      'workflow-agents',
-      'agent-orchestration',
-      'skill-authoring',
-      'deep-research',
-      'youtube-transcript',
-      'docs',
-      'ops',
-    ],
-    frameworks: ['Codex', 'Claude Code', 'Cursor', 'Agent Workflows'],
-    stars: 968,
-    quality: 92,
-    license: 'MIT',
-    lastPushedAt: '2026-07-05T21:16:23.000Z',
-  }),
-  fallbackSkill({
-    slug: 'serenity-skill',
-    name: 'Serenity Skill',
-    description: 'Stock analysis skill for market research and financial reasoning workflows.',
-    repo: 'muxuuu/serenity-skill',
-    category: 'Finance',
-    tags: ['stocks', 'finance', 'analysis'],
-    frameworks: ['Codex', 'Claude Code'],
-    stars: 12_000,
-    quality: 86,
-  }),
-  fallbackSkill({
-    slug: 'seedance-2-0',
-    name: 'Seedance 2.0 Skill',
-    description: 'Creative video generation workflow skill for Seedance 2.0 filmmaking agents.',
-    repo: 'Emily2040/seedance-2.0',
-    category: 'Design',
-    tags: ['video', 'creative', 'seedance'],
-    frameworks: ['Codex', 'Claude Code'],
-    stars: 8_000,
-    quality: 84,
-  }),
-  fallbackSkill({
-    slug: 'vectorbt',
-    name: 'Vectorbt',
-    description: 'Fast quantitative research and backtesting workflows for financial agents.',
-    repo: 'polakowo/vectorbt',
-    category: 'Finance',
-    tags: ['quant', 'backtesting', 'finance'],
-    frameworks: ['Python', 'Codex'],
-    stars: 5_400,
-    quality: 83,
-  }),
-  fallbackSkill({
-    slug: 'openfootball-worldcup',
-    name: 'Openfootball Worldcup',
-    description: 'World Cup football match data and fixtures for sports analytics agents.',
-    repo: 'openfootball/worldcup',
-    category: 'Sports Analytics',
-    tags: ['world cup', 'football', 'soccer', 'match data', 'sports analytics'],
-    frameworks: ['Codex', 'Claude Code', 'Data workflow'],
-    stars: 634,
-    quality: 82,
-    license: 'Public Domain',
-  }),
-  fallbackSkill({
-    slug: 'estiens-world-cup-json',
-    name: 'World Cup JSON',
-    description: 'Structured World Cup JSON data for building football dashboards and match analysis workflows.',
-    repo: 'estiens/world_cup_json',
-    category: 'Sports Analytics',
-    tags: ['world cup', 'football', 'soccer', 'json', 'sports data'],
-    frameworks: ['Codex', 'Claude Code', 'Data workflow'],
-    stars: 926,
-    quality: 82,
-    license: 'MIT',
-  }),
-  fallbackSkill({
-    slug: 'cedricblondeau-world-cup-dashboard',
-    name: 'World Cup CLI Dashboard',
-    description: 'World Cup command-line dashboard and match data workflow for football analytics agents.',
-    repo: 'cedricblondeau/world-cup-2018-cli-dashboard',
-    category: 'Sports Analytics',
-    tags: ['world cup', 'football', 'soccer', 'dashboard', 'match data'],
-    frameworks: ['Codex', 'CLI', 'Data workflow'],
-    stars: 543,
-    quality: 80,
-    license: 'MIT',
-  }),
-]
-
 async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   let timeout: ReturnType<typeof setTimeout> | undefined
   const timeoutPromise = new Promise<T>((_, reject) => {
@@ -515,7 +55,7 @@ const getResolveCandidatePool = unstable_cache(
       // failing a request or scheduling repeated cache revalidations while the
       // registry database is temporarily unavailable.
       console.warn('Agent resolve cache fallback:', error)
-      return RESOLVE_FALLBACK_SKILLS
+      return TRUSTED_RESOLVE_FALLBACKS
     }
   },
   ['agent-resolve-candidate-pool-v2'],
@@ -951,7 +491,7 @@ export async function resolveAgentSkill(input: AgentResolveInput) {
         withTimeout(getResolveCandidatePool(), RESOLVE_QUERY_TIMEOUT_MS, 'agent resolve candidate query')
           .catch((error) => {
             console.warn('Agent resolve candidate fallback:', error)
-            return RESOLVE_FALLBACK_SKILLS
+            return TRUSTED_RESOLVE_FALLBACKS
           }),
         withTimeout(searchSkills(rankingTask, 160), RESOLVE_EXACT_QUERY_TIMEOUT_MS, 'agent resolve exact query')
           .catch((error) => {
@@ -964,12 +504,12 @@ export async function resolveAgentSkill(input: AgentResolveInput) {
           .catch((): Record<string, SkillOutcomeStats> => ({})),
       ])
     : [
-        RESOLVE_FALLBACK_SKILLS,
+        TRUSTED_RESOLVE_FALLBACKS,
         [] as SkillRecord[],
         {} as Record<string, SkillEventStats>,
         {} as Record<string, SkillOutcomeStats>,
       ]
-  const skills = mergeResolveSkillPools(queryPool, qualityPool, RESOLVE_FALLBACK_SKILLS, CURATED_SKILL_SNAPSHOT)
+  const skills = mergeResolveSkillPools(queryPool, qualityPool, TRUSTED_RESOLVE_FALLBACKS)
 
   const ranked = dedupeRankedSkills(rankSkillsForQuery(skills, rankingTask, outcomeStatsMap))
     .filter(({ skill }) => candidateAllowed(skill, constraints))
@@ -977,10 +517,31 @@ export async function resolveAgentSkill(input: AgentResolveInput) {
   const topMatchScore = ranked[0]?.score || 0
 
   const candidates = ranked.map(({ skill, score, semanticRelevance }, index) => {
+    const isFallbackSnapshot = skill.submission_source === 'curated_snapshot'
     const eventStats = eventStatsMap[skill.slug] || null
     const outcomeStats = outcomeStatsMap[skill.slug] || null
     const audit = buildSkillAudit(skill, eventStats)
-    const safety = getAgentSafetyProfile(skill, audit, constraints)
+    const baseSafety = getAgentSafetyProfile(skill, audit, constraints)
+    const safety = isFallbackSnapshot
+      ? {
+          ...baseSafety,
+          safety_tier: {
+            ...baseSafety.safety_tier,
+            auto_install_policy: 'review' as const,
+            recommended_action: 'Verify the live repository and request human approval before installing this fallback snapshot.',
+            reasons: [
+              'Registry fallback snapshots may be stale even when their source path was previously verified.',
+              ...baseSafety.safety_tier.reasons,
+            ],
+          },
+          auto_install_allowed: false,
+          human_review_required: true,
+          policy_warnings: [
+            'Fallback snapshot: live registry metadata was unavailable or did not contain this record.',
+            ...baseSafety.policy_warnings,
+          ],
+        }
+      : baseSafety
     const trust = getSkillTrustProfile(skill, false, eventStats, outcomeStats)
     const trustV5 = getSkillTrustProfileV5(skill, false, eventStats, outcomeStats)
     const agentProven = getAgentProvenProfile(outcomeStats)
@@ -994,6 +555,14 @@ export async function resolveAgentSkill(input: AgentResolveInput) {
       match_score: matchScore,
       raw_match_score: score,
       semantic_relevance: semanticRelevance,
+      registry_source: {
+        kind: isFallbackSnapshot ? 'verified_fallback_snapshot' : 'live_registry',
+        live: !isFallbackSnapshot,
+        auto_install_eligible: !isFallbackSnapshot,
+        warning: isFallbackSnapshot
+          ? 'This is a source-verified fallback snapshot. Re-check the repository before installation.'
+          : null,
+      },
       skill: {
         slug: skill.slug,
         name: skill.name,

--- a/lib/ranking-snapshots.ts
+++ b/lib/ranking-snapshots.ts
@@ -15,8 +15,10 @@ import {
 import { formatCompactNumber, getSkillQualityProfile } from '@/lib/quality'
 import {
   CORE_RANKINGS,
+  normalizeRankingText,
   rankSkillsForDefinition,
   type RankedSkill,
+  type RankingDimensions,
   type RankingDefinition,
 } from '@/lib/rankings'
 import { rankHotSkills, rankTrendingSkills, type GrowthRankedSkill } from '@/lib/seo/growth-directories'
@@ -24,7 +26,7 @@ import { getGitHubOwner } from '@/lib/github-owner'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createPublicClient } from '@/lib/supabase/public'
 
-export const RANKING_METHODOLOGY_VERSION = 'ranking-v3-daily-2026-08'
+export const RANKING_METHODOLOGY_VERSION = 'ranking-v4-dimensions-2026-08'
 const SNAPSHOT_ITEM_LIMIT = 30
 const SNAPSHOT_RETENTION_DAYS = 90
 
@@ -40,6 +42,7 @@ export interface RankingSnapshotItem {
   github_stars: number
   github_forks: number
   quality_score: number
+  dimensions?: RankingDimensions
   install: string
   repository: string
   updated_at: string
@@ -75,15 +78,16 @@ function serializeRankedSkill(item: RankedSkill | GrowthRankedSkill): RankingSna
   return {
     rank: item.rank,
     score: Math.round(Number(item.score || 0) * 100) / 100,
-    badge: item.badge,
-    reason: item.reason,
+    badge: normalizeRankingText(item.badge),
+    reason: normalizeRankingText(item.reason),
     slug: item.skill.slug,
-    name: item.skill.name,
-    description: item.skill.description,
-    category: item.skill.category,
+    name: normalizeRankingText(item.skill.name),
+    description: normalizeRankingText(item.skill.description),
+    category: normalizeRankingText(item.skill.category),
     github_stars: Number(item.skill.github_stars || 0),
     github_forks: Number(item.skill.github_forks || 0),
     quality_score: quality.score,
+    dimensions: 'dimensions' in item ? item.dimensions : undefined,
     install: item.skill.install_command || `npx skills add ${item.skill.github_repo}`,
     repository: item.skill.repository || `https://github.com/${item.skill.github_repo}`,
     updated_at: item.skill.github_last_pushed_at || item.skill.updated_at,
@@ -93,7 +97,7 @@ function serializeRankedSkill(item: RankedSkill | GrowthRankedSkill): RankingSna
 }
 
 function usesOutcomeStats(definition: RankingDefinition) {
-  return definition.kind === 'agent-usage' || definition.kind === 'success-rate' || definition.kind === 'safe-auto-install'
+  return ['highest-quality', 'agent-usage', 'success-rate', 'safe-auto-install', 'agent-platform'].includes(definition.kind)
 }
 
 function createSnapshotRow(
@@ -210,7 +214,7 @@ const getCachedLatestRankingSnapshot = unstable_cache(
     if (error) throw new Error(`Failed to read ranking snapshot: ${error.message}`)
     return data as RankingSnapshot | null
   },
-  ['latest-ranking-snapshot-v1'],
+  ['latest-ranking-snapshot-v2'],
   { revalidate: 300, tags: ['ranking-snapshots'] }
 )
 

--- a/lib/rankings.ts
+++ b/lib/rankings.ts
@@ -33,6 +33,31 @@ export interface RankedSkill {
   score: number
   reason: string
   badge: string
+  dimensions: RankingDimensions
+}
+
+export interface RankingDimensions {
+  popularity: number
+  quality: number
+  freshness: number
+  agentEvidence: number
+  evidenceConfidence: number
+  installReadiness: number
+  fit: number | null
+}
+
+const MOJIBAKE_SEQUENCE = /(?:[\u00c2-\u00df][\u0080-\u00bf]|[\u00e0-\u00ef][\u0080-\u00bf]{2}|[\u00f0-\u00f4][\u0080-\u00bf]{3})+/g
+
+export function normalizeRankingText(value: string | null | undefined) {
+  const text = String(value || '')
+  const repaired = text.replace(MOJIBAKE_SEQUENCE, (segment) =>
+    Buffer.from(segment, 'latin1').toString('utf8')
+  )
+
+  return repaired
+    .replaceAll('Â·', '|')
+    .replaceAll('â', '-')
+    .replaceAll('â', '-')
 }
 
 export const CORE_RANKINGS: RankingDefinition[] = [
@@ -176,6 +201,80 @@ function freshnessScore(value: string | null | undefined) {
   return Math.max(0, 100 - Math.min(100, days * 2))
 }
 
+function clampScore(value: number) {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, Math.round(value * 10) / 10))
+}
+
+function weightedScore(
+  dimensions: RankingDimensions,
+  weights: Partial<Record<keyof RankingDimensions, number>>
+) {
+  let totalWeight = 0
+  let total = 0
+
+  for (const [key, weight] of Object.entries(weights) as Array<[
+    keyof RankingDimensions,
+    number,
+  ]>) {
+    const value = dimensions[key]
+    if (value === null || weight <= 0) continue
+    total += value * weight
+    totalWeight += weight
+  }
+
+  return clampScore(totalWeight > 0 ? total / totalWeight : 0)
+}
+
+function popularityScore(stars: number) {
+  // 100k stars is the top of the public popularity scale. Raw stars still
+  // determine ties and the literal most-starred ordering.
+  return clampScore((Math.log10(Math.max(0, stars) + 1) / 5) * 100)
+}
+
+function evidenceConfidenceScore(totalOutcomes: number, uniqueAgents: number) {
+  if (totalOutcomes <= 0) return 0
+  const sampleConfidence = Math.min(70, (Math.log10(totalOutcomes + 1) / Math.log10(21)) * 70)
+  const agentDiversity = Math.min(30, uniqueAgents * 6)
+  return clampScore(sampleConfidence + agentDiversity)
+}
+
+function installReadinessScore(skill: SkillRecord, riskPenalty = 0) {
+  const command = String(skill.install_command || '')
+  const repository = String(skill.repository || '')
+  const license = String(skill.license || '').toLowerCase()
+  let score = 25
+
+  if (/^npx(?:\s+-y)?\s+skills(?:@latest)?\s+add\s+/i.test(command)) score += 40
+  else if (command.trim()) score += 15
+  if (/^https:\/\/github\.com\//i.test(repository)) score += 12
+  if (license && license !== 'unknown') score += 13
+  if (skill.verified) score += 10
+
+  return clampScore(score - riskPenalty)
+}
+
+function buildDimensions(input: {
+  skill: SkillRecord
+  quality: number
+  freshness: number
+  evidence: number
+  totalOutcomes: number
+  uniqueAgents: number
+  riskPenalty: number
+  fit?: number | null
+}): RankingDimensions {
+  return {
+    popularity: popularityScore(Number(input.skill.github_stars || 0)),
+    quality: clampScore(input.quality),
+    freshness: clampScore(input.freshness),
+    agentEvidence: clampScore(input.evidence),
+    evidenceConfidence: evidenceConfidenceScore(input.totalOutcomes, input.uniqueAgents),
+    installReadiness: installReadinessScore(input.skill, input.riskPenalty),
+    fit: input.fit === undefined || input.fit === null ? null : clampScore(input.fit),
+  }
+}
+
 function compactStars(skill: SkillRecord) {
   return `${formatCompactNumber(skill.github_stars || 0)} stars`
 }
@@ -219,12 +318,34 @@ function rankByUseCase(
   if (!useCase) return []
 
   const scored = skills
-    .map((skill) => ({
-      skill,
-      score: scoreSkillForUseCase(skill, useCase) - rankingSkillPenalty(skill) / 12,
-    }))
-    .filter((item) => item.score >= 6 && rankingSkillPenalty(item.skill) < 45)
-    .sort((a, b) => b.score - a.score || b.skill.github_stars - a.skill.github_stars)
+    .map((skill) => {
+      const rawFit = scoreSkillForUseCase(skill, useCase) - rankingSkillPenalty(skill) / 12
+      const quality = getSkillQualityProfile(skill)
+      const dimensions = buildDimensions({
+        skill,
+        quality: quality.score,
+        freshness: freshnessScore(skill.github_last_pushed_at || skill.updated_at),
+        evidence: 0,
+        totalOutcomes: 0,
+        uniqueAgents: 0,
+        riskPenalty: 0,
+        fit: rawFit,
+      })
+      return {
+        skill,
+        rawFit,
+        dimensions,
+        score: weightedScore(dimensions, {
+          fit: 0.65,
+          quality: 0.15,
+          popularity: 0.08,
+          freshness: 0.07,
+          installReadiness: 0.05,
+        }),
+      }
+    })
+    .filter((item) => item.rawFit >= 6 && rankingSkillPenalty(item.skill) < 45)
+    .sort((a, b) => b.score - a.score || b.rawFit - a.rawFit || b.skill.github_stars - a.skill.github_stars)
 
   return dedupeRankedSkills(scored)
     .slice(0, limit)
@@ -233,7 +354,8 @@ function rankByUseCase(
       rank: index + 1,
       score: item.score,
       badge: `${Math.round(item.score)} fit`,
-      reason: reasonForUseCase(item.skill, item.score),
+      reason: reasonForUseCase(item.skill, item.dimensions.fit || 0),
+      dimensions: item.dimensions,
     }))
 }
 
@@ -275,17 +397,6 @@ export function rankSkillsForDefinition(
         stats?.success_rate === null || stats?.success_rate === undefined
           ? null
           : Number(stats.success_rate)
-      const usageScore =
-        totalUsage > 0
-          ? Math.min(30, Math.log10(totalUsage + 1) * 18) +
-            Math.max(0, successRate || 0) * 0.45 +
-            Math.min(12, Math.log10(installAttempts + 1) * 8) +
-            uniqueAgents * 4 +
-            quality.score * 0.25 +
-            proven.score * 0.45 +
-            Math.min(8, Math.log10(Math.max(1, skill.github_stars || 1)) * 2) -
-            Math.min(30, riskBlocked * 5 + setupRequired * 3 + failures * 2.5 + notRelevant * 4)
-          : quality.score * 0.12 + Math.min(8, Math.log10(Math.max(1, skill.github_stars || 1)) * 2)
       const platformText = [
         skill.name,
         skill.description,
@@ -295,46 +406,81 @@ export function rankSkillsForDefinition(
         ...(skill.tags || []),
         ...(skill.frameworks || []),
       ].filter(Boolean).join(' ').toLowerCase()
-      const platformHit = definition.agentPlatform
-        ? platformText.includes(definition.agentPlatform.toLowerCase()) ||
-          (definition.agentPlatform === 'codex' && /\b(code|coding|repo|repository|github|test|review|frontend|backend)\b/.test(platformText)) ||
+      const exactPlatformHit = definition.agentPlatform
+        ? platformText.includes(definition.agentPlatform.toLowerCase())
+        : false
+      const inferredPlatformHit = definition.agentPlatform
+        ? (definition.agentPlatform === 'codex' && /\b(code|coding|repo|repository|github|test|review|frontend|backend)\b/.test(platformText)) ||
           (definition.agentPlatform === 'claude code' && /\b(claude|code|coding|docs?|research|browser|analysis)\b/.test(platformText)) ||
           (definition.agentPlatform === 'cursor' && /\b(cursor|code|coding|frontend|component|typescript|react|repo)\b/.test(platformText))
         : false
+      const platformFit = exactPlatformHit ? 100 : inferredPlatformHit ? 68 : 0
+      const riskPenalty = Math.min(
+        100,
+        riskBlocked * 25 + setupRequired * 10 + failures * 8 + notRelevant * 12
+      )
+      const dimensions = buildDimensions({
+        skill,
+        quality: quality.score,
+        freshness: lastPushedScore,
+        evidence: proven.score,
+        totalOutcomes: Number(totalUsage || 0),
+        uniqueAgents,
+        riskPenalty,
+        fit: definition.kind === 'agent-platform' ? platformFit : null,
+      })
 
       switch (definition.kind) {
         case 'most-starred':
           return {
             skill,
-            // Popularity is intentionally literal on this ranking. Repositories
-            // that fail the skill-likeness gate are filtered below; qualifying
-            // projects are then ordered by their public GitHub star count.
-            score: Number(skill.github_stars || 0),
+            score: dimensions.popularity,
+            sortScore: Number(skill.github_stars || 0),
+            dimensions,
             badge: compactStars(skill),
             reason: `${compactStars(skill)} and ${quality.label.toLowerCase()} quality signals.`,
           }
         case 'recently-updated':
           return {
             skill,
-            score: lastPushedScore + quality.score / 5 + Math.log10(Math.max(1, skill.github_stars || 1)) - skillSpecificPenalty,
+            score: weightedScore(dimensions, {
+              freshness: 0.6,
+              quality: 0.2,
+              popularity: 0.1,
+              installReadiness: 0.1,
+            }),
+            sortScore: lastPushedScore * 10 + dateValue(skill.github_last_pushed_at || skill.updated_at) / 1_000_000_000_000,
+            dimensions,
             badge: `${Math.round(lastPushedScore)} fresh`,
             reason: `Recently pushed, ${quality.label.toLowerCase()} quality, and ${compactStars(skill)}.`,
           }
         case 'new-this-week':
           return {
             skill,
-            score:
-              (isNewThisWeek ? 100 : 0) +
-              dateValue(skill.created_at) / 1_000_000_000 +
-              quality.score / 10 -
-              skillSpecificPenalty,
+            score: weightedScore(dimensions, {
+              freshness: 0.45,
+              quality: 0.25,
+              popularity: 0.12,
+              installReadiness: 0.18,
+            }),
+            sortScore: (isNewThisWeek ? 10_000 : 0) + dateValue(skill.created_at) / 1_000_000_000_000,
+            dimensions,
             badge: isNewThisWeek ? 'New this week' : 'Recently indexed',
             reason: `Indexed recently with ${quality.label.toLowerCase()} quality and ${compactStars(skill)}.`,
           }
         case 'agent-usage':
           return {
             skill,
-            score: usageScore + quality.score / 10 + proven.score * 0.32 - skillSpecificPenalty,
+            score: weightedScore(dimensions, {
+              agentEvidence: 0.45,
+              evidenceConfidence: 0.25,
+              quality: 0.12,
+              installReadiness: 0.08,
+              popularity: 0.05,
+              freshness: 0.05,
+            }),
+            sortScore: proven.score * 2 + dimensions.evidenceConfidence + Math.log10(totalUsage + 1) * 10,
+            dimensions,
             badge: totalUsage ? `${proven.score}/100 proven` : 'Needs first outcome',
             reason: totalUsage
               ? `${proven.summary} ${formatCompactNumber(installAttempts)} install attempts, ${riskBlocked} risk blocks, and ${quality.label.toLowerCase()} quality.`
@@ -343,13 +489,15 @@ export function rankSkillsForDefinition(
         case 'success-rate':
           return {
             skill,
-            score:
-              (successRate ?? 0) +
-              proven.score * 0.65 +
-              Math.min(18, Math.log10(totalUsage + 1) * 11) +
-              quality.score * 0.16 -
-              Math.min(24, riskBlocked * 5 + setupRequired * 2 + notRelevant * 4) -
-              skillSpecificPenalty,
+            score: clampScore(
+              (successRate ?? 0) * 0.42 +
+              dimensions.agentEvidence * 0.25 +
+              dimensions.evidenceConfidence * 0.2 +
+              dimensions.quality * 0.08 +
+              dimensions.installReadiness * 0.05
+            ),
+            sortScore: (successRate ?? 0) + dimensions.evidenceConfidence * 0.65 + proven.score * 0.35,
+            dimensions,
             badge: successRate === null ? 'No success data' : `${Math.round(successRate)}% success`,
             reason: totalUsage
               ? `${proven.summary} Recent success ${proven.metrics.recentSuccessRate === null ? 'unknown' : `${Math.round(proven.metrics.recentSuccessRate)}%`}.`
@@ -358,38 +506,57 @@ export function rankSkillsForDefinition(
         case 'safe-auto-install':
           return {
             skill,
-            score:
-              quality.score * 0.46 +
-              proven.score * 0.34 +
-              Math.min(18, Math.log10(Math.max(1, skill.github_stars || 1)) * 5) -
-              Math.min(40, riskBlocked * 10 + setupRequired * 4 + failures * 3 + notRelevant * 4) -
-              skillSpecificPenalty,
-            badge: riskBlocked > 0 ? 'Review risk' : 'Sandbox-ready',
+            score: weightedScore(dimensions, {
+              installReadiness: 0.38,
+              quality: 0.2,
+              agentEvidence: 0.18,
+              evidenceConfidence: 0.12,
+              freshness: 0.07,
+              popularity: 0.05,
+            }),
+            sortScore: dimensions.installReadiness * 1.5 + dimensions.agentEvidence + dimensions.evidenceConfidence - riskPenalty,
+            dimensions,
+            badge: riskBlocked > 0 ? 'Review risk' : totalUsage > 0 ? 'Evidence-backed' : 'Needs first run',
             reason: totalUsage
               ? `${proven.summary} ${riskBlocked} risk blocks and ${setupRequired} setup-required reports.`
-              : `${quality.label} quality, ${compactStars(skill)}, and no reported agent risk blocks yet.`,
+              : `${quality.label} quality and ${compactStars(skill)}; no real agent safety evidence yet.`,
           }
         case 'agent-platform':
           return {
             skill,
-            score:
-              (platformHit ? 78 : 0) +
-              quality.score * 0.3 +
-              proven.score * 0.25 +
-              Math.min(18, Math.log10(Math.max(1, skill.github_stars || 1)) * 5) -
-              Math.min(24, riskBlocked * 5 + setupRequired * 2 + notRelevant * 4) -
-              skillSpecificPenalty,
+            score: weightedScore(dimensions, {
+              fit: 0.5,
+              quality: 0.18,
+              installReadiness: 0.1,
+              agentEvidence: 0.08,
+              evidenceConfidence: 0.06,
+              popularity: 0.04,
+              freshness: 0.04,
+            }),
+            sortScore: platformFit * 2 + quality.score + proven.score * 0.5,
+            dimensions,
             badge: definition.agentPlatform ? definition.agentPlatform : 'Agent fit',
             reason: `${definition.shortTitle} fit with ${quality.label.toLowerCase()} quality, ${compactStars(skill)}, and ${proven.label.toLowerCase()}.`,
           }
         case 'highest-quality':
-        default:
+        default: {
+          const qualityRankingScore = weightedScore(dimensions, {
+            quality: 0.5,
+            freshness: 0.18,
+            installReadiness: 0.12,
+            agentEvidence: 0.1,
+            evidenceConfidence: 0.05,
+            popularity: 0.05,
+          })
           return {
             skill,
-            score: quality.score + Math.log10(Math.max(1, skill.github_stars || 1)) - skillSpecificPenalty,
-            badge: `${quality.label} · ${quality.score}`,
-            reason: `${quality.summary} ${compactStars(skill)}.`,
+            score: qualityRankingScore,
+            sortScore: qualityRankingScore - skillSpecificPenalty,
+            dimensions,
+            badge: `${quality.label} | ${quality.score}`,
+            reason: `${quality.summary} ${compactStars(skill)}; ${Math.round(dimensions.evidenceConfidence)}/100 evidence confidence.`,
           }
+        }
       }
     })
     .filter((item) => {
@@ -411,16 +578,18 @@ export function rankSkillsForDefinition(
 
       return true
     })
-    .sort((a, b) => {
-      if (definition.kind === 'new-this-week') {
-        return b.score - a.score || dateValue(b.skill.created_at) - dateValue(a.skill.created_at)
-      }
-      return b.score - a.score || b.skill.github_stars - a.skill.github_stars
-    })
+    .sort((a, b) => b.sortScore - a.sortScore || b.score - a.score || b.skill.github_stars - a.skill.github_stars)
 
   return dedupeRankedSkills(scored)
     .slice(0, limit)
-    .map((item, index) => ({ ...item, rank: index + 1 }))
+    .map((item, index) => ({
+      skill: item.skill,
+      score: clampScore(item.score),
+      badge: item.badge,
+      reason: item.reason,
+      dimensions: item.dimensions,
+      rank: index + 1,
+    }))
 }
 
 export function getRankingCompareHref(rankedSkills: RankedSkill[]) {

--- a/lib/resolve-fallbacks.ts
+++ b/lib/resolve-fallbacks.ts
@@ -1,0 +1,21 @@
+import type { SkillRecord } from '@/lib/db/skills'
+import { CURATED_SKILL_SNAPSHOT } from '@/lib/seo/curated-skill-snapshot'
+
+const STANDARD_SKILL_INSTALL = /^npx(?:\s+-y)?\s+skills(?:@latest)?\s+add\s+[^\s]+\s+--skill\s+[^\s]+$/i
+
+export function isTrustedResolveFallback(skill: SkillRecord) {
+  const repository = String(skill.repository || '')
+  const installCommand = String(skill.install_command || '').trim()
+
+  return (
+    skill.submission_source === 'curated_snapshot' &&
+    skill.verified === true &&
+    /^https:\/\/github\.com\/[^/]+\/[^/]+\/tree\//i.test(repository) &&
+    STANDARD_SKILL_INSTALL.test(installCommand)
+  )
+}
+
+// Resolver fallbacks are an availability safeguard, not extra inventory.
+// Only source-verified records that identify one concrete skill path may be
+// returned when the live registry is unavailable.
+export const TRUSTED_RESOLVE_FALLBACKS = CURATED_SKILL_SNAPSHOT.filter(isTrustedResolveFallback)


### PR DESCRIPTION
## Summary
- bound every public ranking score to 0–100 and expose explicit ranking dimensions
- normalize legacy text encoding and refresh ranking methodology
- remove misleading generic resolver fallbacks and mark trusted snapshots as non-live/manual-review only

## Verification
- pnpm run test
- pnpm run typecheck
- targeted ESLint
- pnpm run build
- local production API verification across all ranking types and resolver fallbacks