### PR TITLE
Fix MCP-aware Agent Skills being hidden

### DIFF
--- a/lib/blog/generate.ts
+++ b/lib/blog/generate.ts
@@ -10,6 +10,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { STATIC_BLOG_POSTS, getStaticBlogPostBySlug } from '@/lib/blog/static-posts'
 import { generateText } from 'ai'
 import { BLOG_GENERATION_MODEL } from '@/lib/ai/models'
+import { isMcpOnlySkillRecord } from '@/lib/skills/registry-scope'
 
 export interface BlogGenerateResult {
   success: boolean
@@ -51,10 +52,6 @@ function buildBlogSlug(skillSlug: string): string {
   return `introducing-${skillSlug}`
 }
 
-function isMcpText(value: string) {
-  return /(^|[^a-z0-9])mcp([^a-z0-9]|$)/i.test(value) || /\bmodel context protocol\b/i.test(value)
-}
-
 export function isBlogMcpSkillRecord(record: {
   name?: string | null
   description?: string | null
@@ -65,20 +62,7 @@ export function isBlogMcpSkillRecord(record: {
   frameworks?: string[] | null
   github_repo?: string | null
 }) {
-  const text = [
-    record.name,
-    record.description,
-    record.long_description,
-    record.tagline,
-    record.category,
-    record.github_repo,
-    ...(record.tags || []),
-    ...(record.frameworks || []),
-  ]
-    .filter(Boolean)
-    .join(' ')
-
-  return isMcpText(text)
+  return isMcpOnlySkillRecord(record)
 }
 
 function toSkillPreview(row: BlogSkillRow): BlogSkillPreview {

--- a/lib/db/skills.ts
+++ b/lib/db/skills.ts
@@ -1,6 +1,7 @@
 import { createPublicClient } from '@/lib/supabase/public'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { withTimeout } from '@/lib/async'
+import { isMcpOnlyCategory, isMcpOnlySkillRecord } from '@/lib/skills/registry-scope'
 import { unstable_cache } from 'next/cache'
 import type { Skill } from '@/lib/types'
 import { CURATED_SKILL_SNAPSHOT } from '@/lib/seo/curated-skill-snapshot'
@@ -145,32 +146,13 @@ function createSitemapClient(requestTimeoutMs = SITEMAP_QUERY_TIMEOUT_MS) {
   return createPublicClient({ requestTimeoutMs })
 }
 
-function isMcpText(value: string) {
-  return /(^|[^a-z0-9])mcp([^a-z0-9]|$)/i.test(value) || /\bmodel context protocol\b/i.test(value)
-}
-
 type SkillOnlyScopeRecord = Pick<
   SkillRecord,
   'name' | 'description' | 'long_description' | 'tagline' | 'category' | 'tags' | 'frameworks' | 'github_repo'
 >
 
-function isMcpSkillRecord(record: SkillOnlyScopeRecord) {
-  const text = [
-    record.name,
-    record.description,
-    record.long_description,
-    record.tagline,
-    record.category,
-    record.github_repo,
-    ...(record.tags || []),
-    ...(record.frameworks || []),
-  ].join(' ')
-
-  return isMcpText(text)
-}
-
 function filterSkillOnly<T extends SkillOnlyScopeRecord>(records: T[]) {
-  return records.filter((record) => !isMcpSkillRecord(record))
+  return records.filter((record) => !isMcpOnlySkillRecord(record))
 }
 
 function sortDirectorySkills(records: SkillRecord[], sort: SkillSortMode) {
@@ -841,7 +823,7 @@ const getCachedCategories = unstable_cache(
     }
 
     return [...categories]
-      .filter((category) => !isMcpText(category))
+      .filter((category) => !isMcpOnlyCategory(category))
       .sort()
   },
   ['public-skill-categories-v2'],
@@ -871,7 +853,7 @@ const getCachedSkillBySlug = unstable_cache(
       .maybeSingle()
 
     if (error) throw error
-    if (!data || isMcpSkillRecord(data)) return null
+    if (!data || isMcpOnlySkillRecord(data)) return null
     return data as SkillRecord
   },
   ['public-skill-by-slug-v3'],

--- a/lib/skills/registry-scope.ts
+++ b/lib/skills/registry-scope.ts
@@ -1,0 +1,39 @@
+export interface RegistryScopeRecord {
+  name?: string | null
+  description?: string | null
+  long_description?: string | null
+  tagline?: string | null
+  category?: string | null
+  tags?: string[] | null
+  frameworks?: string[] | null
+  github_repo?: string | null
+}
+
+const MCP_ONLY_CATEGORY = /^(?:mcp|mcp[-_\s]?(?:server|servers|registry)|model[-_\s]?context[-_\s]?protocol)$/i
+const MCP_ONLY_MARKER = /^(?:mcp[-_\s]?(?:server|servers|client|host|gateway|proxy|registry)|model[-_\s]?context[-_\s]?protocol)$/i
+const MCP_SERVER_IDENTITY = /\bmcp[-_\s]?(?:server|servers|client|host|gateway|proxy|registry)\b|\bmodel context protocol\b/i
+const BARE_MCP_IDENTITY = /(^|[^a-z0-9])mcp([^a-z0-9]|$)/i
+const SKILL_IDENTITY = /(^|[^a-z0-9])skills?([^a-z0-9]|$)/i
+
+export function isMcpOnlyCategory(category: string | null | undefined) {
+  return MCP_ONLY_CATEGORY.test((category || '').trim())
+}
+
+/**
+ * Exclude MCP-only products without hiding Agent Skills that merely inspect,
+ * configure, secure, or otherwise mention MCP servers in their instructions.
+ */
+export function isMcpOnlySkillRecord(record: RegistryScopeRecord) {
+  if (isMcpOnlyCategory(record.category)) return true
+
+  const markers = [...(record.tags || []), ...(record.frameworks || [])]
+    .map((value) => value.trim())
+    .filter(Boolean)
+  if (markers.some((value) => MCP_ONLY_MARKER.test(value))) return true
+
+  const identity = [record.name, record.github_repo].filter(Boolean).join(' ')
+  if (MCP_SERVER_IDENTITY.test(identity)) return true
+
+  const skillIdentity = [identity, ...markers].join(' ')
+  return BARE_MCP_IDENTITY.test(identity) && !SKILL_IDENTITY.test(skillIdentity)
+}

--- a/scripts/test-security-regressions.ts
+++ b/scripts/test-security-regressions.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 // Node's type-stripping runner needs the explicit extension.
 // @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
 import { SkillSubmissionSchema } from '../lib/schema/skill-schema.ts'
+// @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
+import { isMcpOnlySkillRecord } from '../lib/skills/registry-scope.ts'
 
 const validSubmission = {
   name: 'Secure repository skill',
@@ -30,5 +32,29 @@ for (const repository of [
   const result = SkillSubmissionSchema.safeParse({ ...validSubmission, repository })
   assert.equal(result.success, false, `expected rejection for ${repository}`)
 }
+
+assert.equal(isMcpOnlySkillRecord({
+  name: 'Plugin Scanner',
+  description: 'Scans Agent Skills and MCP servers before installation.',
+  category: 'security',
+  tags: ['mcp-security', 'agent-skill'],
+  github_repo: 'hashgraph-online/hol-guard-plugin',
+}), false, 'security skills that mention MCP must remain visible')
+
+assert.equal(isMcpOnlySkillRecord({
+  name: 'MCP Server for Example API',
+  description: 'A Model Context Protocol transport.',
+  category: 'integration',
+  tags: ['mcp-server'],
+  github_repo: 'example/example-mcp-server',
+}), true, 'MCP-only servers must remain excluded')
+
+assert.equal(isMcpOnlySkillRecord({
+  name: 'MCP Builder Skill',
+  description: 'A reusable Agent Skill for reviewing MCP integrations.',
+  category: 'developer-tools',
+  tags: ['agent-skill'],
+  github_repo: 'example/mcp-builder-skill',
+}), false, 'explicit Agent Skills must not be hidden by MCP identity terms')
 
 console.log('Security regression tests passed.')


### PR DESCRIPTION
## Summary
- distinguish MCP-only projects from Agent Skills that mention, inspect, or secure MCP
- apply the same scope rule to directory, detail, category, and blog reads
- add regression coverage for MCP security Skills and MCP-only servers

## Verification
- pnpm run test:security
- pnpm run typecheck
- pnpm run build

Closes the visibility defect discovered while re-reviewing #52.