### PR TITLE
Add GitHub creator onboarding

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,12 +1,27 @@
 'use client'
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { Suspense, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
+import { GitHubAuthButton } from '@/components/github-auth-button'
 
 export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  )
+}
+
+function LoginForm() {
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const requestedNext = searchParams.get('next')
+  const nextPath = requestedNext && requestedNext.startsWith('/') && !requestedNext.startsWith('//')
+    ? requestedNext
+    : '/profile'
+  const creatorIntent = nextPath === '/creator' || searchParams.get('intent') === 'creator'
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -22,7 +37,6 @@ export default function LoginPage() {
       setError(error.message)
       setLoading(false)
     } else {
-      const nextPath = new URLSearchParams(window.location.search).get('next') || '/profile'
       router.push(nextPath)
       router.refresh()
     }
@@ -35,13 +49,22 @@ export default function LoginPage() {
           OpenAgentSkill
         </Link>
 
-        <h1 className="font-display text-2xl font-bold mb-1">Sign in</h1>
+        <h1 className="font-display text-2xl font-bold mb-1">
+          {creatorIntent ? 'Sign in to Creator Center' : 'Sign in'}
+        </h1>
+        <p className="mb-3 text-sm leading-relaxed text-secondary">
+          {creatorIntent
+            ? 'Claim your skills, manage your public creator profile, and view install analytics.'
+            : 'Access your OpenAgentSkill account.'}
+        </p>
         <p className="text-sm text-secondary mb-6">
           No account?{' '}
-          <Link href="/auth/sign-up" className="underline hover:opacity-70 transition-opacity">
+          <Link href={`/auth/sign-up?next=${encodeURIComponent(nextPath)}`} className="underline hover:opacity-70 transition-opacity">
             Create one
           </Link>
         </p>
+
+        <GitHubAuthButton fallbackNext={nextPath} />
 
         <form onSubmit={handleLogin} className="space-y-4">
           <div>

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Suspense } from 'react'
+import { GitHubAuthButton } from '@/components/github-auth-button'
 
 export default function SignUpPage() {
   return (
@@ -20,6 +21,11 @@ function SignUpForm() {
   const searchParams = useSearchParams()
   const refCode = searchParams.get('ref')
   const inviterName = searchParams.get('inviter')
+  const requestedNext = searchParams.get('next')
+  const nextPath = requestedNext && requestedNext.startsWith('/') && !requestedNext.startsWith('//')
+    ? requestedNext
+    : '/creator'
+  const creatorIntent = nextPath === '/creator'
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [displayName, setDisplayName] = useState('')
@@ -56,16 +62,25 @@ function SignUpForm() {
 
         {inviterName && (
           <div className="border border-border px-4 py-3 mb-6 text-sm text-secondary">
-            Invited by <strong className="text-foreground">{inviterName}</strong> — you'll both earn bonus points.
+            Invited by <strong className="text-foreground">{inviterName}</strong> — you&apos;ll both earn bonus points.
           </div>
         )}
-        <h1 className="font-display text-2xl font-bold mb-1">Create an account</h1>
+        <h1 className="font-display text-2xl font-bold mb-1">
+          {creatorIntent ? 'Create your Creator Center' : 'Create an account'}
+        </h1>
+        {creatorIntent ? (
+          <p className="mb-3 text-sm leading-relaxed text-secondary">
+            Claim your skills, publish a verified creator profile, and track install performance.
+          </p>
+        ) : null}
         <p className="text-sm text-secondary mb-6">
           Already have one?{' '}
-          <Link href="/auth/login" className="underline hover:opacity-70 transition-opacity">
+          <Link href={`/auth/login?next=${encodeURIComponent(nextPath)}`} className="underline hover:opacity-70 transition-opacity">
             Sign in
           </Link>
         </p>
+
+        <GitHubAuthButton fallbackNext={nextPath} label="Create account with GitHub" />
 
         <form onSubmit={handleSignUp} className="space-y-4">
           <div>

--- a/components/github-auth-button.tsx
+++ b/components/github-auth-button.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import { Github } from 'lucide-react'
+import { createClient } from '@/lib/supabase/client'
+
+function safeNext(value: string | null, fallback: string) {
+  return value && value.startsWith('/') && !value.startsWith('//') ? value : fallback
+}
+
+export function GitHubAuthButton({
+  fallbackNext = '/creator',
+  label = 'Continue with GitHub',
+}: {
+  fallbackNext?: string
+  label?: string
+}) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const enabled = process.env.NEXT_PUBLIC_GITHUB_OAUTH_ENABLED === 'true'
+
+  if (!enabled) return null
+
+  async function continueWithGitHub() {
+    setLoading(true)
+    setError('')
+    const next = safeNext(new URLSearchParams(window.location.search).get('next'), fallbackNext)
+    const redirectTo = new URL('/auth/callback', window.location.origin)
+    redirectTo.searchParams.set('next', next)
+
+    const { error: oauthError } = await createClient().auth.signInWithOAuth({
+      provider: 'github',
+      options: { redirectTo: redirectTo.toString() },
+    })
+    if (oauthError) {
+      setError('GitHub sign-in could not start. You can still use email and password.')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mb-5">
+      <button
+        type="button"
+        onClick={continueWithGitHub}
+        disabled={loading}
+        className="flex w-full items-center justify-center gap-2 border border-foreground bg-foreground px-4 py-2.5 text-sm font-semibold text-background transition-opacity hover:opacity-85 disabled:opacity-50"
+      >
+        <Github className="size-4" aria-hidden="true" />
+        {loading ? 'Connecting to GitHub…' : label}
+      </button>
+      {error ? <p className="mt-2 text-xs text-red-600" role="alert">{error}</p> : null}
+      <div className="mt-5 flex items-center gap-3 text-[10px] uppercase tracking-[0.18em] text-secondary" aria-hidden="true">
+        <span className="h-px flex-1 bg-border" />
+        <span>or continue with email</span>
+        <span className="h-px flex-1 bg-border" />
+      </div>
+    </div>
+  )
+}

--- a/lib/i18n/dictionaries/de.ts
+++ b/lib/i18n/dictionaries/de.ts
@@ -26,7 +26,7 @@ const de = {
     safety: 'Sicherheitsprüfung',
     cli: 'CLI',
     forCreators: 'Für Creator',
-    creatorConsole: 'Creator-Konsole',
+    creatorConsole: 'Creator-Center',
     creators: 'Creator-Verzeichnis',
     creatorKit: 'Creator-Kit',
     learn: 'Lernen',

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -23,7 +23,7 @@ export default {
     safety: 'Safety Gate',
     cli: 'CLI',
     forCreators: 'For Creators',
-    creatorConsole: 'Creator Console',
+    creatorConsole: 'Creator Center',
     creators: 'Creator Registry',
     creatorKit: 'Creator Kit',
     learn: 'Learn',

--- a/lib/i18n/dictionaries/es.ts
+++ b/lib/i18n/dictionaries/es.ts
@@ -26,7 +26,7 @@ const es = {
     safety: 'Control de seguridad',
     cli: 'CLI',
     forCreators: 'Para creadores',
-    creatorConsole: 'Panel de creadores',
+    creatorConsole: 'Centro de creadores',
     creators: 'Registro de creadores',
     creatorKit: 'Kit para creadores',
     learn: 'Aprender',

--- a/lib/i18n/dictionaries/fr.ts
+++ b/lib/i18n/dictionaries/fr.ts
@@ -26,7 +26,7 @@ const fr = {
     safety: 'Contrôle de sécurité',
     cli: 'CLI',
     forCreators: 'Pour les créateurs',
-    creatorConsole: 'Console créateur',
+    creatorConsole: 'Espace créateur',
     creators: 'Registre des créateurs',
     creatorKit: 'Kit créateur',
     learn: 'Apprendre',

--- a/lib/i18n/dictionaries/id.ts
+++ b/lib/i18n/dictionaries/id.ts
@@ -26,7 +26,7 @@ const id = {
     safety: 'Pemeriksaan Keamanan',
     cli: 'CLI',
     forCreators: 'Untuk Kreator',
-    creatorConsole: 'Konsol Kreator',
+    creatorConsole: 'Pusat Kreator',
     creators: 'Registri Kreator',
     creatorKit: 'Kit Kreator',
     learn: 'Pelajari',

--- a/lib/i18n/dictionaries/ja.ts
+++ b/lib/i18n/dictionaries/ja.ts
@@ -26,7 +26,7 @@ const ja = {
     safety: '安全チェック',
     cli: 'CLI',
     forCreators: 'クリエイター向け',
-    creatorConsole: 'クリエイターコンソール',
+    creatorConsole: 'クリエイターセンター',
     creators: 'クリエイター名簿',
     creatorKit: 'クリエイターキット',
     learn: '学ぶ',

--- a/lib/i18n/dictionaries/ko.ts
+++ b/lib/i18n/dictionaries/ko.ts
@@ -26,7 +26,7 @@ const ko = {
     safety: '안전 검사',
     cli: 'CLI',
     forCreators: '크리에이터용',
-    creatorConsole: '크리에이터 콘솔',
+    creatorConsole: '크리에이터 센터',
     creators: '크리에이터 레지스트리',
     creatorKit: '크리에이터 키트',
     learn: '학습',

--- a/lib/i18n/dictionaries/zh.ts
+++ b/lib/i18n/dictionaries/zh.ts
@@ -23,7 +23,7 @@ export default {
     safety: '安全审查',
     cli: '命令行工具',
     forCreators: '创作者',
-    creatorConsole: '创作者控制台',
+    creatorConsole: '创作者中心',
     creators: '创作者名录',
     creatorKit: '创作者工具包',
     learn: '学习',


### PR DESCRIPTION
## Summary
- rename Creator Console to Creator Center across all supported locales
- explain creator benefits at the authentication boundary
- add gated GitHub sign-in and sign-up entry points with safe callback handling
- preserve email/password as a fallback

## Production configuration
- GitHub OAuth App created with the Supabase callback
- GitHub provider and manual identity linking enabled in Supabase
- production site URL and callback allowlist corrected
- Vercel production feature flag enabled

## Verification
- pnpm run typecheck
- targeted ESLint
- pnpm test
- NEXT_PUBLIC_GITHUB_OAUTH_ENABLED=true pnpm run build