### PR TITLE
Establish creator ownership foundation

### DIFF
--- a/app/api/claims/route.ts
+++ b/app/api/claims/route.ts
@@ -1,20 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import {
+  CLAIM_CHALLENGE_TTL_MS,
+  createClaimChallenge,
+  getClaimChallengePath,
+  getGitHubIdentity,
+  hashClaimChallenge,
+  parseSkillRepository,
+} from '@/lib/creator-ownership'
 
 const ClaimSchema = z.object({
-  skill_slug: z.string().min(1).max(200),
-  github_username: z.string().max(39).regex(/^$|^[a-z0-9]([a-z0-9-]{0,37}[a-z0-9])?$/i).optional().default(''),
-  x_username: z.string().max(15).regex(/^$|^[a-z0-9_]{1,15}$/i).optional().default(''),
-  repo_url: z.string().url().nullable().optional(),
-  verification_method: z.enum(['github_profile', 'repository_issue', 'website_link', 'manual']).default('github_profile'),
-  evidence_url: z.string().url().nullable().optional(),
-  evidence_note: z.string().max(2000).nullable().optional(),
-}).superRefine((value, context) => {
-  if (!value.github_username && !value.x_username && !value.evidence_url) {
-    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Add a GitHub handle, X handle, or evidence URL.' })
-  }
+  skill_slug: z.string().trim().min(1).max(200).regex(/^[a-z0-9][a-z0-9-]*$/),
+  github_username: z.string().trim().max(39).regex(/^$|^[a-z0-9]([a-z0-9-]{0,37}[a-z0-9])?$/i).optional().default(''),
+  x_username: z.string().trim().max(15).regex(/^$|^[a-z0-9_]{1,15}$/i).optional().default(''),
+  evidence_url: z.union([z.literal(''), z.string().url().max(500)]).nullable().optional(),
+  evidence_note: z.string().trim().max(2000).nullable().optional(),
 })
+
+const CLAIM_SELECT = [
+  'id', 'skill_slug', 'github_username', 'x_username', 'repo_url',
+  'evidence_url', 'evidence_note', 'verification_method', 'verification_tier',
+  'verified_at', 'challenge_expires_at', 'status', 'created_at', 'updated_at',
+].join(',')
 
 export async function GET(request: NextRequest) {
   const skillSlug = request.nextUrl.searchParams.get('skill_slug')
@@ -26,71 +35,133 @@ export async function GET(request: NextRequest) {
 
   const { data, error } = await supabase
     .from('skill_claims')
-    .select('id, skill_slug, github_username, x_username, evidence_url, evidence_note, verification_method, status, created_at, updated_at')
+    .select(CLAIM_SELECT)
     .eq('skill_slug', skillSlug)
     .eq('user_id', user.id)
     .maybeSingle()
 
-  if (error) {
-    return NextResponse.json({ error: 'Failed to load claim', details: error.message }, { status: 500 })
-  }
-
+  if (error) return NextResponse.json({ error: 'Failed to load claim' }, { status: 500 })
   return NextResponse.json({ claim: data || null })
 }
 
 export async function POST(request: NextRequest) {
   const parsed = ClaimSchema.safeParse(await request.json().catch(() => null))
-  if (!parsed.success) {
-    return NextResponse.json({ error: 'Invalid claim payload' }, { status: 400 })
-  }
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid claim payload' }, { status: 400 })
 
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { error: profileError } = await supabase.from('profiles').upsert({
-    id: user.id,
-    display_name: user.email?.split('@')[0] || parsed.data.github_username || parsed.data.x_username,
-    github_username: parsed.data.github_username.toLowerCase() || null,
-    x_username: parsed.data.x_username.toLowerCase() || null,
-  })
+  const admin = createAdminClient({ requestTimeoutMs: 15_000 })
+  const { data: skill, error: skillError } = await admin
+    .from('skills')
+    .select('slug,name,repository,github_repo,ai_review_approved')
+    .eq('slug', parsed.data.skill_slug)
+    .eq('ai_review_approved', true)
+    .maybeSingle()
+  if (skillError || !skill) return NextResponse.json({ error: 'Skill not found' }, { status: 404 })
 
-  if (profileError) {
-    return NextResponse.json({ error: 'Failed to prepare profile', details: profileError.message }, { status: 500 })
+  const repository = parseSkillRepository(skill.repository, skill.github_repo)
+  if (!repository) return NextResponse.json({ error: 'This listing has no verifiable GitHub source.' }, { status: 422 })
+
+  const githubIdentity = getGitHubIdentity(user)
+  const requestedGitHub = parsed.data.github_username.replace(/^@/, '').toLowerCase()
+  const githubUsername = (githubIdentity?.username || requestedGitHub || repository.owner).toLowerCase()
+  const xUsername = parsed.data.x_username.replace(/^@/, '').toLowerCase() || null
+  const oauthOwnerMatch = Boolean(
+    githubIdentity && githubIdentity.username.toLowerCase() === repository.owner.toLowerCase()
+  )
+  const challenge = oauthOwnerMatch ? null : createClaimChallenge()
+  const challengePath = getClaimChallengePath(skill.slug)
+  const now = new Date()
+  const challengeExpiresAt = challenge ? new Date(now.getTime() + CLAIM_CHALLENGE_TTL_MS).toISOString() : null
+
+  const profilePayload: Record<string, unknown> = {
+    id: user.id,
+    display_name: user.email?.split('@')[0] || githubUsername || xUsername || 'Creator',
+    github_username: githubUsername || null,
+    x_username: xUsername,
+    twitter: xUsername ? `https://x.com/${xUsername}` : null,
+    updated_at: now.toISOString(),
+  }
+  if (githubIdentity) {
+    const githubId = Number(githubIdentity.id)
+    profilePayload.github_user_id = Number.isSafeInteger(githubId) ? githubId : null
+    profilePayload.github_verified_at = now.toISOString()
+    if (githubIdentity.avatarUrl) profilePayload.avatar_url = githubIdentity.avatarUrl
+  }
+  const { error: profileError } = await admin.from('profiles').upsert(profilePayload)
+  if (profileError) return NextResponse.json({ error: 'Failed to prepare creator profile' }, { status: 500 })
+
+  const { data: existing } = await admin
+    .from('skill_claims')
+    .select('id,status')
+    .eq('skill_slug', skill.slug)
+    .eq('user_id', user.id)
+    .maybeSingle()
+  if (existing?.status === 'approved') {
+    const { data: approvedClaim } = await admin.from('skill_claims').select(CLAIM_SELECT).eq('id', existing.id).single()
+    return NextResponse.json({ ok: true, claim: approvedClaim, alreadyVerified: true })
   }
 
-  const { data, error } = await supabase
+  const status = oauthOwnerMatch ? 'approved' : 'pending'
+  const { data: claim, error: claimError } = await admin
     .from('skill_claims')
     .upsert({
-      skill_slug: parsed.data.skill_slug,
+      skill_slug: skill.slug,
       user_id: user.id,
-      github_username: parsed.data.github_username.toLowerCase() || null,
-      x_username: parsed.data.x_username.toLowerCase() || null,
-      repo_url: parsed.data.repo_url || null,
-      verification_method: parsed.data.github_username ? parsed.data.verification_method : parsed.data.x_username ? 'manual' : 'website_link',
-      evidence_url: parsed.data.evidence_url || null,
+      github_username: githubUsername || null,
+      x_username: xUsername,
+      repo_url: `https://github.com/${repository.owner}/${repository.repo}`,
+      verification_method: oauthOwnerMatch ? 'github_oauth' : 'repository_file',
+      verification_tier: 'maintainer',
+      verified_at: oauthOwnerMatch ? now.toISOString() : null,
+      evidence_url: parsed.data.evidence_url || skill.repository,
       evidence_note: parsed.data.evidence_note || null,
-      status: 'pending',
+      challenge_token_hash: challenge ? hashClaimChallenge(challenge) : null,
+      challenge_expires_at: challengeExpiresAt,
+      status,
+      reviewer_note: null,
       metadata: {
         source: 'skill_detail_page',
+        repository_owner: repository.owner,
+        challenge_path: challengePath,
+        github_oauth_owner_match: oauthOwnerMatch,
       },
-    }, {
-      onConflict: 'skill_slug,user_id',
-    })
-    .select('id, skill_slug, github_username, x_username, evidence_url, evidence_note, verification_method, status, created_at, updated_at')
+      updated_at: now.toISOString(),
+    }, { onConflict: 'skill_slug,user_id' })
+    .select(CLAIM_SELECT)
     .single()
 
-  if (error) {
-    return NextResponse.json({ error: 'Failed to submit claim', details: error.message }, { status: 500 })
+  if (claimError) return NextResponse.json({ error: 'Failed to submit claim' }, { status: 500 })
+
+  if (status === 'approved') {
+    await admin.from('skills').update({
+      author_user_id: user.id,
+      publisher_github: githubUsername,
+      publisher_x: xUsername,
+      publisher_verified: true,
+    }).eq('slug', skill.slug)
   }
 
-  await supabase.from('skill_events').insert({
-    skill_slug: parsed.data.skill_slug,
+  await admin.from('skill_events').insert({
+    skill_slug: skill.slug,
     event_type: 'claim_submit',
     user_id: user.id,
-    path: `/skills/${parsed.data.skill_slug}`,
-    metadata: { source: 'claim_api' },
+    path: `/skills/${skill.slug}`,
+    source: 'creator_claim',
+    is_verified: false,
+    metadata: { verification_method: oauthOwnerMatch ? 'github_oauth' : 'repository_file' },
   })
 
-  return NextResponse.json({ ok: true, claim: data })
+  return NextResponse.json({
+    ok: true,
+    claim,
+    challenge: challenge ? {
+      token: challenge,
+      path: challengePath,
+      expires_at: challengeExpiresAt,
+      repository: `https://github.com/${repository.owner}/${repository.repo}`,
+    } : null,
+  })
 }

--- a/app/api/claims/verify/route.ts
+++ b/app/api/claims/verify/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import {
+  challengeMatches,
+  fetchRepositoryChallenge,
+  getClaimChallengePath,
+  parseSkillRepository,
+} from '@/lib/creator-ownership'
+import { validateGitHubRepo } from '@/lib/github/api'
+
+const VerifySchema = z.object({
+  skill_slug: z.string().trim().min(1).max(200).regex(/^[a-z0-9][a-z0-9-]*$/),
+})
+
+export async function POST(request: NextRequest) {
+  const parsed = VerifySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid verification request' }, { status: 400 })
+
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const admin = createAdminClient({ requestTimeoutMs: 15_000 })
+  const { data: claim } = await admin
+    .from('skill_claims')
+    .select('id,skill_slug,user_id,status,github_username,x_username,challenge_token_hash,challenge_expires_at')
+    .eq('skill_slug', parsed.data.skill_slug)
+    .eq('user_id', user.id)
+    .maybeSingle()
+  if (!claim) return NextResponse.json({ error: 'Claim not found' }, { status: 404 })
+  if (claim.status === 'approved') return NextResponse.json({ ok: true, alreadyVerified: true })
+  if (!claim.challenge_token_hash || !claim.challenge_expires_at) {
+    return NextResponse.json({ error: 'Create a fresh repository challenge first.' }, { status: 409 })
+  }
+  if (Date.parse(claim.challenge_expires_at) <= Date.now()) {
+    return NextResponse.json({ error: 'Challenge expired. Generate a new challenge.' }, { status: 410 })
+  }
+
+  const { data: skill } = await admin
+    .from('skills')
+    .select('repository,github_repo')
+    .eq('slug', claim.skill_slug)
+    .maybeSingle()
+  const repository = parseSkillRepository(skill?.repository, skill?.github_repo)
+  if (!repository) return NextResponse.json({ error: 'Repository source is unavailable.' }, { status: 422 })
+
+  const repo = await validateGitHubRepo(`${repository.owner}/${repository.repo}`, {
+    checkReadme: false,
+    checkSkillJson: false,
+  }).catch(() => null)
+  if (!repo) return NextResponse.json({ error: 'Could not read the GitHub repository.' }, { status: 502 })
+
+  const challengePath = getClaimChallengePath(claim.skill_slug)
+  const value = await fetchRepositoryChallenge({
+    owner: repository.owner,
+    repo: repository.repo,
+    ref: repository.ref || repo.defaultBranch,
+    path: challengePath,
+  })
+  if (!value || !challengeMatches(value, claim.challenge_token_hash)) {
+    return NextResponse.json({
+      error: `Verification file not found or token mismatch at ${challengePath}.`,
+    }, { status: 422 })
+  }
+
+  const verifiedAt = new Date().toISOString()
+  const { error } = await admin.from('skill_claims').update({
+    status: 'approved',
+    verification_method: 'repository_file',
+    verification_tier: 'maintainer',
+    verified_at: verifiedAt,
+    challenge_token_hash: null,
+    challenge_expires_at: null,
+    reviewer_note: 'Repository ownership challenge verified automatically.',
+    updated_at: verifiedAt,
+  }).eq('id', claim.id).eq('user_id', user.id).eq('status', 'pending')
+  if (error) return NextResponse.json({ error: 'Could not approve the claim.' }, { status: 500 })
+
+  await admin.from('skills').update({
+    author_user_id: user.id,
+    publisher_github: claim.github_username || repository.owner,
+    publisher_x: claim.x_username,
+    publisher_verified: true,
+  }).eq('slug', claim.skill_slug)
+
+  return NextResponse.json({ ok: true, status: 'approved', verified_at: verifiedAt })
+}

--- a/app/api/cron/skill-source-sync/route.ts
+++ b/app/api/cron/skill-source-sync/route.ts
@@ -57,6 +57,37 @@ async function staleIndexedRepositories(limit: number): Promise<SourceRequest[]>
     }))
 }
 
+async function staleClaimedRepositories(limit: number): Promise<SourceRequest[]> {
+  if (limit <= 0) return []
+  const supabase = createPublicClient({ requestTimeoutMs: 12_000 })
+  const { data: claims, error: claimError } = await supabase
+    .from('skill_claims')
+    .select('skill_slug')
+    .eq('status', 'approved')
+    .limit(Math.max(limit * 5, 25))
+
+  if (claimError || !claims?.length) return []
+  const slugs = Array.from(new Set(claims.map((claim) => claim.skill_slug).filter(Boolean)))
+  const { data: skills, error: skillError } = await supabase
+    .from('skills')
+    .select('github_repo,last_synced_at')
+    .in('slug', slugs)
+    .eq('ai_review_approved', true)
+    .not('github_repo', 'is', null)
+    .order('last_synced_at', { ascending: true, nullsFirst: true })
+    .limit(limit)
+
+  if (skillError) {
+    console.warn('[skill-source-sync] claimed repository lookup failed:', skillError.message)
+    return []
+  }
+
+  return uniqueSources((skills || []).map((row) => ({
+    sourceUrl: normalizeRepositoryUrl(String(row.github_repo)),
+    discoverySource: 'claimed-repository-rescan',
+  }))).slice(0, limit)
+}
+
 async function handleRun(request: NextRequest) {
   if (!isAutomationAuthorized(request, ['CRON_SECRET', 'INDEXER_SECRET', 'INDEXER_TRIGGER_SECRET'])) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -71,9 +102,11 @@ async function handleRun(request: NextRequest) {
         .filter(Boolean)
         .map((sourceUrl: string) => ({ sourceUrl, discoverySource: 'manual-source-sync' }))
     : []
-  const staleSources = await staleIndexedRepositories(Math.max(0, limit - HIGH_SIGNAL_SKILL_SOURCES.length))
+  const claimedSources = await staleClaimedRepositories(Math.max(2, Math.floor(limit / 2)))
+  const staleSources = await staleIndexedRepositories(limit)
   const sources = uniqueSources([
     ...requestedSources,
+    ...claimedSources,
     ...HIGH_SIGNAL_SKILL_SOURCES.map(({ sourceUrl, discoverySource }) => ({ sourceUrl, discoverySource })),
     ...staleSources,
   ]).slice(0, limit)
@@ -84,7 +117,7 @@ async function handleRun(request: NextRequest) {
       results.push(await syncRepositorySkills({
         reference: source.sourceUrl,
         discoverySource: source.discoverySource,
-        maxSkills: source.discoverySource === 'incremental-repository-rescan' ? 6 : 4,
+        maxSkills: source.discoverySource.includes('repository-rescan') ? 6 : 4,
       }))
     } catch (error) {
       results.push({

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getGitHubIdentity } from '@/lib/creator-ownership'
+
+function safeNext(value: string | null) {
+  return value && value.startsWith('/') && !value.startsWith('//') ? value : '/creator'
+}
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get('code')
+  const next = safeNext(request.nextUrl.searchParams.get('next'))
+  const redirectUrl = new URL(next, request.nextUrl.origin)
+
+  if (!code) {
+    redirectUrl.searchParams.set('error', 'oauth-code-missing')
+    return NextResponse.redirect(redirectUrl)
+  }
+
+  const supabase = await createClient()
+  const { error } = await supabase.auth.exchangeCodeForSession(code)
+  if (error) {
+    redirectUrl.searchParams.set('error', 'github-connect-failed')
+    return NextResponse.redirect(redirectUrl)
+  }
+
+  const { data: { user } } = await supabase.auth.getUser()
+  const github = user ? getGitHubIdentity(user) : null
+  if (user && github) {
+    const githubId = Number(github.id)
+    await supabase.from('profiles').upsert({
+      id: user.id,
+      github_username: github.username.toLowerCase(),
+      github_user_id: Number.isSafeInteger(githubId) ? githubId : null,
+      github_verified_at: new Date().toISOString(),
+      ...(github.avatarUrl ? { avatar_url: github.avatarUrl } : {}),
+      updated_at: new Date().toISOString(),
+    })
+    redirectUrl.searchParams.set('connected', 'github')
+  }
+
+  return NextResponse.redirect(redirectUrl)
+}

--- a/app/creator/actions.ts
+++ b/app/creator/actions.ts
@@ -30,8 +30,18 @@ export async function updateCreatorProfile(formData: FormData) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/auth/login?next=/creator')
 
-  const githubUsername = parsed.data.github_username.toLowerCase() || null
-  const xUsername = parsed.data.x_username.toLowerCase() || null
+  const { data: currentProfile } = await supabase
+    .from('profiles')
+    .select('github_username,github_verified_at,x_username,x_verified_at')
+    .eq('id', user.id)
+    .maybeSingle()
+
+  const githubUsername = currentProfile?.github_verified_at
+    ? currentProfile.github_username
+    : parsed.data.github_username.toLowerCase() || null
+  const xUsername = currentProfile?.x_verified_at
+    ? currentProfile.x_username
+    : parsed.data.x_username.toLowerCase() || null
   const { error } = await supabase.from('profiles').upsert({
     id: user.id,
     username: parsed.data.username.toLowerCase(),

--- a/app/creator/page.tsx
+++ b/app/creator/page.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import { CheckCircle2, Circle, ExternalLink, GitCommitHorizontal, ShieldCheck } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
+import { CreatorIdentityConnections } from '@/components/creator-identity-connections'
+import { MarketingPageShell } from '@/components/marketing-page'
 import { updateCreatorProfile } from './actions'
 
 export const dynamic = 'force-dynamic'
@@ -9,10 +12,23 @@ function metric(value: unknown) {
   return Number(value || 0).toLocaleString('en-US')
 }
 
+function percent(numerator: number, denominator: number) {
+  return denominator > 0 ? `${Math.round((numerator / denominator) * 100)}%` : '—'
+}
+
+function shortSha(value: string | null | undefined) {
+  return value ? value.slice(0, 7) : 'not tracked'
+}
+
+function dateLabel(value: string | null | undefined) {
+  if (!value) return 'Not synced yet'
+  return new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(value))
+}
+
 export default async function CreatorDashboard({
   searchParams,
 }: {
-  searchParams: Promise<{ saved?: string; error?: string }>
+  searchParams: Promise<{ saved?: string; connected?: string; error?: string }>
 }) {
   const params = await searchParams
   const supabase = await createClient()
@@ -23,15 +39,15 @@ export default async function CreatorDashboard({
     supabase.from('profiles').select('*').eq('id', user.id).maybeSingle(),
     supabase
       .from('skill_claims')
-      .select('id,skill_slug,status,github_username,x_username,created_at,updated_at')
+      .select('id,skill_slug,status,github_username,x_username,verification_method,verification_tier,verified_at,challenge_expires_at,created_at,updated_at')
       .eq('user_id', user.id)
       .order('updated_at', { ascending: false }),
   ])
 
   const approvedSlugs = (claims || []).filter((claim) => claim.status === 'approved').map((claim) => claim.skill_slug)
-  const [{ data: skills }, { data: events }, { data: outcomes }] = await Promise.all([
+  const [{ data: skills }, { data: events }, { data: outcomes }, { data: dailyEvents }, { data: versions }] = await Promise.all([
     approvedSlugs.length
-      ? supabase.from('skills').select('slug,name,category,repository').in('slug', approvedSlugs)
+      ? supabase.from('skills').select('slug,name,category,repository,version,license,license_source,license_status,source_commit_sha,source_sync_status,last_synced_at').in('slug', approvedSlugs)
       : Promise.resolve({ data: [] }),
     approvedSlugs.length
       ? supabase.from('skill_event_stats').select('*').in('skill_slug', approvedSlugs)
@@ -39,10 +55,18 @@ export default async function CreatorDashboard({
     approvedSlugs.length
       ? supabase.from('agent_outcome_stats').select('*').in('skill_slug', approvedSlugs)
       : Promise.resolve({ data: [] }),
+    approvedSlugs.length
+      ? supabase.from('skill_events_daily').select('skill_slug,event_date,views,install_starts,install_successes,outcome_successes').in('skill_slug', approvedSlugs).order('event_date', { ascending: false }).limit(Math.max(30, approvedSlugs.length * 31))
+      : Promise.resolve({ data: [] }),
+    approvedSlugs.length
+      ? supabase.from('skill_versions').select('skill_slug,source_content_hash,detected_at').in('skill_slug', approvedSlugs).order('detected_at', { ascending: false })
+      : Promise.resolve({ data: [] }),
   ])
 
   const eventMap = new Map((events || []).map((row) => [row.skill_slug, row]))
   const outcomeMap = new Map((outcomes || []).map((row) => [row.skill_slug, row]))
+  const versionCounts = new Map<string, number>()
+  for (const row of versions || []) versionCounts.set(row.skill_slug, (versionCounts.get(row.skill_slug) || 0) + 1)
   const totals = (skills || []).reduce(
     (sum, skill) => {
       const event = eventMap.get(skill.slug)
@@ -55,65 +79,104 @@ export default async function CreatorDashboard({
     },
     { views: 0, installStarts: 0, verifiedInstalls: 0, successes: 0 }
   )
+  const last30 = (dailyEvents || []).reduce((sum, row) => ({
+    views: sum.views + Number(row.views || 0),
+    starts: sum.starts + Number(row.install_starts || 0),
+    installs: sum.installs + Number(row.install_successes || 0),
+    outcomes: sum.outcomes + Number(row.outcome_successes || 0),
+  }), { views: 0, starts: 0, installs: 0, outcomes: 0 })
   const username = profile?.username || user.email?.split('@')[0]?.toLowerCase().replace(/[^a-z0-9-]/g, '-') || 'creator'
+  const hasVerifiedClaim = approvedSlugs.length > 0
+  const steps = [
+    { label: 'Account', detail: user.email || 'Signed in', done: true },
+    { label: 'Identity', detail: profile?.github_verified_at ? 'GitHub OAuth verified' : 'Repository proof available', done: Boolean(profile?.github_verified_at) },
+    { label: 'Ownership', detail: hasVerifiedClaim ? `${approvedSlugs.length} verified skill${approvedSlugs.length === 1 ? '' : 's'}` : 'Claim your first listing', done: hasVerifiedClaim },
+    { label: 'Outcomes', detail: totals.verifiedInstalls ? `${metric(totals.verifiedInstalls)} verified installs` : 'Waiting for first receipt', done: totals.verifiedInstalls > 0 },
+  ]
 
   return (
-    <main className="mx-auto min-h-screen max-w-6xl px-6 py-16">
-      <div className="flex flex-wrap items-end justify-between gap-4 border-b border-border pb-8">
+    <MarketingPageShell><div className="mx-auto min-h-screen max-w-6xl px-5 py-12 sm:px-6 sm:py-16">
+      <header className="grid gap-8 border-b border-border pb-10 lg:grid-cols-[1.25fr_0.75fr] lg:items-end">
         <div>
-          <p className="font-mono text-xs uppercase tracking-[0.22em] text-secondary">Creator Console</p>
-          <h1 className="mt-3 font-display text-4xl font-semibold">Own the listing. Prove the outcome.</h1>
-          <p className="mt-3 max-w-2xl text-secondary">Bind an optional GitHub or X identity, claim skills, and measure the complete path from discovery to verified agent success.</p>
+          <p className="font-mono text-xs uppercase tracking-[0.22em] text-secondary">Creator ownership console</p>
+          <h1 className="mt-4 max-w-3xl font-display text-4xl font-semibold leading-[0.98] sm:text-6xl">Turn a GitHub repository into a verified creator asset.</h1>
+          <p className="mt-5 max-w-2xl text-base leading-7 text-secondary">Claim provenance, keep source versions synchronized, publish license evidence, and see the path from discovery to a successful Agent outcome.</p>
         </div>
-        {profile?.username ? <Link className="border border-border px-4 py-2 text-sm hover:border-foreground" href={`/creators/${profile.username}`}>View public profile</Link> : null}
-      </div>
+        <div className="flex flex-wrap gap-3 lg:justify-end">
+          <Link href="/submit" className="bg-foreground px-4 py-3 text-sm font-semibold text-background">Add a skill</Link>
+          {profile?.username ? <Link className="inline-flex items-center gap-2 border border-border px-4 py-3 text-sm hover:border-foreground" href={`/creators/${profile.username}`}>Public profile <ExternalLink className="size-3.5" /></Link> : null}
+        </div>
+      </header>
 
-      {params.saved ? <p className="mt-6 border border-emerald-600/40 bg-emerald-500/5 p-3 text-sm">Profile saved.</p> : null}
-      {params.error ? <p className="mt-6 border border-red-600/40 bg-red-500/5 p-3 text-sm">Could not save this profile. Check the fields or choose another public handle.</p> : null}
+      {params.saved ? <p className="mt-6 border border-emerald-600/40 bg-emerald-500/5 p-3 text-sm">Creator profile saved.</p> : null}
+      {params.connected === 'github' ? <p className="mt-6 border border-emerald-600/40 bg-emerald-500/5 p-3 text-sm">GitHub identity connected and verified.</p> : null}
+      {params.error ? <p className="mt-6 border border-red-600/40 bg-red-500/5 p-3 text-sm">Could not complete that action. Check the fields or try repository verification.</p> : null}
 
-      <section className="mt-8 grid gap-px border border-border bg-border sm:grid-cols-2 lg:grid-cols-4">
-        {[
-          ['Views', totals.views],
-          ['Install starts', totals.installStarts],
-          ['Verified installs', totals.verifiedInstalls],
-          ['Successful outcomes', totals.successes],
-        ].map(([label, value]) => (
-          <div key={String(label)} className="bg-background p-5">
-            <p className="font-mono text-xs uppercase tracking-[0.16em] text-secondary">{label}</p>
-            <p className="mt-3 font-display text-3xl">{metric(value)}</p>
+      <section className="mt-8 grid gap-px border border-border bg-border sm:grid-cols-2 lg:grid-cols-4" aria-label="Ownership progress">
+        {steps.map((step, index) => (
+          <div key={step.label} className="bg-background p-5">
+            <div className="flex items-center justify-between">
+              <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-secondary">0{index + 1}</span>
+              {step.done ? <CheckCircle2 className="size-4 text-emerald-700" /> : <Circle className="size-4 text-secondary" />}
+            </div>
+            <p className="mt-6 font-semibold">{step.label}</p>
+            <p className="mt-1 text-xs text-secondary">{step.detail}</p>
           </div>
         ))}
       </section>
 
-      <section className="mt-10 grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
-        <form action={updateCreatorProfile} className="border border-border p-6">
-          <h2 className="font-display text-2xl">Creator identity</h2>
-          <p className="mt-2 text-sm text-secondary">GitHub and X are optional. A public handle gives your claimed skills a citable creator page.</p>
-          <div className="mt-6 space-y-4">
-            {[
-              ['username', 'Public profile handle', username],
-              ['display_name', 'Display name', profile?.display_name || ''],
-              ['website', 'Website', profile?.website || ''],
-              ['github_username', 'GitHub username (optional)', profile?.github_username || ''],
-              ['x_username', 'X username (optional)', profile?.x_username || ''],
-            ].map(([name, label, value]) => (
-              <label key={name} className="block text-sm">
-                <span className="mb-1 block text-secondary">{label}</span>
-                <input name={name} defaultValue={value} className="w-full border border-border bg-background px-3 py-2 outline-none focus:border-foreground" />
-              </label>
-            ))}
-            <label className="block text-sm">
-              <span className="mb-1 block text-secondary">Bio</span>
-              <textarea name="bio" rows={4} defaultValue={profile?.bio || ''} className="w-full border border-border bg-background px-3 py-2 outline-none focus:border-foreground" />
-            </label>
-            <button className="w-full bg-foreground px-4 py-3 font-semibold text-background">Save creator profile</button>
+      <section className="mt-10 grid gap-px border border-border bg-border sm:grid-cols-2 lg:grid-cols-4" aria-label="Creator analytics">
+        {[
+          ['Views', totals.views, `${metric(last30.views)} in 30 days`],
+          ['Install starts', totals.installStarts, `${percent(totals.installStarts, totals.views)} from views`],
+          ['Verified installs', totals.verifiedInstalls, `${percent(totals.verifiedInstalls, totals.installStarts)} completion`],
+          ['Successful outcomes', totals.successes, `${percent(totals.successes, totals.verifiedInstalls)} post-install success`],
+        ].map(([label, value, note]) => (
+          <div key={String(label)} className="bg-background p-5">
+            <p className="font-mono text-xs uppercase tracking-[0.16em] text-secondary">{label}</p>
+            <p className="mt-3 font-display text-3xl">{metric(value)}</p>
+            <p className="mt-2 text-xs text-secondary">{note}</p>
           </div>
-        </form>
+        ))}
+      </section>
 
-        <div className="border border-border">
+      <section className="mt-10 grid gap-8 lg:grid-cols-[0.92fr_1.08fr]">
+        <div className="space-y-8">
+          <CreatorIdentityConnections
+            githubUsername={profile?.github_username}
+            githubVerifiedAt={profile?.github_verified_at}
+            xUsername={profile?.x_username}
+            githubOAuthEnabled={process.env.NEXT_PUBLIC_GITHUB_OAUTH_ENABLED === 'true'}
+          />
+          <form action={updateCreatorProfile} className="border border-border p-6">
+            <h2 className="font-display text-2xl">Public creator record</h2>
+            <p className="mt-2 text-sm leading-6 text-secondary">This page is crawlable only after a verified Skill claim. OAuth-verified handles cannot be overwritten by text fields.</p>
+            <div className="mt-6 space-y-4">
+              {[
+                ['username', 'Public profile handle', username],
+                ['display_name', 'Display name', profile?.display_name || ''],
+                ['website', 'Website', profile?.website || ''],
+                ['github_username', profile?.github_verified_at ? 'GitHub username · OAuth verified' : 'GitHub username', profile?.github_username || ''],
+                ['x_username', 'X username · optional, self-reported', profile?.x_username || ''],
+              ].map(([name, label, value]) => (
+                <label key={name} className="block text-sm">
+                  <span className="mb-1.5 block text-secondary">{label}</span>
+                  <input name={name} defaultValue={value} readOnly={name === 'github_username' && Boolean(profile?.github_verified_at)} className="w-full border border-border bg-background px-3 py-2.5 outline-none focus:border-foreground read-only:bg-muted/40 read-only:text-secondary" />
+                </label>
+              ))}
+              <label className="block text-sm">
+                <span className="mb-1.5 block text-secondary">Bio</span>
+                <textarea name="bio" rows={4} defaultValue={profile?.bio || ''} className="w-full border border-border bg-background px-3 py-2.5 outline-none focus:border-foreground" />
+              </label>
+              <button className="w-full bg-foreground px-4 py-3 font-semibold text-background">Save public profile</button>
+            </div>
+          </form>
+        </div>
+
+        <section className="border border-border" aria-labelledby="claimed-skills-heading">
           <div className="flex items-center justify-between border-b border-border p-6">
-            <div><h2 className="font-display text-2xl">Claimed skills</h2><p className="mt-1 text-sm text-secondary">Only approved claims contribute creator analytics.</p></div>
-            <Link href="/submit" className="text-sm underline underline-offset-4">Submit skill</Link>
+            <div><p className="font-mono text-[11px] uppercase tracking-[0.18em] text-secondary">Provenance ledger</p><h2 id="claimed-skills-heading" className="mt-2 font-display text-2xl">Claimed skills</h2></div>
+            <Link href="/skills" className="text-sm underline underline-offset-4">Find listing</Link>
           </div>
           {(claims || []).length ? (
             <div className="divide-y divide-border">
@@ -121,23 +184,40 @@ export default async function CreatorDashboard({
                 const skill = (skills || []).find((item) => item.slug === claim.skill_slug)
                 const event = eventMap.get(claim.skill_slug)
                 const outcome = outcomeMap.get(claim.skill_slug)
-                return <div key={claim.id} className="p-5">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <Link href={`/skills/${claim.skill_slug}`} className="font-semibold hover:underline">{skill?.name || claim.skill_slug}</Link>
-                    <span className="font-mono text-xs uppercase text-secondary">{claim.status}</span>
+                return <article key={claim.id} className="p-5">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <Link href={`/skills/${claim.skill_slug}`} className="font-semibold hover:underline">{skill?.name || claim.skill_slug}</Link>
+                      <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.12em] text-secondary">{claim.verification_tier || 'maintainer'} · {claim.verification_method?.replaceAll('_', ' ')}</p>
+                    </div>
+                    <span className={`border px-2.5 py-1 font-mono text-[10px] uppercase ${claim.status === 'approved' ? 'border-emerald-700/40 text-emerald-700' : 'border-border text-secondary'}`}>{claim.status}</span>
                   </div>
-                  {claim.status === 'approved' ? <div className="mt-4 grid grid-cols-4 gap-3 text-xs text-secondary">
-                    <span>Views <b className="block text-base text-foreground">{metric(event?.views)}</b></span>
-                    <span>Starts <b className="block text-base text-foreground">{metric(event?.install_starts || event?.install_copies)}</b></span>
-                    <span>Installs <b className="block text-base text-foreground">{metric(outcome?.verified_installs)}</b></span>
-                    <span>Success <b className="block text-base text-foreground">{metric(outcome?.successful_outcomes)}</b></span>
-                  </div> : <p className="mt-3 text-sm text-secondary">Awaiting review. You can update evidence from the skill page.</p>}
-                </div>
+                  {claim.status === 'approved' && skill ? <>
+                    <div className="mt-4 grid grid-cols-4 gap-3 border-y border-border py-3 text-xs text-secondary">
+                      <span>Views <b className="block text-base text-foreground">{metric(event?.views)}</b></span>
+                      <span>Starts <b className="block text-base text-foreground">{metric(event?.install_starts || event?.install_copies)}</b></span>
+                      <span>Installs <b className="block text-base text-foreground">{metric(outcome?.verified_installs)}</b></span>
+                      <span>Success <b className="block text-base text-foreground">{metric(outcome?.successful_outcomes)}</b></span>
+                    </div>
+                    <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                      <div className="border border-border p-3">
+                        <p className="flex items-center gap-2 text-xs font-semibold"><GitCommitHorizontal className="size-3.5" /> Source sync</p>
+                        <p className="mt-2 font-mono text-xs">{shortSha(skill.source_commit_sha)} · {versionCounts.get(skill.slug) || 0} snapshot{versionCounts.get(skill.slug) === 1 ? '' : 's'}</p>
+                        <p className="mt-1 text-[11px] text-secondary">{dateLabel(skill.last_synced_at)} · {skill.source_sync_status || 'untracked'}</p>
+                      </div>
+                      <div className="border border-border p-3">
+                        <p className="flex items-center gap-2 text-xs font-semibold"><ShieldCheck className="size-3.5" /> License evidence</p>
+                        <p className="mt-2 font-mono text-xs">{skill.license || 'Unknown'}</p>
+                        <p className="mt-1 text-[11px] text-secondary">{skill.license_status || 'unknown'} · {(skill.license_source || 'unknown').replaceAll('_', ' ')}</p>
+                      </div>
+                    </div>
+                  </> : <p className="mt-3 text-sm leading-6 text-secondary">Open the Skill page to generate or refresh the repository verification challenge. Approval is automatic after the file is detected.</p>}
+                </article>
               })}
             </div>
-          ) : <div className="p-8 text-sm text-secondary">No claims yet. Open one of your skill pages and choose “Claim this skill”.</div>}
-        </div>
+          ) : <div className="p-8 text-sm leading-6 text-secondary">No ownership claims yet. Open one of your Skill pages and choose “Claim this skill” to generate a verifiable repository challenge.</div>}
+        </section>
       </section>
-    </main>
+    </div></MarketingPageShell>
   )
 }

--- a/app/creators/[username]/page.tsx
+++ b/app/creators/[username]/page.tsx
@@ -1,58 +1,158 @@
 import type { Metadata } from 'next'
+import Image from 'next/image'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
+import { cache } from 'react'
+import { BadgeCheck, ExternalLink, GitCommitHorizontal, ShieldCheck } from 'lucide-react'
 import { createPublicClient } from '@/lib/supabase/public'
+import { MarketingPageShell } from '@/components/marketing-page'
 
 type Props = { params: Promise<{ username: string }> }
+const SITE_URL = 'https://www.openagentskill.com'
 
-async function loadCreator(username: string) {
-  const supabase = createPublicClient()
-  const { data: profile } = await supabase.from('profiles').select('id,username,display_name,bio,website,github_username,x_username').eq('username', username).maybeSingle()
+const loadCreator = cache(async (username: string) => {
+  const supabase = createPublicClient({ requestTimeoutMs: 7_000 })
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id,username,display_name,bio,avatar_url,website,github_username,github_verified_at,x_username,x_verified_at,updated_at')
+    .eq('username', username.toLowerCase())
+    .maybeSingle()
   if (!profile) return null
-  const { data: claims } = await supabase.from('skill_claims').select('skill_slug').eq('user_id', profile.id).eq('status', 'approved')
+
+  const { data: claims } = await supabase
+    .from('skill_claims')
+    .select('skill_slug,verification_tier,verification_method,verified_at')
+    .eq('user_id', profile.id)
+    .eq('status', 'approved')
   const slugs = (claims || []).map((claim) => claim.skill_slug)
-  const { data: skills } = slugs.length
-    ? await supabase.from('skills').select('slug,name,description,category,github_stars').in('slug', slugs).order('github_stars', { ascending: false })
-    : { data: [] }
-  return { profile, skills: skills || [] }
-}
+  const [{ data: skills }, { data: events }, { data: outcomes }] = await Promise.all([
+    slugs.length
+      ? supabase.from('skills').select('slug,name,description,category,github_stars,version,license,license_status,last_synced_at,source_commit_sha').in('slug', slugs).order('github_stars', { ascending: false })
+      : Promise.resolve({ data: [] }),
+    slugs.length
+      ? supabase.from('skill_event_stats').select('skill_slug,views,install_starts,install_successes').in('skill_slug', slugs)
+      : Promise.resolve({ data: [] }),
+    slugs.length
+      ? supabase.from('agent_outcome_stats').select('skill_slug,verified_installs,successful_outcomes').in('skill_slug', slugs)
+      : Promise.resolve({ data: [] }),
+  ])
+  return { profile, claims: claims || [], skills: skills || [], events: events || [], outcomes: outcomes || [] }
+})
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { username } = await params
   const creator = await loadCreator(username)
-  if (!creator) return { title: 'Creator not found' }
+  if (!creator) return { title: 'Creator not found', robots: { index: false, follow: false } }
   const name = creator.profile.display_name || creator.profile.username
-  return { title: `${name} — Agent Skill Creator`, description: creator.profile.bio || `Verified skills published by ${name} on OpenAgentSkill.` }
+  const description = creator.profile.bio || `${creator.skills.length} verified open-source Agent Skills by ${name}, with source, license, and install evidence.`
+  const canonical = `${SITE_URL}/creators/${creator.profile.username}`
+  return {
+    title: `${name} — Verified Agent Skill Creator`,
+    description,
+    alternates: { canonical },
+    robots: { index: creator.skills.length > 0, follow: true },
+    openGraph: { title: `${name} — Agent Skill Creator`, description, url: canonical, type: 'profile' },
+  }
+}
+
+function compact(value: unknown) {
+  return Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 }).format(Number(value || 0))
 }
 
 export default async function CreatorPage({ params }: Props) {
   const { username } = await params
   const creator = await loadCreator(username)
   if (!creator) notFound()
-  const { profile, skills } = creator
+  const { profile, claims, skills, events, outcomes } = creator
   const name = profile.display_name || profile.username
-  const sameAs = [profile.website, profile.github_username ? `https://github.com/${profile.github_username}` : null, profile.x_username ? `https://x.com/${profile.x_username}` : null].filter(Boolean)
-  const jsonLd = { '@context': 'https://schema.org', '@type': 'Person', name, url: `https://www.openagentskill.com/creators/${profile.username}`, sameAs, description: profile.bio || undefined }
+  const claimMap = new Map(claims.map((claim) => [claim.skill_slug, claim]))
+  const eventMap = new Map(events.map((event) => [event.skill_slug, event]))
+  const outcomeMap = new Map(outcomes.map((outcome) => [outcome.skill_slug, outcome]))
+  const isOfficial = claims.some((claim) => claim.verification_tier === 'official')
+  const sameAs = [
+    profile.website,
+    profile.github_verified_at && profile.github_username ? `https://github.com/${profile.github_username}` : null,
+    profile.x_verified_at && profile.x_username ? `https://x.com/${profile.x_username}` : null,
+  ].filter(Boolean)
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    '@id': `${SITE_URL}/creators/${profile.username}#creator`,
+    name,
+    url: `${SITE_URL}/creators/${profile.username}`,
+    image: profile.avatar_url || undefined,
+    sameAs,
+    description: profile.bio || undefined,
+    knowsAbout: ['AI agents', 'Agent Skills', ...Array.from(new Set(skills.map((skill) => skill.category)))],
+    mainEntityOfPage: `${SITE_URL}/creators/${profile.username}`,
+  }
+  const listLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `Verified Agent Skills by ${name}`,
+    numberOfItems: skills.length,
+    itemListElement: skills.map((skill, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: `${SITE_URL}/skills/${skill.slug}`,
+      name: skill.name,
+    })),
+  }
 
-  return <main className="mx-auto min-h-screen max-w-5xl px-6 py-16">
+  return <MarketingPageShell><div className="mx-auto min-h-screen max-w-5xl px-5 py-12 sm:px-6 sm:py-16">
     <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
-    <p className="font-mono text-xs uppercase tracking-[0.2em] text-secondary">Verified creator</p>
-    <h1 className="mt-4 font-display text-5xl font-semibold">{name}</h1>
-    {profile.bio ? <p className="mt-4 max-w-2xl text-lg text-secondary">{profile.bio}</p> : null}
-    <div className="mt-6 flex flex-wrap gap-3 text-sm">
-      {profile.website ? <a className="border border-border px-3 py-2" href={profile.website}>Website</a> : null}
-      {profile.github_username ? <a className="border border-border px-3 py-2" href={`https://github.com/${profile.github_username}`}>GitHub @{profile.github_username}</a> : null}
-      {profile.x_username ? <a className="border border-border px-3 py-2" href={`https://x.com/${profile.x_username}`}>X @{profile.x_username}</a> : null}
-    </div>
-    <section className="mt-12">
-      <h2 className="font-display text-2xl">Verified skills ({skills.length})</h2>
-      <div className="mt-5 grid gap-4 md:grid-cols-2">
-        {skills.map((skill) => <Link key={skill.slug} href={`/skills/${skill.slug}`} className="border border-border p-5 hover:border-foreground">
-          <p className="font-mono text-xs uppercase text-secondary">{skill.category} · ★ {Number(skill.github_stars || 0).toLocaleString()}</p>
-          <h3 className="mt-2 font-display text-xl">{skill.name}</h3>
-          <p className="mt-2 line-clamp-3 text-sm text-secondary">{skill.description}</p>
-        </Link>)}
+    {skills.length ? <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }} /> : null}
+    <header className="grid gap-8 border-b border-border pb-10 sm:grid-cols-[auto_1fr] sm:items-start">
+      {profile.avatar_url ? <Image src={profile.avatar_url} alt="" width={96} height={96} className="size-24 border border-border object-cover" /> : <div className="grid size-24 place-items-center border border-border font-display text-3xl">{name.slice(0, 1).toUpperCase()}</div>}
+      <div>
+        <p className="flex items-center gap-2 font-mono text-xs uppercase tracking-[0.2em] text-secondary">
+          <BadgeCheck className="size-4 text-emerald-700" /> {isOfficial ? 'Official publisher' : skills.length ? 'Verified maintainer' : 'Creator profile'}
+        </p>
+        <h1 className="mt-3 font-display text-4xl font-semibold sm:text-6xl">{name}</h1>
+        {profile.bio ? <p className="mt-4 max-w-2xl text-lg leading-7 text-secondary">{profile.bio}</p> : null}
+        <div className="mt-6 flex flex-wrap gap-3 text-sm">
+          {profile.website ? <a className="inline-flex items-center gap-2 border border-border px-3 py-2 hover:border-foreground" href={profile.website} rel="me">Website <ExternalLink className="size-3" /></a> : null}
+          {profile.github_username ? <a className="inline-flex items-center gap-2 border border-border px-3 py-2 hover:border-foreground" href={`https://github.com/${profile.github_username}`} rel={profile.github_verified_at ? 'me' : undefined}>GitHub @{profile.github_username}{profile.github_verified_at ? <BadgeCheck className="size-3 text-emerald-700" /> : null}</a> : null}
+          {profile.x_username ? <a className="border border-border px-3 py-2 hover:border-foreground" href={`https://x.com/${profile.x_username}`}>X @{profile.x_username}{profile.x_verified_at ? ' · verified' : ''}</a> : null}
+        </div>
       </div>
+    </header>
+
+    <section className="mt-10 grid gap-px border border-border bg-border sm:grid-cols-3" aria-label="Creator proof">
+      <div className="bg-background p-5"><p className="font-mono text-[10px] uppercase tracking-[0.16em] text-secondary">Verified ownership</p><p className="mt-3 font-display text-3xl">{skills.length}</p></div>
+      <div className="bg-background p-5"><p className="font-mono text-[10px] uppercase tracking-[0.16em] text-secondary">GitHub adoption</p><p className="mt-3 font-display text-3xl">{compact(skills.reduce((sum, skill) => sum + Number(skill.github_stars || 0), 0))}</p></div>
+      <div className="bg-background p-5"><p className="font-mono text-[10px] uppercase tracking-[0.16em] text-secondary">Verified installs</p><p className="mt-3 font-display text-3xl">{compact(outcomes.reduce((sum, row) => sum + Number(row.verified_installs || 0), 0))}</p></div>
     </section>
-  </main>
+
+    <section className="mt-12">
+      <div className="flex items-end justify-between gap-4">
+        <div><p className="font-mono text-xs uppercase tracking-[0.18em] text-secondary">Public provenance</p><h2 className="mt-2 font-display text-3xl">Verified skills ({skills.length})</h2></div>
+        <Link href="/creators" className="text-sm underline underline-offset-4">All creators</Link>
+      </div>
+      {skills.length ? <div className="mt-6 divide-y divide-border border border-border">
+        {skills.map((skill) => {
+          const claim = claimMap.get(skill.slug)
+          const event = eventMap.get(skill.slug)
+          const outcome = outcomeMap.get(skill.slug)
+          return <Link key={skill.slug} href={`/skills/${skill.slug}`} className="grid gap-5 p-5 transition-colors hover:bg-muted/40 sm:grid-cols-[1fr_auto] sm:items-center">
+            <div>
+              <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-secondary">{skill.category} · {claim?.verification_tier || 'maintainer'} verified</p>
+              <h3 className="mt-2 font-display text-2xl">{skill.name}</h3>
+              <p className="mt-2 line-clamp-2 text-sm leading-6 text-secondary">{skill.description}</p>
+              <div className="mt-4 flex flex-wrap gap-2 text-[11px] text-secondary">
+                <span className="inline-flex items-center gap-1 border border-border px-2 py-1"><GitCommitHorizontal className="size-3" /> {skill.source_commit_sha?.slice(0, 7) || 'sync pending'}</span>
+                <span className="inline-flex items-center gap-1 border border-border px-2 py-1"><ShieldCheck className="size-3" /> {skill.license || 'Unknown'} · {skill.license_status || 'unknown'}</span>
+                <span className="border border-border px-2 py-1">v{skill.version || '1.0.0'}</span>
+              </div>
+            </div>
+            <dl className="grid grid-cols-3 gap-5 text-right text-xs">
+              <div><dt className="text-secondary">Stars</dt><dd className="mt-1 font-mono text-sm">{compact(skill.github_stars)}</dd></div>
+              <div><dt className="text-secondary">Starts</dt><dd className="mt-1 font-mono text-sm">{compact(event?.install_starts)}</dd></div>
+              <div><dt className="text-secondary">Installs</dt><dd className="mt-1 font-mono text-sm">{compact(outcome?.verified_installs)}</dd></div>
+            </dl>
+          </Link>
+        })}
+      </div> : <div className="mt-6 border border-border p-8 text-sm text-secondary">This profile has no verified Skill ownership yet and is not eligible for search indexing.</div>}
+    </section>
+  </div></MarketingPageShell>
 }

--- a/app/creators/page.tsx
+++ b/app/creators/page.tsx
@@ -1,0 +1,100 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import { unstable_cache } from 'next/cache'
+import { BadgeCheck } from 'lucide-react'
+import { createPublicClient } from '@/lib/supabase/public'
+import { MarketingPageShell } from '@/components/marketing-page'
+
+export const revalidate = 3600
+
+export const metadata: Metadata = {
+  title: 'Verified Agent Skill Creators',
+  description: 'Discover verified open-source Agent Skill maintainers, their GitHub-backed listings, licenses, versions, and real install evidence.',
+  alternates: { canonical: 'https://www.openagentskill.com/creators' },
+  openGraph: {
+    title: 'Verified Agent Skill Creators | OpenAgentSkill',
+    description: 'GitHub-backed creator ownership and open-source Agent Skills with provenance.',
+    url: 'https://www.openagentskill.com/creators',
+  },
+}
+
+const loadCreators = unstable_cache(async () => {
+  const supabase = createPublicClient({ requestTimeoutMs: 7_000 })
+  const { data: claims } = await supabase
+    .from('skill_claims')
+    .select('user_id,skill_slug,verification_tier')
+    .eq('status', 'approved')
+    .limit(1000)
+  if (!claims?.length) return []
+
+  const userIds = Array.from(new Set(claims.map((claim) => claim.user_id)))
+  const slugs = Array.from(new Set(claims.map((claim) => claim.skill_slug)))
+  const [{ data: profiles }, { data: skills }, { data: outcomes }] = await Promise.all([
+    supabase.from('profiles').select('id,username,display_name,bio,avatar_url,github_username,github_verified_at,x_username').in('id', userIds).not('username', 'is', null),
+    supabase.from('skills').select('slug,name,github_stars').in('slug', slugs).eq('ai_review_approved', true),
+    supabase.from('agent_outcome_stats').select('skill_slug,verified_installs').in('skill_slug', slugs),
+  ])
+  const skillMap = new Map((skills || []).map((skill) => [skill.slug, skill]))
+  const outcomeMap = new Map((outcomes || []).map((row) => [row.skill_slug, row]))
+
+  return (profiles || []).map((profile) => {
+    const profileClaims = claims.filter((claim) => claim.user_id === profile.id)
+    const profileSkills = profileClaims.map((claim) => skillMap.get(claim.skill_slug)).filter(Boolean)
+    return {
+      ...profile,
+      skillCount: profileSkills.length,
+      stars: profileSkills.reduce((sum, skill) => sum + Number(skill?.github_stars || 0), 0),
+      verifiedInstalls: profileClaims.reduce((sum, claim) => sum + Number(outcomeMap.get(claim.skill_slug)?.verified_installs || 0), 0),
+      official: profileClaims.some((claim) => claim.verification_tier === 'official'),
+      topSkills: profileSkills.slice(0, 3).map((skill) => skill?.name).filter(Boolean),
+    }
+  }).filter((creator) => creator.skillCount > 0).sort((a, b) => b.stars - a.stars || b.verifiedInstalls - a.verifiedInstalls)
+}, ['verified-creator-directory-v1'], { revalidate: 3600, tags: ['creator-directory'] })
+
+function compact(value: number) {
+  return Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 }).format(value)
+}
+
+export default async function CreatorsPage() {
+  const creators = await loadCreators()
+  const totalSkills = creators.reduce((sum, creator) => sum + creator.skillCount, 0)
+
+  return <MarketingPageShell><div className="mx-auto min-h-screen max-w-6xl px-5 py-12 sm:px-6 sm:py-16">
+    <header className="grid gap-8 border-b border-border pb-10 lg:grid-cols-[1fr_auto] lg:items-end">
+      <div>
+        <p className="font-mono text-xs uppercase tracking-[0.22em] text-secondary">Creator registry · provenance verified</p>
+        <h1 className="mt-4 max-w-4xl font-display text-5xl font-semibold leading-[0.96] sm:text-7xl">The people behind open-source Agent Skills.</h1>
+        <p className="mt-5 max-w-2xl text-base leading-7 text-secondary">Every profile below controls at least one listed repository. Explore source-backed versions, license evidence, adoption, and verified install outcomes.</p>
+      </div>
+      <Link href="/creator" className="bg-foreground px-5 py-3 text-sm font-semibold text-background">Claim your skills</Link>
+    </header>
+
+    <section className="mt-8 grid gap-px border border-border bg-border sm:grid-cols-3">
+      <div className="bg-background p-5"><p className="font-mono text-[10px] uppercase tracking-[0.16em] text-secondary">Verified creators</p><p className="mt-3 font-display text-3xl">{creators.length.toLocaleString()}</p></div>
+      <div className="bg-background p-5"><p className="font-mono text-[10px] uppercase tracking-[0.16em] text-secondary">Owned skills</p><p className="mt-3 font-display text-3xl">{totalSkills.toLocaleString()}</p></div>
+      <div className="bg-background p-5"><p className="font-mono text-[10px] uppercase tracking-[0.16em] text-secondary">Proof standard</p><p className="mt-3 font-display text-3xl">GitHub</p></div>
+    </section>
+
+    <section className="mt-12" aria-labelledby="creator-list-heading">
+      <div className="flex items-end justify-between gap-4"><h2 id="creator-list-heading" className="font-display text-3xl">Verified maintainers</h2><p className="font-mono text-xs text-secondary">Ranked by repository adoption</p></div>
+      {creators.length ? <div className="mt-6 divide-y divide-border border border-border">
+        {creators.map((creator, index) => <Link key={creator.id} href={`/creators/${creator.username}`} className="grid gap-5 p-5 transition-colors hover:bg-muted/40 sm:grid-cols-[auto_1fr_auto] sm:items-center">
+          <span className="font-mono text-xs text-secondary">{String(index + 1).padStart(2, '0')}</span>
+          <div className="flex min-w-0 items-center gap-4">
+            {creator.avatar_url ? <Image src={creator.avatar_url} alt="" width={48} height={48} className="size-12 border border-border object-cover" /> : <div className="grid size-12 shrink-0 place-items-center border border-border font-display text-xl">{(creator.display_name || creator.username).slice(0, 1).toUpperCase()}</div>}
+            <div className="min-w-0">
+              <p className="flex items-center gap-2 truncate font-semibold">{creator.display_name || creator.username}<BadgeCheck className="size-4 shrink-0 text-emerald-700" /></p>
+              <p className="mt-1 truncate text-xs text-secondary">{creator.topSkills.join(' · ') || creator.bio || `@${creator.github_username || creator.username}`}</p>
+            </div>
+          </div>
+          <dl className="grid grid-cols-3 gap-6 text-right text-xs">
+            <div><dt className="text-secondary">Skills</dt><dd className="mt-1 font-mono text-sm">{creator.skillCount}</dd></div>
+            <div><dt className="text-secondary">Stars</dt><dd className="mt-1 font-mono text-sm">{compact(creator.stars)}</dd></div>
+            <div><dt className="text-secondary">Installs</dt><dd className="mt-1 font-mono text-sm">{compact(creator.verifiedInstalls)}</dd></div>
+          </dl>
+        </Link>)}
+      </div> : <div className="mt-6 border border-border p-8 text-sm text-secondary">The verified creator registry is opening now. Claim the first repository-backed profile.</div>}
+    </section>
+  </div></MarketingPageShell>
+}

--- a/app/sitemaps/[section]/route.ts
+++ b/app/sitemaps/[section]/route.ts
@@ -3,6 +3,7 @@ import {
   getBestSitemapEntries,
   getCoreSitemapEntries,
   getGuideSitemapEntries,
+  getCreatorSitemapEntries,
   getRankingSitemapEntries,
   getSkillSitemapEntries,
   renderUrlSet,
@@ -18,7 +19,7 @@ const SHARDED_SECTION_PREFIXES: Array<[RegExp, SitemapSection]> = [
 
 const RETIRED_SHARDED_SITEMAPS = /^(skill-audits|skill-evals|alternatives)-(\d+)\.xml$/
 
-function staticEntriesFor(section: string) {
+async function staticEntriesFor(section: string) {
   const now = new Date()
 
   switch (section) {
@@ -30,6 +31,8 @@ function staticEntriesFor(section: string) {
       return getRankingSitemapEntries(now)
     case 'guides.xml':
       return getGuideSitemapEntries(now)
+    case 'creators.xml':
+      return getCreatorSitemapEntries()
     default:
       return null
   }
@@ -40,7 +43,7 @@ export async function GET(
   { params }: { params: Promise<{ section: string }> }
 ) {
   const { section } = await params
-  const staticEntries = staticEntriesFor(section)
+  const staticEntries = await staticEntriesFor(section)
 
   if (staticEntries) {
     // Static section entries change at editorial cadence, not whenever this

--- a/app/skills/[slug]/page.tsx
+++ b/app/skills/[slug]/page.tsx
@@ -1770,6 +1770,17 @@ export default async function SkillDetailPage({
                   ))}
               </dl>
 
+              {dbSkill?.source_sync_status && dbSkill.source_sync_status !== 'untracked' ? (
+                <div className="mt-5 border border-border bg-muted/20 p-4">
+                  <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-secondary">Source provenance</p>
+                  <dl className="mt-3 grid gap-3 text-xs sm:grid-cols-3">
+                    <div><dt className="text-secondary">Commit</dt><dd className="mt-1 font-mono">{dbSkill.source_commit_sha?.slice(0, 7) || 'Tracked'}</dd></div>
+                    <div><dt className="text-secondary">Sync status</dt><dd className="mt-1 font-mono capitalize">{dbSkill.source_sync_status}</dd></div>
+                    <div><dt className="text-secondary">License evidence</dt><dd className="mt-1 font-mono capitalize">{(dbSkill.license_status || 'unknown')} · {(dbSkill.license_source || 'unknown').replaceAll('_', ' ')}</dd></div>
+                  </dl>
+                </div>
+              ) : null}
+
               {skill.technical.frameworks.length > 0 && (
                 <div className="mt-5">
                   <p className="text-xs text-secondary mb-2">
@@ -2140,6 +2151,8 @@ export default async function SkillDetailPage({
                         github_username: approvedClaim.github_username,
                         x_username: approvedClaim.x_username,
                         evidence_url: approvedClaim.evidence_url,
+                        verification_tier: approvedClaim.verification_tier,
+                        verified_at: approvedClaim.verified_at,
                       }
                     : null
                 }

--- a/components/claim-skill-panel.tsx
+++ b/components/claim-skill-panel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { createClient } from '@/lib/supabase/client'
 import { trackSkillEvent } from '@/components/skill-event-tracker'
 import { useI18n } from '@/lib/i18n/context'
@@ -19,15 +20,28 @@ interface ClaimSkillPanelProps {
     github_username: string | null
     x_username?: string | null
     evidence_url: string | null
+    verification_tier?: 'maintainer' | 'official'
+    verified_at?: string | null
   } | null
 }
 
 interface ClaimState {
   status: 'pending' | 'approved' | 'rejected'
-  github_username: string
+  github_username: string | null
   x_username: string | null
   evidence_url: string | null
   evidence_note: string | null
+  verification_method?: string
+  verification_tier?: 'maintainer' | 'official'
+  verified_at?: string | null
+  challenge_expires_at?: string | null
+}
+
+interface ClaimChallenge {
+  token: string
+  path: string
+  expires_at: string
+  repository: string
 }
 
 function getSourceLabelCopyKey(value: string): SkillDetailCopyKey | null {
@@ -57,6 +71,7 @@ export function ClaimSkillPanel({
   approvedClaim,
 }: ClaimSkillPanelProps) {
   const { locale } = useI18n()
+  const router = useRouter()
   const [open, setOpen] = useState(false)
   const [hasUser, setHasUser] = useState<boolean | null>(null)
   const [existingClaim, setExistingClaim] = useState<ClaimState | null>(null)
@@ -65,6 +80,9 @@ export function ClaimSkillPanel({
   const [evidenceUrl, setEvidenceUrl] = useState(repository || '')
   const [evidenceNote, setEvidenceNote] = useState('')
   const [status, setStatus] = useState<'idle' | 'loading' | 'saved' | 'error'>('idle')
+  const [challenge, setChallenge] = useState<ClaimChallenge | null>(null)
+  const [verificationStatus, setVerificationStatus] = useState<'idle' | 'checking' | 'verified' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
 
   useEffect(() => {
     let active = true
@@ -99,7 +117,7 @@ export function ClaimSkillPanel({
 
     if (!hasUser) {
       const next = getLocalizedNavigationHref(`/skills/${skillSlug}`, locale)
-      window.location.href = `/auth/login?next=${encodeURIComponent(next)}`
+      router.push(`/auth/login?next=${encodeURIComponent(next)}`)
       return
     }
     setOpen(true)
@@ -123,14 +141,41 @@ export function ClaimSkillPanel({
       }),
     })
 
+    const data = await response.json().catch(() => ({}))
     if (!response.ok) {
+      setErrorMessage(data.error || 'Could not create the ownership challenge.')
       setStatus('error')
       return
     }
 
-    const data = await response.json()
     setExistingClaim(data.claim)
+    setChallenge(data.challenge || null)
     setStatus('saved')
+  }
+
+  async function verifyChallenge() {
+    if (verificationStatus === 'checking') return
+    setVerificationStatus('checking')
+    setErrorMessage('')
+    const response = await fetch('/api/claims/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ skill_slug: skillSlug }),
+    })
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      setErrorMessage(data.error || 'Verification failed. Check the file and try again.')
+      setVerificationStatus('error')
+      return
+    }
+    setExistingClaim((current) => current ? { ...current, status: 'approved', verified_at: data.verified_at } : current)
+    setVerificationStatus('verified')
+    setChallenge(null)
+  }
+
+  async function copyChallengeToken() {
+    if (!challenge) return
+    await navigator.clipboard.writeText(challenge.token)
   }
 
   if (approvedClaim) {
@@ -140,7 +185,7 @@ export function ClaimSkillPanel({
           {formatSkillDetailCopy(locale, 'ownerClaim')}
         </p>
         <h3 className="font-display text-lg font-semibold">
-          {formatSkillDetailCopy(locale, 'verifiedMaintainer')}
+          {approvedClaim.verification_tier === 'official' ? 'Official publisher' : formatSkillDetailCopy(locale, 'verifiedMaintainer')}
         </h3>
         <p className="mt-2 text-xs leading-relaxed text-secondary">
           {formatSkillDetailCopy(locale, 'verifiedMaintainerDescription', {
@@ -181,7 +226,7 @@ export function ClaimSkillPanel({
       {existingClaim && !open ? (
         <div className="mt-4 border border-border p-3 text-xs text-secondary">
           {formatSkillDetailCopy(locale, 'claimStatus')}:{' '}
-          <span className="font-mono text-foreground">{existingClaim.status}</span>
+          <span className="font-mono text-foreground">{verificationStatus === 'verified' ? 'approved' : existingClaim.status}</span>
         </div>
       ) : null}
 
@@ -197,6 +242,9 @@ export function ClaimSkillPanel({
         </button>
       ) : (
         <div className="mt-4 space-y-3">
+          <div className="border border-border bg-muted/30 p-3 text-xs leading-relaxed text-secondary">
+            GitHub OAuth can approve a matching personal repository immediately. Otherwise, we generate a one-time file challenge that proves write access to this repository. X is optional and does not verify ownership by itself.
+          </div>
           <label className="block">
             <span className="mb-1 block text-xs text-secondary">
               {formatSkillDetailCopy(locale, 'githubUsername')}
@@ -250,14 +298,38 @@ export function ClaimSkillPanel({
               ? formatSkillDetailCopy(locale, 'submitting')
               : formatSkillDetailCopy(locale, 'submitClaim')}
           </button>
+          {challenge ? (
+            <div className="border border-emerald-700/40 bg-emerald-500/5 p-4 text-xs">
+              <p className="font-mono uppercase tracking-[0.14em] text-emerald-700">Ownership challenge</p>
+              <ol className="mt-3 list-decimal space-y-2 pl-4 leading-relaxed text-secondary">
+                <li>Create <code className="break-all text-foreground">{challenge.path}</code> on the repository default branch.</li>
+                <li>Paste the exact token below as the complete file content and commit it.</li>
+                <li>Return here and verify. The token expires in 24 hours.</li>
+              </ol>
+              <div className="mt-3 flex items-stretch border border-border bg-background">
+                <code className="min-w-0 flex-1 break-all p-3 text-foreground">{challenge.token}</code>
+                <button type="button" onClick={copyChallengeToken} className="border-l border-border px-3 font-semibold hover:bg-muted">Copy</button>
+              </div>
+              <button
+                type="button"
+                onClick={verifyChallenge}
+                disabled={verificationStatus === 'checking'}
+                className="mt-3 w-full bg-foreground px-3 py-2 font-semibold text-background disabled:opacity-50"
+              >
+                {verificationStatus === 'checking' ? 'Checking GitHub…' : 'Verify repository ownership'}
+              </button>
+            </div>
+          ) : null}
           {status === 'saved' && (
             <p className="text-xs text-secondary">
-              {formatSkillDetailCopy(locale, 'claimSubmitted')}
+              {existingClaim?.status === 'approved'
+                ? 'Ownership verified. This listing is now linked to your creator profile.'
+                : formatSkillDetailCopy(locale, 'claimSubmitted')}
             </p>
           )}
-          {status === 'error' && (
-            <p className="text-xs text-secondary">
-              {formatSkillDetailCopy(locale, 'claimSubmitError')}
+          {(status === 'error' || verificationStatus === 'error') && (
+            <p className="text-xs text-red-600" role="alert">
+              {errorMessage || formatSkillDetailCopy(locale, 'claimSubmitError')}
             </p>
           )}
         </div>

--- a/components/creator-identity-connections.tsx
+++ b/components/creator-identity-connections.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { useState } from 'react'
+import { Github, ShieldCheck } from 'lucide-react'
+import { createClient } from '@/lib/supabase/client'
+
+export function CreatorIdentityConnections({
+  githubUsername,
+  githubVerifiedAt,
+  xUsername,
+  githubOAuthEnabled,
+}: {
+  githubUsername?: string | null
+  githubVerifiedAt?: string | null
+  xUsername?: string | null
+  githubOAuthEnabled: boolean
+}) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  async function connectGitHub() {
+    setLoading(true)
+    setError('')
+    const supabase = createClient()
+    const redirectTo = `${window.location.origin}/auth/callback?next=/creator`
+    const { error: linkError } = await supabase.auth.linkIdentity({
+      provider: 'github',
+      options: { redirectTo },
+    })
+    if (linkError) {
+      setError('GitHub OAuth is not available for this account yet. Repository-file verification below still works immediately.')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section className="border border-border" aria-labelledby="identity-connections-heading">
+      <div className="border-b border-border p-5">
+        <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-secondary">Identity ledger</p>
+        <h2 id="identity-connections-heading" className="mt-2 font-display text-2xl">Connected accounts</h2>
+      </div>
+      <div className="divide-y divide-border">
+        <div className="flex flex-wrap items-center justify-between gap-4 p-5">
+          <div className="flex items-center gap-3">
+            <span className="grid size-10 place-items-center border border-border"><Github className="size-4" /></span>
+            <div>
+              <p className="font-semibold">GitHub {githubUsername ? `@${githubUsername}` : ''}</p>
+              <p className="mt-1 text-xs text-secondary">
+                {githubVerifiedAt ? 'OAuth identity verified' : 'Connect once for instant personal-repository claims'}
+              </p>
+            </div>
+          </div>
+          {githubVerifiedAt ? (
+            <span className="inline-flex items-center gap-1.5 border border-emerald-700/40 bg-emerald-500/5 px-3 py-2 text-xs text-emerald-700">
+              <ShieldCheck className="size-3.5" /> Verified
+            </span>
+          ) : githubOAuthEnabled ? (
+            <button type="button" onClick={connectGitHub} disabled={loading} className="border border-foreground bg-foreground px-4 py-2 text-sm font-semibold text-background disabled:opacity-50">
+              {loading ? 'Connecting…' : 'Connect GitHub'}
+            </button>
+          ) : (
+            <span className="border border-border px-3 py-2 text-xs text-secondary">Verify through repository</span>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-4 p-5">
+          <div>
+            <p className="font-semibold">X {xUsername ? `@${xUsername}` : ''}</p>
+            <p className="mt-1 text-xs text-secondary">Optional public attribution. It is shown as self-reported until OAuth verification is available.</p>
+          </div>
+          <span className="border border-border px-3 py-2 text-xs text-secondary">{xUsername ? 'Linked · unverified' : 'Not linked'}</span>
+        </div>
+      </div>
+      {error ? <p className="border-t border-border p-4 text-xs text-amber-700" role="alert">{error}</p> : null}
+    </section>
+  )
+}

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -30,6 +30,7 @@ type NavLabelKey =
   | 'cli'
   | 'forCreators'
   | 'creatorConsole'
+  | 'creators'
   | 'creatorKit'
   | 'submitSkill'
   | 'learn'
@@ -69,6 +70,7 @@ const mobileSections: Array<{ labelKey: NavLabelKey; items: MobileNavItem[] }> =
     labelKey: 'forCreators',
     items: [
       { href: '/submit', labelKey: 'submitSkill' },
+      { href: '/creators', labelKey: 'creators' },
       { href: '/creator', labelKey: 'creatorConsole' },
       { href: '/creator-kit', labelKey: 'creatorKit' },
     ],

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -125,6 +125,7 @@ export function SiteFooter() {
                 <FooterLink href="/openapi.json" className="hover:text-foreground">OpenAPI</FooterLink>
                 <FooterLink href="/cli" className="hover:text-foreground">CLI</FooterLink>
                 <FooterLink href="/creator-kit" className="hover:text-foreground">Creator Kit</FooterLink>
+                <FooterLink href="/creators" className="hover:text-foreground">Creator Registry</FooterLink>
                 <FooterLink href="/x-kit" className="hover:text-foreground">X Growth Kit</FooterLink>
                 <FooterLink href="/submit" className="hover:text-foreground">{t.nav.submit}</FooterLink>
                 <FooterLink href="/blog" className="hover:text-foreground">Blog</FooterLink>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -51,6 +51,7 @@ type NavLabelKey =
   | 'cli'
   | 'forCreators'
   | 'creatorConsole'
+  | 'creators'
   | 'creatorKit'
   | 'submitSkill'
   | 'learn'
@@ -86,6 +87,7 @@ const agentItems: NavItem[] = [
 
 const creatorItems: NavItem[] = [
   { href: '/submit', labelKey: 'submitSkill', icon: Plus },
+  { href: '/creators', labelKey: 'creators', icon: UserRound },
   { href: '/creator', labelKey: 'creatorConsole', icon: UserRound },
   { href: '/creator-kit', labelKey: 'creatorKit', icon: Wrench },
 ]

--- a/lib/creator-ownership.ts
+++ b/lib/creator-ownership.ts
@@ -1,0 +1,92 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
+import type { User } from '@supabase/supabase-js'
+import { parseGitHubSkillReference } from '@/lib/github/skill-source'
+
+const CHALLENGE_PREFIX = 'oas_claim_'
+export const CLAIM_CHALLENGE_TTL_MS = 24 * 60 * 60 * 1000
+
+export interface GitHubIdentity {
+  id: string
+  username: string
+  avatarUrl: string | null
+}
+
+export function createClaimChallenge() {
+  return `${CHALLENGE_PREFIX}${randomBytes(24).toString('base64url')}`
+}
+
+export function hashClaimChallenge(value: string) {
+  return createHash('sha256').update(value.trim()).digest('hex')
+}
+
+export function challengeMatches(value: string, expectedHash: string) {
+  const actual = Buffer.from(hashClaimChallenge(value), 'hex')
+  const expected = Buffer.from(expectedHash, 'hex')
+  return actual.length === expected.length && timingSafeEqual(actual, expected)
+}
+
+export function getClaimChallengePath(skillSlug: string) {
+  const safeSlug = skillSlug.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '')
+  return `.openagentskill/claim-${safeSlug || 'skill'}.txt`
+}
+
+export function getGitHubIdentity(user: Pick<User, 'identities'>): GitHubIdentity | null {
+  const identity = user.identities?.find((item) => item.provider === 'github')
+  if (!identity) return null
+  const data = identity.identity_data || {}
+  const username = String(data.user_name || data.preferred_username || data.login || '').trim()
+  const id = String(data.provider_id || data.sub || identity.id || '').trim()
+  if (!username || !id) return null
+  return {
+    id,
+    username,
+    avatarUrl: typeof data.avatar_url === 'string' ? data.avatar_url : null,
+  }
+}
+
+export function parseSkillRepository(repository: string | null | undefined, githubRepo?: string | null) {
+  const reference = parseGitHubSkillReference(repository || githubRepo || '')
+  return reference ? { owner: reference.owner, repo: reference.repo, ref: reference.ref } : null
+}
+
+function githubHeaders() {
+  const token = (process.env.GITHUB_TOKEN || '').trim()
+  return {
+    Accept: 'application/vnd.github.raw+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'OpenAgentSkill-Ownership/1.0',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  }
+}
+
+export async function fetchRepositoryChallenge(options: {
+  owner: string
+  repo: string
+  ref: string
+  path: string
+}) {
+  const encodedPath = options.path.split('/').map(encodeURIComponent).join('/')
+  const response = await fetch(
+    `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.repo)}/contents/${encodedPath}?ref=${encodeURIComponent(options.ref)}`,
+    { headers: githubHeaders(), cache: 'no-store', signal: AbortSignal.timeout(12_000) }
+  )
+  if (!response.ok) return null
+  const value = (await response.text()).trim()
+  return value.length <= 500 ? value : null
+}
+
+export function getLicenseEvidence(frontmatterLicense?: string, repositoryLicense?: string) {
+  const declared = frontmatterLicense?.trim()
+  const repository = repositoryLicense?.trim()
+  const license = declared || repository || 'Unknown'
+  const normalized = license.toLowerCase()
+  return {
+    license,
+    source: declared ? 'skill_frontmatter' : repository ? 'github_repository' : 'unknown',
+    status: !license || ['unknown', 'noassertion', 'other'].includes(normalized)
+      ? 'missing'
+      : /non-commercial|cc-by-nc/.test(normalized)
+        ? 'restricted'
+        : 'detected',
+  } as const
+}

--- a/lib/db/skills.ts
+++ b/lib/db/skills.ts
@@ -46,6 +46,14 @@ export interface SkillRecord {
   quality_signals: Record<string, unknown> | null
   github_language: string | null
   github_last_pushed_at: string | null
+  last_synced_at?: string | null
+  source_ref?: string | null
+  source_path?: string | null
+  source_commit_sha?: string | null
+  source_content_hash?: string | null
+  source_sync_status?: 'untracked' | 'current' | 'changed' | 'error'
+  license_source?: 'skill_frontmatter' | 'github_repository' | 'manual' | 'unknown'
+  license_status?: 'detected' | 'missing' | 'unknown' | 'restricted'
   created_at: string
   updated_at: string
 }
@@ -570,6 +578,9 @@ export interface SkillClaimRecord {
   metadata: Record<string, unknown> | null
   created_at: string
   updated_at: string
+  verified_at: string | null
+  verification_tier: 'maintainer' | 'official'
+  challenge_expires_at?: string | null
 }
 
 /**
@@ -790,7 +801,7 @@ export async function getApprovedClaimBySkillSlug(skillSlug: string): Promise<Sk
   const supabase = createPublicClient()
   const { data, error } = await supabase
     .from('skill_claims')
-    .select('*')
+    .select('id,skill_slug,user_id,github_username,x_username,repo_url,verification_method,evidence_url,evidence_note,status,reviewer_note,metadata,created_at,updated_at,verified_at,verification_tier,challenge_expires_at')
     .eq('skill_slug', skillSlug)
     .eq('status', 'approved')
     .order('created_at', { ascending: true })

--- a/lib/github/api.ts
+++ b/lib/github/api.ts
@@ -77,6 +77,25 @@ export async function validateGitHubRepo(
   }
 }
 
+export async function fetchRepositoryCommitSha(owner: string, repo: string, ref: string): Promise<string | null> {
+  const response = await fetch(
+    `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/${encodeURIComponent(ref)}`,
+    {
+      headers: {
+        'Accept': 'application/vnd.github.v3+json',
+        ...(process.env.GITHUB_TOKEN && {
+          'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
+        }),
+      },
+      signal: AbortSignal.timeout(12_000),
+    }
+  )
+
+  if (!response.ok) return null
+  const data = await response.json() as { sha?: string }
+  return typeof data.sha === 'string' && /^[a-f0-9]{40}$/i.test(data.sha) ? data.sha : null
+}
+
 // Fetch README content
 export async function fetchReadme(owner: string, repo: string): Promise<string> {
   const response = await fetch(

--- a/lib/i18n/dictionaries/de.ts
+++ b/lib/i18n/dictionaries/de.ts
@@ -27,6 +27,7 @@ const de = {
     cli: 'CLI',
     forCreators: 'Für Creator',
     creatorConsole: 'Creator-Konsole',
+    creators: 'Creator-Verzeichnis',
     creatorKit: 'Creator-Kit',
     learn: 'Lernen',
     guides: 'Anleitungen',

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -24,6 +24,7 @@ export default {
     cli: 'CLI',
     forCreators: 'For Creators',
     creatorConsole: 'Creator Console',
+    creators: 'Creator Registry',
     creatorKit: 'Creator Kit',
     learn: 'Learn',
     guides: 'Guides',

--- a/lib/i18n/dictionaries/es.ts
+++ b/lib/i18n/dictionaries/es.ts
@@ -27,6 +27,7 @@ const es = {
     cli: 'CLI',
     forCreators: 'Para creadores',
     creatorConsole: 'Panel de creadores',
+    creators: 'Registro de creadores',
     creatorKit: 'Kit para creadores',
     learn: 'Aprender',
     guides: 'Guías',

--- a/lib/i18n/dictionaries/fr.ts
+++ b/lib/i18n/dictionaries/fr.ts
@@ -27,6 +27,7 @@ const fr = {
     cli: 'CLI',
     forCreators: 'Pour les créateurs',
     creatorConsole: 'Console créateur',
+    creators: 'Registre des créateurs',
     creatorKit: 'Kit créateur',
     learn: 'Apprendre',
     guides: 'Guides',

--- a/lib/i18n/dictionaries/id.ts
+++ b/lib/i18n/dictionaries/id.ts
@@ -27,6 +27,7 @@ const id = {
     cli: 'CLI',
     forCreators: 'Untuk Kreator',
     creatorConsole: 'Konsol Kreator',
+    creators: 'Registri Kreator',
     creatorKit: 'Kit Kreator',
     learn: 'Pelajari',
     guides: 'Panduan',

--- a/lib/i18n/dictionaries/ja.ts
+++ b/lib/i18n/dictionaries/ja.ts
@@ -27,6 +27,7 @@ const ja = {
     cli: 'CLI',
     forCreators: 'クリエイター向け',
     creatorConsole: 'クリエイターコンソール',
+    creators: 'クリエイター名簿',
     creatorKit: 'クリエイターキット',
     learn: '学ぶ',
     guides: 'ガイド',

--- a/lib/i18n/dictionaries/ko.ts
+++ b/lib/i18n/dictionaries/ko.ts
@@ -27,6 +27,7 @@ const ko = {
     cli: 'CLI',
     forCreators: '크리에이터용',
     creatorConsole: '크리에이터 콘솔',
+    creators: '크리에이터 레지스트리',
     creatorKit: '크리에이터 키트',
     learn: '학습',
     guides: '가이드',

--- a/lib/i18n/dictionaries/zh.ts
+++ b/lib/i18n/dictionaries/zh.ts
@@ -24,6 +24,7 @@ export default {
     cli: '命令行工具',
     forCreators: '创作者',
     creatorConsole: '创作者控制台',
+    creators: '创作者名录',
     creatorKit: '创作者工具包',
     learn: '学习',
     guides: '指南',

--- a/lib/indexer/repository-skill-sync.ts
+++ b/lib/indexer/repository-skill-sync.ts
@@ -1,8 +1,9 @@
 import 'server-only'
 
+import { createHash } from 'node:crypto'
 import type { SkillRecord } from '@/lib/db/skills'
 import { reviewSkill } from '@/lib/ai-review/reviewer'
-import { validateGitHubRepo } from '@/lib/github/api'
+import { fetchRepositoryCommitSha, validateGitHubRepo } from '@/lib/github/api'
 import {
   discoverGitHubSkills,
   fetchDelegatedGitHubSkill,
@@ -14,6 +15,8 @@ import { analyzeCode } from '@/lib/security/static-analysis'
 import { evaluateSkillSubmissionPolicy } from '@/lib/skills/submission-policy'
 import { estimateSubmissionQuality } from '@/lib/skills/submission-quality'
 import { createPublicClient } from '@/lib/supabase/public'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { getLicenseEvidence } from '@/lib/creator-ownership'
 
 const DEFAULT_MAX_SKILLS_PER_REPOSITORY = 8
 const MAX_SKILLS_PER_REPOSITORY = 20
@@ -92,6 +95,10 @@ function normalizeVersion(value: string | undefined) {
   return value && /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/.test(value) ? value : '1.0.0'
 }
 
+function contentHash(value: string) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
 function normalizeSourceUrl(value: string | null | undefined) {
   return (value || '').trim().replace(/\/$/, '').toLowerCase()
 }
@@ -127,6 +134,7 @@ function payloadForExisting(
   discoverySource: string,
   discoveryMetadata?: Record<string, unknown>
 ) {
+  const license = getLicenseEvidence(skill.frontmatter.license, repository.license || existing.license)
   return {
     ...existing,
     repository: skill.sourceUrl,
@@ -137,7 +145,10 @@ function payloadForExisting(
     github_last_pushed_at: repository.updatedAt,
     long_description: skill.document.slice(0, 12_000),
     version: normalizeVersion(skill.frontmatter.version || existing.version),
-    license: skill.frontmatter.license || repository.license || existing.license || 'Unknown',
+    license: license.license,
+    license_source: license.source,
+    license_status: license.status,
+    source_content_hash: contentHash(skill.document),
     submission_source: existing.submission_source || discoverySource,
     ai_review_score: {
       ...(existing.ai_review_score && typeof existing.ai_review_score === 'object' ? existing.ai_review_score : {}),
@@ -214,6 +225,7 @@ async function payloadForNew(
     reviewTotal: review.totalScore,
     tags,
   })
+  const license = getLicenseEvidence(skill.frontmatter.license, repository.license)
 
   return {
     reason: null,
@@ -235,7 +247,10 @@ async function payloadForNew(
       tags,
       frameworks: skill.frontmatter.frameworks,
       version: normalizeVersion(skill.frontmatter.version),
-      license: skill.frontmatter.license || repository.license || 'Unknown',
+      license: license.license,
+      license_source: license.source,
+      license_status: license.status,
+      source_content_hash: contentHash(skill.document),
       install_command: `npx skills add ${repository.fullName} --skill ${skill.frontmatter.name}`,
       verified: false,
       submission_source: discoverySource,
@@ -278,8 +293,14 @@ export async function syncRepositorySkills(
     checkReadme: true,
     checkSkillJson: false,
   })
+  const sourceCommitSha = await fetchRepositoryCommitSha(
+    reference.owner,
+    reference.repo,
+    reference.ref || repository.defaultBranch
+  )
   const discovery = await discoverGitHubSkills(reference, repository)
   const supabase = createPublicClient({ requestTimeoutMs: DB_TIMEOUT_MS })
+  const admin = createAdminClient({ requestTimeoutMs: DB_TIMEOUT_MS })
   const { data: existingData, error: existingError } = await supabase
     .from('skills')
     .select('*')
@@ -347,12 +368,31 @@ export async function syncRepositorySkills(
       })
       if (error) throw new Error(error.message)
 
+      const sourceContentHash = String(result.payload.source_content_hash || contentHash(skill.document))
+      const { data: versionData, error: versionError } = await admin.rpc('record_skill_source_version', {
+        p_server_secret: serverSecret,
+        p_skill_slug: String(result.payload.slug || fallbackSlug),
+        p_source_commit_sha: sourceCommitSha || '',
+        p_source_content_hash: sourceContentHash,
+        p_source_ref: skill.ref,
+        p_source_path: skill.path,
+        p_version: String(result.payload.version || '1.0.0'),
+        p_license: String(result.payload.license || 'Unknown'),
+        p_license_source: String(result.payload.license_source || 'unknown'),
+        p_metadata: {
+          source_url: skill.sourceUrl,
+          discovery_source: discoverySource,
+        },
+      })
+      if (versionError) throw new Error(`Source version record failed: ${versionError.message}`)
+
       entries.push({
         slug: String(result.payload.slug || fallbackSlug),
         name: skill.frontmatter.name,
         path: skill.path,
         sourceUrl: skill.sourceUrl,
         status: data?.created ? 'created' : 'updated',
+        ...(versionData?.changed ? { reason: 'Source content changed and a new version was recorded.' } : {}),
       })
     } catch (error) {
       entries.push({

--- a/lib/seo/sitemap.ts
+++ b/lib/seo/sitemap.ts
@@ -19,6 +19,7 @@ import { SKILL_CLUSTERS } from '@/lib/seo/skill-clusters'
 import { CURATED_SKILL_SNAPSHOT } from '@/lib/seo/curated-skill-snapshot'
 import { SKILL_PACKS } from '@/lib/skill-packs'
 import { USE_CASES } from '@/lib/use-cases'
+import { createPublicClient } from '@/lib/supabase/public'
 import {
   SEARCH_INDEX_MIN_GITHUB_STARS,
   SEARCH_INDEX_MIN_QUALITY_SCORE,
@@ -125,6 +126,7 @@ export async function getSitemapIndexEntries() {
     { loc: `${SITEMAP_BASE_URL}/sitemaps/best.xml` },
     { loc: `${SITEMAP_BASE_URL}/sitemaps/rankings.xml` },
     { loc: `${SITEMAP_BASE_URL}/sitemaps/guides.xml` },
+    { loc: `${SITEMAP_BASE_URL}/sitemaps/creators.xml` },
   ]
 
   const skillSections = [
@@ -178,6 +180,7 @@ export function getCoreSitemapEntries(now = new Date()): SitemapEntry[] {
     { url: `${SITEMAP_BASE_URL}/docs`, lastModified: now, changeFrequency: 'weekly', priority: 0.8 },
     { url: `${SITEMAP_BASE_URL}/cli`, lastModified: now, changeFrequency: 'weekly', priority: 0.86 },
     { url: `${SITEMAP_BASE_URL}/creator-kit`, lastModified: now, changeFrequency: 'weekly', priority: 0.82 },
+    { url: `${SITEMAP_BASE_URL}/creators`, lastModified: now, changeFrequency: 'daily', priority: 0.86 },
     { url: `${SITEMAP_BASE_URL}/x-kit`, lastModified: now, changeFrequency: 'daily', priority: 0.74 },
     { url: `${SITEMAP_BASE_URL}/activity`, lastModified: now, changeFrequency: 'hourly', priority: 0.6 },
   ]
@@ -289,6 +292,35 @@ export function getGuideSitemapEntries(now = new Date()): SitemapEntry[] {
     lastModified: now,
     changeFrequency: 'weekly',
     priority: guide.intent === 'compare' ? 0.86 : 0.88,
+  }))
+}
+
+export async function getCreatorSitemapEntries(): Promise<SitemapEntry[]> {
+  const supabase = createPublicClient({ requestTimeoutMs: 6_500 })
+  const { data: claims, error: claimError } = await supabase
+    .from('skill_claims')
+    .select('user_id,verified_at')
+    .eq('status', 'approved')
+    .limit(1000)
+  if (claimError || !claims?.length) return []
+
+  const latestByUser = new Map<string, string | null>()
+  for (const claim of claims) {
+    const current = latestByUser.get(claim.user_id)
+    if (!current || (claim.verified_at && claim.verified_at > current)) latestByUser.set(claim.user_id, claim.verified_at)
+  }
+  const { data: profiles, error: profileError } = await supabase
+    .from('profiles')
+    .select('id,username,updated_at')
+    .in('id', Array.from(latestByUser.keys()))
+    .not('username', 'is', null)
+  if (profileError) return []
+
+  return (profiles || []).map((profile) => ({
+    url: `${SITEMAP_BASE_URL}/creators/${profile.username}`,
+    lastModified: profile.updated_at || latestByUser.get(profile.id) || undefined,
+    changeFrequency: 'weekly' as const,
+    priority: 0.76,
   }))
 }
 

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,6 +1,19 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ||
+  process.env.SUPABASE_URL ||
+  'https://rtuodkczrlkxwwtaxwrr.supabase.co'
+
+// The anon key is intentionally public; RLS is the authorization boundary.
+// Keeping the same fallback as the browser/public clients prevents auth-aware
+// routes from crashing in local previews that do not load a .env file.
+const SUPABASE_ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJ0dW9ka2N6cmxreHd3dGF4d3JyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzE1OTc0ODAsImV4cCI6MjA4NzE3MzQ4MH0.KlJ70ysYG78x1hwOTmePW53t_IEeLqC_PzGiBozh2Ug'
+
 /**
  * Especially important if using Fluid compute: Don't put this client in a
  * global variable. Always create a new client within each function when using
@@ -10,8 +23,8 @@ export async function createClient() {
   const cookieStore = await cookies()
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    SUPABASE_URL,
+    SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll() {

--- a/supabase/migrations/20260901143000_creator_ownership_foundation.sql
+++ b/supabase/migrations/20260901143000_creator_ownership_foundation.sql
@@ -1,0 +1,214 @@
+-- Creator ownership foundation: verifiable identities, repository claims,
+-- source provenance, version history, and explicit license evidence.
+
+alter table public.profiles
+  add column if not exists github_user_id bigint,
+  add column if not exists github_verified_at timestamptz,
+  add column if not exists x_user_id text,
+  add column if not exists x_verified_at timestamptz;
+
+create unique index if not exists profiles_github_user_id_unique
+  on public.profiles (github_user_id) where github_user_id is not null;
+create unique index if not exists profiles_x_user_id_unique
+  on public.profiles (x_user_id) where x_user_id is not null;
+
+alter table public.skill_claims
+  add column if not exists verified_at timestamptz,
+  add column if not exists verification_tier text not null default 'maintainer',
+  add column if not exists challenge_token_hash text,
+  add column if not exists challenge_expires_at timestamptz;
+
+alter table public.skill_claims
+  drop constraint if exists skill_claims_verification_method_check,
+  add constraint skill_claims_verification_method_check check (
+    verification_method = any (array[
+      'github_profile', 'github_oauth', 'repository_file',
+      'repository_issue', 'website_link', 'manual'
+    ])
+  ),
+  drop constraint if exists skill_claims_verification_tier_check,
+  add constraint skill_claims_verification_tier_check check (
+    verification_tier = any (array['maintainer', 'official'])
+  ),
+  drop constraint if exists skill_claims_verified_state_check,
+  add constraint skill_claims_verified_state_check check (
+    (status <> 'approved') or verified_at is not null
+  );
+
+alter table public.skills
+  add column if not exists source_commit_sha text,
+  add column if not exists source_content_hash text,
+  add column if not exists source_sync_status text not null default 'untracked',
+  add column if not exists license_source text not null default 'unknown',
+  add column if not exists license_status text not null default 'unknown';
+
+alter table public.skills
+  drop constraint if exists skills_source_sync_status_check,
+  add constraint skills_source_sync_status_check check (
+    source_sync_status = any (array['untracked', 'current', 'changed', 'error'])
+  ),
+  drop constraint if exists skills_license_source_check,
+  add constraint skills_license_source_check check (
+    license_source = any (array['skill_frontmatter', 'github_repository', 'manual', 'unknown'])
+  ),
+  drop constraint if exists skills_license_status_check,
+  add constraint skills_license_status_check check (
+    license_status = any (array['detected', 'missing', 'unknown', 'restricted'])
+  );
+
+update public.skills set
+  license_source = case
+    when coalesce(trim(license), '') = '' or lower(trim(license)) in ('unknown', 'noassertion', 'other') then 'unknown'
+    else 'github_repository'
+  end,
+  license_status = case
+    when coalesce(trim(license), '') = '' or lower(trim(license)) in ('unknown', 'noassertion', 'other') then 'missing'
+    when lower(license) like '%non-commercial%' or lower(license) like '%cc-by-nc%' then 'restricted'
+    else 'detected'
+  end;
+
+create table if not exists public.skill_versions (
+  id uuid primary key default gen_random_uuid(),
+  skill_slug text not null references public.skills(slug) on delete cascade,
+  version text not null default '1.0.0',
+  source_commit_sha text,
+  source_content_hash text not null,
+  source_ref text,
+  source_path text,
+  license text not null default 'Unknown',
+  license_source text not null default 'unknown',
+  detected_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  unique (skill_slug, source_content_hash)
+);
+
+create index if not exists skill_versions_skill_detected_idx
+  on public.skill_versions (skill_slug, detected_at desc);
+
+alter table public.skill_versions enable row level security;
+drop policy if exists skill_versions_select_approved on public.skill_versions;
+create policy skill_versions_select_approved
+  on public.skill_versions for select to anon, authenticated
+  using (exists (
+    select 1 from public.skills
+    where skills.slug = skill_versions.skill_slug
+      and skills.ai_review_approved = true
+  ));
+
+-- A one-time challenge is sensitive until it is consumed. Keep it out of
+-- public SELECT grants even though approved claims themselves are public.
+revoke all on public.skill_claims from anon, authenticated;
+grant select (
+  id, skill_slug, user_id, github_username, x_username, repo_url,
+  verification_method, evidence_url, evidence_note, status, reviewer_note,
+  metadata, created_at, updated_at, verified_at, verification_tier,
+  challenge_expires_at
+) on public.skill_claims to anon, authenticated;
+
+-- Claim mutations go through authenticated server routes so callers cannot
+-- promote their own status, verification tier, or challenge lifecycle.
+drop policy if exists skill_claims_insert_own_pending on public.skill_claims;
+drop policy if exists skill_claims_update_own_pending on public.skill_claims;
+
+revoke all on public.skill_versions from anon, authenticated;
+grant select on public.skill_versions to anon, authenticated;
+
+create or replace function public.record_skill_source_version(
+  p_server_secret text,
+  p_skill_slug text,
+  p_source_commit_sha text,
+  p_source_content_hash text,
+  p_source_ref text,
+  p_source_path text,
+  p_version text,
+  p_license text,
+  p_license_source text,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_previous_hash text;
+  v_changed boolean;
+  v_license_status text;
+begin
+  perform public.assert_indexer_secret(p_server_secret);
+
+  if p_source_content_hash is null or p_source_content_hash !~ '^[a-f0-9]{64}$' then
+    raise exception 'Invalid source content hash';
+  end if;
+
+  select source_content_hash into v_previous_hash
+  from public.skills where slug = p_skill_slug for update;
+
+  if not found then
+    raise exception 'Skill not found';
+  end if;
+
+  v_changed := v_previous_hash is not null and v_previous_hash is distinct from p_source_content_hash;
+  v_license_status := case
+    when coalesce(trim(p_license), '') = '' or lower(trim(p_license)) in ('unknown', 'noassertion', 'other') then 'missing'
+    when lower(p_license) like '%non-commercial%' or lower(p_license) like '%cc-by-nc%' then 'restricted'
+    else 'detected'
+  end;
+
+  update public.skills set
+    source_commit_sha = nullif(p_source_commit_sha, ''),
+    source_content_hash = p_source_content_hash,
+    source_sync_status = case when v_changed then 'changed' else 'current' end,
+    source_ref = coalesce(nullif(p_source_ref, ''), source_ref),
+    source_path = coalesce(nullif(p_source_path, ''), source_path),
+    license_source = case
+      when p_license_source in ('skill_frontmatter', 'github_repository', 'manual') then p_license_source
+      else 'unknown'
+    end,
+    license_status = v_license_status,
+    last_synced_at = now(),
+    updated_at = now()
+  where slug = p_skill_slug;
+
+  insert into public.skill_versions (
+    skill_slug, version, source_commit_sha, source_content_hash,
+    source_ref, source_path, license, license_source, metadata
+  ) values (
+    p_skill_slug, coalesce(nullif(p_version, ''), '1.0.0'),
+    nullif(p_source_commit_sha, ''), p_source_content_hash,
+    nullif(p_source_ref, ''), nullif(p_source_path, ''),
+    coalesce(nullif(p_license, ''), 'Unknown'),
+    case when p_license_source in ('skill_frontmatter', 'github_repository', 'manual')
+      then p_license_source else 'unknown' end,
+    coalesce(p_metadata, '{}'::jsonb)
+  ) on conflict (skill_slug, source_content_hash) do update set
+    source_commit_sha = excluded.source_commit_sha,
+    version = excluded.version,
+    license = excluded.license,
+    license_source = excluded.license_source,
+    metadata = public.skill_versions.metadata || excluded.metadata;
+
+  return jsonb_build_object(
+    'changed', v_changed,
+    'previous_hash', v_previous_hash,
+    'current_hash', p_source_content_hash,
+    'license_status', v_license_status
+  );
+end;
+$$;
+
+revoke all on function public.record_skill_source_version(
+  text, text, text, text, text, text, text, text, text, jsonb
+) from public, anon, authenticated;
+grant execute on function public.record_skill_source_version(
+  text, text, text, text, text, text, text, text, text, jsonb
+) to service_role;
+
+comment on column public.profiles.github_verified_at is
+  'Set only after a GitHub OAuth identity is linked to this Supabase user.';
+comment on column public.skill_claims.verified_at is
+  'Time repository control or equivalent maintainer evidence was verified.';
+comment on column public.skill_claims.verification_tier is
+  'Maintainer is verified repository control; official requires separate organization review.';
+comment on table public.skill_versions is
+  'Immutable-by-content source snapshots recorded by the authenticated source sync.';

--- a/supabase/migrations/20260901151000_harden_creator_source_version_rpc.sql
+++ b/supabase/migrations/20260901151000_harden_creator_source_version_rpc.sql
@@ -1,0 +1,9 @@
+-- The source sync now calls this function with the service role. Remove the
+-- temporary anon/authenticated execution path so the provenance writer is not
+-- exposed through the public Data API.
+revoke execute on function public.record_skill_source_version(
+  text, text, text, text, text, text, text, text, text, jsonb
+) from public, anon, authenticated;
+grant execute on function public.record_skill_source_version(
+  text, text, text, text, text, text, text, text, text, jsonb
+) to service_role;


### PR DESCRIPTION
## Summary
- add secure GitHub repository proof and optional OAuth identity linking for Skill claims
- add creator dashboard, public creator registry/profiles, provenance, license and funnel analytics
- add source commit/version snapshots, prioritized claimed-skill sync and creator sitemap coverage
- harden claim and source-version database permissions

## Verification
- pnpm run typecheck
- targeted ESLint
- pnpm test
- pnpm run build
- desktop/mobile browser verification for /creators, /creator and skill claim entry
- production Supabase migrations and security advisor review