### PR TITLE
feat: add rate-safe candidate intake pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,20 @@ SUPABASE_SECRET_KEY=your-supabase-secret-key
 # GitHub API (for auto-indexer)
 GITHUB_TOKEN=ghp_your_github_token
 
+# High-volume candidate intake. GitHub search is capped at 22 requests/window
+# and paced below the authenticated search limit. Validation/publication skip
+# automatically when GITHUB_TOKEN is absent. Set the kill switch to true for
+# an immediate operational pause without a code rollback.
+CANDIDATE_PIPELINE_DISABLED=false
+CANDIDATE_DISCOVERY_LIMIT=2000
+CANDIDATE_DISCOVERY_MAX_QUERIES=22
+CANDIDATE_DISCOVERY_PER_PAGE=100
+CANDIDATE_DISCOVERY_MIN_STARS=10
+CANDIDATE_DISCOVERY_LOOKBACK_DAYS=90
+CANDIDATE_VALIDATION_LIMIT=120
+CANDIDATE_FAST_TRACK_LIMIT=20
+CANDIDATE_AI_REVIEW_LIMIT=21
+
 # Optional: Indexer authentication
 # Required in production for indexer and blog-generation routes
 INDEXER_SECRET=your-random-secret-string

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Contributions are welcome across product, APIs, indexing, trust, documentation, 
 
 Project decisions and maintainer responsibilities are documented in [GOVERNANCE.md](./GOVERNANCE.md). Releases are tracked in [CHANGELOG.md](./CHANGELOG.md), and planned work lives in [ROADMAP.md](./ROADMAP.md).
 
+The two-layer discovery, validation, deduplication, fast-track, and GitHub rate-safety design is documented in [docs/candidate-intake-pipeline.md](./docs/candidate-intake-pipeline.md).
+
 ## License
 
 [MIT](./LICENSE) © OpenAgentSkill contributors.

--- a/app/api/agent/discovery/route.ts
+++ b/app/api/agent/discovery/route.ts
@@ -462,6 +462,9 @@ export async function GET() {
       : 'hourly GitHub scan; X hotspot scan is disabled until an X search budget is configured',
     indexnow_cron: '15 3 * * *',
     indexnow_frequency: 'daily baseline submission plus automatic submission after new skill imports',
+    candidate_discovery_cron: '10 * * * *',
+    candidate_validation_cron: '20,50 * * * *',
+    candidate_publication_cron: '40 * * * *',
   }
   const estimatedDailyCapacity = scheduledHourlyTargetNew * 24
   const remainingToTarget =
@@ -596,6 +599,38 @@ export async function GET() {
       filters,
       schedule,
     },
+    candidate_pipeline: {
+      status: 'active',
+      kill_switch: 'CANDIDATE_PIPELINE_DISABLED=true',
+      architecture: ['indexed_candidates', 'installable_skills'],
+      discovery_capacity_per_day: 52_800,
+      light_validation_capacity_per_day: 5_760,
+      publication_capacity_per_day: 984,
+      fast_track: {
+        minimum_github_stars: 100,
+        requirements: [
+          'unrestricted detected license',
+          'repository updated within 12 months',
+          'documentation-only package',
+          'low deterministic security risk',
+        ],
+        note: 'Stars are only an adoption signal. Every fast-track skill is scanned again immediately before publication.',
+      },
+      deduplication: [
+        'stable GitHub repository id plus SKILL.md path',
+        'canonical source URL',
+        'exact source content SHA-256 across candidates and published skills',
+        'public skill slug uniqueness',
+      ],
+      github_safety: {
+        authenticated_search_interval_ms: 2100,
+        unauthenticated_search_interval_ms: 6100,
+        maximum_search_queries_per_window: 22,
+        stop_on_403_or_429: true,
+        leased_queue_claims: true,
+        exponential_retry_backoff: true,
+      },
+    },
     skill_radar: {
       status: 'active',
       private_endpoint: '/api/cron/skill-radar',
@@ -716,6 +751,9 @@ export async function GET() {
       private_logs: '/api/indexer/logs',
       private_skill_radar: '/api/cron/skill-radar',
       private_skill_source_sync: '/api/cron/skill-source-sync',
+      private_candidate_discovery: '/api/cron/skill-candidates-discover',
+      private_candidate_validation: '/api/cron/skill-candidates-validate',
+      private_candidate_publication: '/api/cron/skill-candidates-publish',
       private_indexnow_submit: '/api/indexnow/submit',
       public_agent_outcomes: '/api/agent/outcome',
       public_agent_outcomes_text: '/api/agent/outcome?format=text',

--- a/app/api/cron/skill-candidates-discover/route.ts
+++ b/app/api/cron/skill-candidates-discover/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { enqueueRepositoryCandidates } from '@/lib/indexer/candidate-intake'
+import { searchHotSkillRepos } from '@/lib/indexer/hot-skill-discovery'
+import { isAutomationAuthorized } from '@/lib/security/route-auth'
+
+export const runtime = 'nodejs'
+export const maxDuration = 300
+
+function boundedInt(value: unknown, fallback: number, min: number, max: number) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? Math.min(Math.max(Math.floor(parsed), min), max) : fallback
+}
+
+async function handleRun(request: NextRequest) {
+  if (!isAutomationAuthorized(request, ['CRON_SECRET', 'INDEXER_SECRET', 'INDEXER_TRIGGER_SECRET'])) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (process.env.CANDIDATE_PIPELINE_DISABLED === 'true') {
+    return NextResponse.json({ success: true, skipped: true, reason: 'Candidate pipeline is disabled by configuration.' })
+  }
+
+  const body = request.method === 'POST' ? await request.json().catch(() => ({})) : {}
+  const limit = boundedInt(body.limit ?? process.env.CANDIDATE_DISCOVERY_LIMIT, 2_000, 1, 2_000)
+  const maxQueries = boundedInt(body.maxQueries ?? process.env.CANDIDATE_DISCOVERY_MAX_QUERIES, 22, 1, 22)
+  const perPage = boundedInt(body.perPage ?? process.env.CANDIDATE_DISCOVERY_PER_PAGE, 100, 5, 100)
+  const minStars = boundedInt(body.minStars ?? process.env.CANDIDATE_DISCOVERY_MIN_STARS, 10, 10, 100_000)
+  const lookbackDays = boundedInt(body.lookbackDays ?? process.env.CANDIDATE_DISCOVERY_LOOKBACK_DAYS, 90, 1, 90)
+  const hourlyWindow = Math.floor(Date.now() / 3_600_000)
+  const discovery = await searchHotSkillRepos({
+    limit,
+    maxQueries,
+    perPage,
+    minStars,
+    lookbackDays,
+    queryOffset: hourlyWindow * maxQueries,
+  })
+  const intake = await enqueueRepositoryCandidates(discovery.candidates, 'github-candidate-discovery')
+
+  return NextResponse.json({
+    success: true,
+    mode: 'candidate-discovery',
+    discovery: {
+      searched_queries: discovery.searchedQueries,
+      candidates: discovery.candidates.length,
+      min_stars: discovery.minStars,
+      since: discovery.since,
+      rate_limited: discovery.rateLimited,
+      retry_after_ms: discovery.retryAfterMs,
+    },
+    intake,
+  })
+}
+
+export async function GET(request: NextRequest) {
+  return handleRun(request)
+}
+
+export async function POST(request: NextRequest) {
+  return handleRun(request)
+}

--- a/app/api/cron/skill-candidates-publish/route.ts
+++ b/app/api/cron/skill-candidates-publish/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { buildIndexNowUrlsForSkill, submitIndexNowUrls } from '@/lib/indexnow'
+import { runCandidatePublicationBatch } from '@/lib/indexer/candidate-intake'
+import { isAutomationAuthorized } from '@/lib/security/route-auth'
+
+export const runtime = 'nodejs'
+export const maxDuration = 300
+
+function boundedInt(value: unknown, fallback: number, min: number, max: number) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? Math.min(Math.max(Math.floor(parsed), min), max) : fallback
+}
+
+async function handleRun(request: NextRequest) {
+  if (!isAutomationAuthorized(request, ['CRON_SECRET', 'INDEXER_SECRET', 'INDEXER_TRIGGER_SECRET'])) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (process.env.CANDIDATE_PIPELINE_DISABLED === 'true') {
+    return NextResponse.json({ success: true, skipped: true, reason: 'Candidate pipeline is disabled by configuration.' })
+  }
+  if (!process.env.GITHUB_TOKEN) {
+    return NextResponse.json({
+      success: true,
+      skipped: true,
+      reason: 'GITHUB_TOKEN is required for candidate publication; no unauthenticated GitHub requests were sent.',
+    })
+  }
+  const body = request.method === 'POST' ? await request.json().catch(() => ({})) : {}
+  const fastTrackLimit = boundedInt(body.fastTrackLimit ?? process.env.CANDIDATE_FAST_TRACK_LIMIT, 20, 1, 50)
+  const aiReviewLimit = boundedInt(body.aiReviewLimit ?? process.env.CANDIDATE_AI_REVIEW_LIMIT, 21, 0, 25)
+  const result = await runCandidatePublicationBatch({ fastTrackLimit, aiReviewLimit })
+  const indexing = await submitIndexNowUrls(result.slugs.flatMap(buildIndexNowUrlsForSkill))
+
+  return NextResponse.json({
+    success: !result.rateLimited && result.errors === 0,
+    mode: 'candidate-publication',
+    result,
+    indexing,
+  })
+}
+
+export async function GET(request: NextRequest) {
+  return handleRun(request)
+}
+
+export async function POST(request: NextRequest) {
+  return handleRun(request)
+}

--- a/app/api/cron/skill-candidates-validate/route.ts
+++ b/app/api/cron/skill-candidates-validate/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { runCandidateValidationBatch } from '@/lib/indexer/candidate-intake'
+import { isAutomationAuthorized } from '@/lib/security/route-auth'
+
+export const runtime = 'nodejs'
+export const maxDuration = 300
+
+async function handleRun(request: NextRequest) {
+  if (!isAutomationAuthorized(request, ['CRON_SECRET', 'INDEXER_SECRET', 'INDEXER_TRIGGER_SECRET'])) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (process.env.CANDIDATE_PIPELINE_DISABLED === 'true') {
+    return NextResponse.json({ success: true, skipped: true, reason: 'Candidate pipeline is disabled by configuration.' })
+  }
+  if (!process.env.GITHUB_TOKEN) {
+    return NextResponse.json({
+      success: true,
+      skipped: true,
+      reason: 'GITHUB_TOKEN is required for high-volume validation; no unauthenticated GitHub requests were sent.',
+    })
+  }
+  const body = request.method === 'POST' ? await request.json().catch(() => ({})) : {}
+  const requested = Number(body.limit ?? request.nextUrl.searchParams.get('limit') ?? process.env.CANDIDATE_VALIDATION_LIMIT ?? 120)
+  const limit = Number.isFinite(requested) ? Math.min(Math.max(Math.floor(requested), 1), 250) : 120
+  const result = await runCandidateValidationBatch(limit)
+
+  return NextResponse.json({
+    success: !result.rateLimited,
+    mode: 'candidate-light-validation',
+    result,
+  })
+}
+
+export async function GET(request: NextRequest) {
+  return handleRun(request)
+}
+
+export async function POST(request: NextRequest) {
+  return handleRun(request)
+}

--- a/docs/candidate-intake-pipeline.md
+++ b/docs/candidate-intake-pipeline.md
@@ -1,0 +1,43 @@
+# Candidate intake pipeline
+
+OpenAgentSkill keeps discovery scale separate from public marketplace quality:
+
+- `skill_candidates` is an internal, service-role-only queue. Candidate rows do not create public pages or sitemap entries.
+- `skills` remains the installable public registry. A candidate reaches it only after deterministic or AI review.
+
+## Scheduled capacity
+
+| Stage | Schedule | Default bound | Daily bound |
+| --- | --- | ---: | ---: |
+| GitHub discovery | hourly at `:10` | 22 searches × 100 results | 52,800 result slots |
+| Light validation | hourly at `:20` and `:50` | 120 candidates/run | 5,760 candidates |
+| 100-star deterministic fast track | hourly at `:40` | 20 skills/run | 480 skills |
+| AI review | hourly at `:40` | 21 skills/run | 504 skills |
+
+These are ceilings, not promised insert counts. Repository relevance filtering, stable identifiers, source URLs, exact content hashes, licenses, security checks, and existing registry records reduce the number of unique public skills.
+
+## Fast-track policy
+
+GitHub stars are an adoption signal, not a security guarantee. A repository with at least 100 stars is eligible only when all of the following remain true at publication time:
+
+1. An unrestricted license is detected.
+2. The repository was pushed within the last 12 months.
+3. The bounded package is documentation-only and fully scanned.
+4. Static analysis and instruction scanning report low risk.
+5. The same source or exact SHA-256 content is not already queued or published.
+
+The policy runs once during validation and again immediately before the public upsert. Script files, truncated packages, dangerous shell instructions, secrets, elevated privileges, command execution, and network execution all leave the fast track.
+
+## GitHub limit protection
+
+- Authenticated search requests are spaced by at least 2.1 seconds (under 30 requests/minute).
+- Unauthenticated search requests are spaced by at least 6.1 seconds (under 10 requests/minute).
+- Search stops for the current window on HTTP 403 or 429 and respects reset/retry headers.
+- Validation uses two workers with pacing between chunks; publication is sequential with a 2.5-second gap.
+- Validation and publication do not run without `GITHUB_TOKEN`.
+- Queue claims use leases and `FOR UPDATE SKIP LOCKED`, so overlapping invocations do not process the same row.
+- Validation and publication failures have separate retry states with exponential backoff.
+- Workers stop at a 210-second internal time budget, release unstarted leases, and reclaim stale `publishing` rows after interruption.
+- AI review is capped at 20 seconds per candidate so one provider timeout cannot exhaust the whole cron run.
+
+Set `CANDIDATE_PIPELINE_DISABLED=true` for an immediate pause. Cron endpoints remain authenticated by the existing automation secrets.

--- a/lib/ai-review/reviewer.ts
+++ b/lib/ai-review/reviewer.ts
@@ -163,6 +163,7 @@ Return only JSON without markdown fences:
       model: SUBMISSION_REVIEW_MODEL,
       prompt,
       temperature: 0.2,
+      abortSignal: AbortSignal.timeout(20_000),
     })
     const jsonMatch = result.text.match(/\{[\s\S]*\}/)
     if (!jsonMatch) throw new Error('Invalid AI response format')

--- a/lib/github/api.ts
+++ b/lib/github/api.ts
@@ -35,6 +35,7 @@ export async function validateGitHubRepo(
         'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
       }),
     },
+    signal: AbortSignal.timeout(12_000),
   })
 
   if (!response.ok) {
@@ -55,13 +56,20 @@ export async function validateGitHubRepo(
   const [readmeResponse, skillJsonResponse] = await Promise.all([
     options.checkReadme === false
       ? null
-      : fetch(`https://api.github.com/repos/${owner}/${repo}/readme`, { headers: optionalHeaders }),
+      : fetch(`https://api.github.com/repos/${owner}/${repo}/readme`, {
+          headers: optionalHeaders,
+          signal: AbortSignal.timeout(12_000),
+        }),
     options.checkSkillJson === false
       ? null
-      : fetch(`https://api.github.com/repos/${owner}/${repo}/contents/skill.json`, { headers: optionalHeaders }),
+      : fetch(`https://api.github.com/repos/${owner}/${repo}/contents/skill.json`, {
+          headers: optionalHeaders,
+          signal: AbortSignal.timeout(12_000),
+        }),
   ])
 
   return {
+    id: typeof data.id === 'number' ? data.id : undefined,
     owner,
     repo,
     fullName: data.full_name,
@@ -71,6 +79,7 @@ export async function validateGitHubRepo(
     language: data.language || undefined,
     license: data.license?.spdx_id || undefined,
     updatedAt: data.updated_at,
+    pushedAt: typeof data.pushed_at === 'string' ? data.pushed_at : null,
     defaultBranch: data.default_branch,
     hasReadme: Boolean(readmeResponse?.ok),
     hasSkillJson: Boolean(skillJsonResponse?.ok),

--- a/lib/github/skill-source.ts
+++ b/lib/github/skill-source.ts
@@ -356,6 +356,7 @@ const REVIEWABLE_EXTENSIONS = new Set([
   '.md', '.txt', '.json', '.yaml', '.yml', '.toml', '.sh', '.bash', '.zsh',
   '.js', '.mjs', '.cjs', '.ts', '.tsx', '.py', '.go', '.rs', '.java', '.rb',
 ])
+const SAFE_ASSET_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico', '.pdf'])
 
 function extension(path: string) {
   const file = path.slice(path.lastIndexOf('/') + 1)
@@ -363,27 +364,56 @@ function extension(path: string) {
   return dot >= 0 ? file.slice(dot).toLowerCase() : ''
 }
 
-export async function fetchSkillPackageFiles(skill: DiscoveredGitHubSkill) {
+export async function fetchSkillPackageSnapshot(
+  skill: DiscoveredGitHubSkill,
+  options: { maxFiles?: number } = {}
+) {
   const { tree } = await fetchRepositoryTree(skill.owner, skill.repo, skill.ref)
   const prefix = skill.directory ? `${skill.directory}/` : ''
-  const paths = tree
+  const packageItems = tree
     .filter((item) => item.type === 'blob')
     .filter((item) => !prefix || item.path.startsWith(prefix))
-    .filter((item) => REVIEWABLE_EXTENSIONS.has(extension(item.path)))
     .filter((item) => !/(^|\/)(node_modules|dist|build|vendor|\.git)(\/|$)/i.test(item.path))
     .filter((item) => !item.size || item.size <= MAX_FILE_BYTES)
+  const reviewablePaths = packageItems
+    .filter((item) => REVIEWABLE_EXTENSIONS.has(extension(item.path)))
     .sort((a, b) => {
       if (a.path === skill.path) return -1
       if (b.path === skill.path) return 1
       return a.path.localeCompare(b.path)
     })
-    .slice(0, MAX_PACKAGE_FILES)
     .map((item) => item.path)
+  const maxFiles = Math.min(Math.max(Math.floor(options.maxFiles || MAX_PACKAGE_FILES), 1), MAX_PACKAGE_FILES)
+  const paths = reviewablePaths.slice(0, maxFiles)
 
-  return Promise.all(paths.map(async (path) => ({
+  const files = await Promise.all(paths.map(async (path) => ({
     path,
     content: path === skill.path
       ? skill.document
       : await fetchRepositoryFile(skill.owner, skill.repo, skill.ref, path).catch(() => ''),
   })))
+  const unreviewedPaths = packageItems
+    .map((item) => item.path)
+    .filter((path) => {
+      const ext = extension(path)
+      const fileName = path.slice(path.lastIndexOf('/') + 1)
+      return !REVIEWABLE_EXTENSIONS.has(ext) &&
+        !SAFE_ASSET_EXTENSIONS.has(ext) &&
+        !/^(LICENSE|COPYING|NOTICE)(?:\.[A-Za-z0-9-]+)?$/i.test(fileName)
+    })
+
+  return {
+    files,
+    totalFiles: reviewablePaths.length,
+    truncated: reviewablePaths.length > files.length,
+    hasUnreviewedFiles: unreviewedPaths.length > 0,
+    unreviewedPaths: unreviewedPaths.slice(0, 5),
+  }
+}
+
+export async function fetchSkillPackageFiles(
+  skill: DiscoveredGitHubSkill,
+  options: { maxFiles?: number } = {}
+) {
+  return (await fetchSkillPackageSnapshot(skill, options)).files
 }

--- a/lib/indexer/candidate-identity.ts
+++ b/lib/indexer/candidate-identity.ts
@@ -1,0 +1,29 @@
+function normalizePath(value: string | null | undefined) {
+  return (value || '').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '').replace(/\/{2,}/g, '/')
+}
+
+function normalizeFullName(value: string) {
+  return value.trim().replace(/^\/+|\/+$/g, '').toLowerCase()
+}
+
+export function buildCandidateSourceKey(
+  repositoryId: number | null | undefined,
+  fullName: string,
+  sourcePath?: string | null
+) {
+  const repositoryKey = repositoryId ? String(repositoryId) : `name:${normalizeFullName(fullName)}`
+  return `github:${repositoryKey}:${normalizePath(sourcePath) || '@repo'}`
+}
+
+export function canonicalGitHubSourceUrl(fullName: string, ref?: string | null, path?: string | null) {
+  const [owner, repo] = fullName.split('/')
+  const normalizedPath = normalizePath(path)
+  if (!normalizedPath) return `https://github.com/${owner}/${repo}`
+  const branch = (ref || 'HEAD').trim()
+  if (/SKILL\.md$/i.test(normalizedPath)) {
+    return `https://github.com/${owner}/${repo}/blob/${branch}/${normalizedPath}`
+  }
+  return `https://github.com/${owner}/${repo}/tree/${branch}/${normalizedPath}`
+}
+
+export { normalizePath as normalizeCandidateSourcePath }

--- a/lib/indexer/candidate-intake.ts
+++ b/lib/indexer/candidate-intake.ts
@@ -1,0 +1,501 @@
+import 'server-only'
+
+import { createHash, randomUUID } from 'node:crypto'
+import { getLicenseEvidence } from '@/lib/creator-ownership'
+import { validateGitHubRepo } from '@/lib/github/api'
+import {
+  discoverGitHubSkills,
+  fetchSkillPackageSnapshot,
+  parseGitHubSkillReference,
+  type DiscoveredGitHubSkill,
+} from '@/lib/github/skill-source'
+import { createAdminClient } from '@/lib/supabase/admin'
+import type { CandidateRepo } from './github-search'
+import {
+  buildCandidateSourceKey,
+  canonicalGitHubSourceUrl,
+  normalizeCandidateSourcePath,
+} from './candidate-identity'
+import { evaluateFastTrackCandidate } from './fast-track'
+import { syncRepositorySkills } from './repository-skill-sync'
+
+const DB_TIMEOUT_MS = 20_000
+const CANDIDATE_LEASE_SECONDS = 240
+const VALIDATION_CONCURRENCY = 2
+const VALIDATION_CHUNK_DELAY_MS = 800
+const PUBLICATION_DELAY_MS = 2_500
+const WORKER_TIME_BUDGET_MS = 210_000
+
+export type SkillCandidateStatus =
+  | 'discovered'
+  | 'validating'
+  | 'expanded'
+  | 'fast_track'
+  | 'review_required'
+  | 'publishing'
+  | 'published'
+  | 'rejected'
+  | 'duplicate'
+  | 'validation_error'
+  | 'publication_error'
+
+export interface SkillCandidateRow {
+  id: string
+  source_key: string
+  github_repository_id: number | null
+  github_full_name: string
+  github_owner: string
+  github_repo: string
+  source_ref: string | null
+  source_path: string
+  canonical_source_url: string
+  source_content_hash: string | null
+  skill_name: string | null
+  skill_description: string | null
+  github_stars: number
+  github_updated_at: string | null
+  license: string | null
+  license_status: 'unknown' | 'missing' | 'restricted' | 'detected'
+  status: SkillCandidateStatus
+  risk_level: 'unknown' | 'low' | 'medium' | 'high' | 'critical'
+  risk_reasons: string[]
+  fast_track_eligible: boolean
+  requires_ai_review: boolean
+  duplicate_of: string | null
+  discovery_source: string
+  discovery_payload: Record<string, unknown>
+  attempt_count: number
+}
+
+function contentHash(value: string) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function admin() {
+  return createAdminClient({ requestTimeoutMs: DB_TIMEOUT_MS })
+}
+
+export async function enqueueRepositoryCandidates(
+  candidates: CandidateRepo[],
+  discoverySource = 'github-search'
+) {
+  const unique = new Map<string, Record<string, unknown>>()
+
+  for (const candidate of candidates) {
+    const sourcePath = candidate.skillSourceUrl ? parseGitHubSkillReference(candidate.skillSourceUrl)?.path || '' : ''
+    const sourceKey = buildCandidateSourceKey(candidate.githubId, candidate.fullName, sourcePath)
+    unique.set(sourceKey, {
+      source_key: sourceKey,
+      github_repository_id: candidate.githubId || null,
+      github_full_name: candidate.fullName,
+      github_owner: candidate.owner,
+      github_repo: candidate.repo,
+      source_ref: null,
+      source_path: normalizeCandidateSourcePath(sourcePath),
+      canonical_source_url: candidate.skillSourceUrl || candidate.htmlUrl || canonicalGitHubSourceUrl(candidate.fullName),
+      github_stars: Math.max(0, candidate.stars || 0),
+      github_updated_at: candidate.pushedAt || candidate.updatedAt || null,
+      status: 'discovered',
+      discovery_source: discoverySource,
+      discovery_payload: {
+        description: candidate.description,
+        language: candidate.language,
+        topics: candidate.topics || [],
+        discovery: candidate.discovery || null,
+      },
+      last_seen_at: new Date().toISOString(),
+    })
+  }
+
+  const rows = Array.from(unique.values())
+  if (!rows.length) return { attempted: 0, inserted: 0, duplicates: 0 }
+
+  const { data, error } = await admin()
+    .from('skill_candidates')
+    .upsert(rows, { onConflict: 'source_key', ignoreDuplicates: true })
+    .select('id')
+  if (error) throw new Error(`Candidate enqueue failed: ${error.message}`)
+
+  const inserted = data?.length || 0
+  return { attempted: rows.length, inserted, duplicates: rows.length - inserted }
+}
+
+async function claimCandidates(statuses: SkillCandidateStatus[], limit: number, workerPrefix: string) {
+  const workerId = `${workerPrefix}-${randomUUID()}`
+  const { data, error } = await admin().rpc('claim_skill_candidates', {
+    p_statuses: statuses,
+    p_limit: Math.min(Math.max(limit, 1), 250),
+    p_worker_id: workerId,
+    p_lease_seconds: CANDIDATE_LEASE_SECONDS,
+  })
+  if (error) throw new Error(`Candidate claim failed: ${error.message}`)
+  return (data || []) as SkillCandidateRow[]
+}
+
+async function updateCandidate(id: string, values: Record<string, unknown>) {
+  const { error } = await admin()
+    .from('skill_candidates')
+    .update({ ...values, lease_owner: null, lease_expires_at: null })
+    .eq('id', id)
+  if (error) throw new Error(`Candidate update failed: ${error.message}`)
+}
+
+async function releaseCandidates(ids: string[]) {
+  if (!ids.length) return
+  const { error } = await admin()
+    .from('skill_candidates')
+    .update({ lease_owner: null, lease_expires_at: null })
+    .in('id', ids)
+  if (error) console.warn('[candidate-intake] failed to release unused leases:', error.message)
+}
+
+function isGitHubRateLimitError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error || '')
+  return /GitHub.*(?:403|429|rate.?limit)|API error:\s*(?:Forbidden|Too Many Requests)|Unable to read.*\((?:403|429)\)/i.test(message)
+}
+
+async function findDuplicateContent(sourceKey: string, hash: string, sourceUrl: string) {
+  const { data, error } = await admin()
+    .from('skill_candidates')
+    .select('id, status, published_skill_slug')
+    .eq('source_content_hash', hash)
+    .neq('source_key', sourceKey)
+    .in('status', ['fast_track', 'review_required', 'publishing', 'published', 'publication_error'])
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle()
+  if (error) throw new Error(`Content dedupe lookup failed: ${error.message}`)
+  if (data) {
+    return {
+      candidateId: String(data.id),
+      publishedSkillSlug: data.published_skill_slug ? String(data.published_skill_slug) : null,
+    }
+  }
+
+  const { data: publishedBySource, error: publishedBySourceError } = await admin()
+    .from('skills')
+    .select('slug')
+    .eq('repository', sourceUrl)
+    .eq('ai_review_approved', true)
+    .limit(1)
+    .maybeSingle()
+  if (publishedBySourceError) throw new Error(`Published source dedupe lookup failed: ${publishedBySourceError.message}`)
+  if (publishedBySource) {
+    return { candidateId: null, publishedSkillSlug: String(publishedBySource.slug) }
+  }
+
+  const { data: published, error: publishedError } = await admin()
+    .from('skills')
+    .select('slug')
+    .eq('source_content_hash', hash)
+    .eq('ai_review_approved', true)
+    .limit(1)
+    .maybeSingle()
+  if (publishedError) throw new Error(`Published content dedupe lookup failed: ${publishedError.message}`)
+  return published
+    ? { candidateId: null, publishedSkillSlug: String(published.slug) }
+    : null
+}
+
+async function insertExpandedCandidate(row: Record<string, unknown>) {
+  const client = admin()
+  const { data, error } = await client
+    .from('skill_candidates')
+    .upsert(row, { onConflict: 'source_key', ignoreDuplicates: true })
+    .select('id, status')
+  if (!error) return data || []
+
+  if (error.code !== '23505' || !/skill_candidates_active_content_unique/i.test(error.message)) {
+    throw new Error(`Expanded candidate insert failed: ${error.message}`)
+  }
+
+  const sourceKey = String(row.source_key || '')
+  const hash = String(row.source_content_hash || '')
+  const sourceUrl = String(row.canonical_source_url || '')
+  const duplicate = await findDuplicateContent(sourceKey, hash, sourceUrl)
+  const duplicateRow = {
+    ...row,
+    status: 'duplicate',
+    fast_track_eligible: false,
+    requires_ai_review: false,
+    duplicate_of: duplicate?.candidateId || null,
+    risk_reasons: [duplicate?.candidateId
+      ? `Exact content duplicate of candidate ${duplicate.candidateId}`
+      : `Exact content already published as ${duplicate?.publishedSkillSlug || 'another listing'}`],
+  }
+  const { data: duplicateData, error: duplicateError } = await client
+    .from('skill_candidates')
+    .upsert(duplicateRow, { onConflict: 'source_key', ignoreDuplicates: true })
+    .select('id, status')
+  if (duplicateError) throw new Error(`Concurrent duplicate insert failed: ${duplicateError.message}`)
+  return duplicateData || []
+}
+
+async function buildSkillCandidateRow(
+  parent: SkillCandidateRow,
+  repository: Awaited<ReturnType<typeof validateGitHubRepo>>,
+  skill: DiscoveredGitHubSkill
+) {
+  const hash = contentHash(skill.document)
+  const sourceKey = buildCandidateSourceKey(repository.id || parent.github_repository_id, repository.fullName, skill.path)
+  const license = getLicenseEvidence(skill.frontmatter.license, repository.license)
+  const duplicate = await findDuplicateContent(sourceKey, hash, skill.sourceUrl)
+  let files: Array<{ path: string; content: string }> = [{ path: skill.path, content: skill.document }]
+  let packageTruncated = false
+  let hasUnreviewedFiles = false
+
+  if (!duplicate && repository.stars >= 100 && license.status === 'detected') {
+    const snapshot = await fetchSkillPackageSnapshot(skill, { maxFiles: 4 })
+    files = snapshot.files
+    packageTruncated = snapshot.truncated
+    hasUnreviewedFiles = snapshot.hasUnreviewedFiles
+  }
+
+  const decision = evaluateFastTrackCandidate({
+    stars: repository.stars,
+    licenseStatus: license.status,
+    updatedAt: repository.pushedAt || repository.updatedAt,
+    document: skill.document,
+    files,
+    packageTruncated,
+    hasUnreviewedFiles,
+  })
+  const status: SkillCandidateStatus = duplicate
+    ? 'duplicate'
+    : license.status === 'missing' || license.status === 'restricted'
+      ? 'rejected'
+      : decision.eligible
+        ? 'fast_track'
+        : 'review_required'
+
+  return {
+    source_key: sourceKey,
+    github_repository_id: repository.id || parent.github_repository_id,
+    github_full_name: repository.fullName,
+    github_owner: repository.owner,
+    github_repo: repository.repo,
+    source_ref: skill.ref,
+    source_path: skill.path,
+    canonical_source_url: skill.sourceUrl,
+    source_content_hash: hash,
+    skill_name: skill.frontmatter.name,
+    skill_description: skill.frontmatter.description,
+    github_stars: repository.stars,
+    github_updated_at: repository.pushedAt || repository.updatedAt,
+    license: license.license,
+    license_status: license.status,
+    status,
+    risk_level: decision.riskLevel,
+    risk_reasons: duplicate
+      ? [duplicate.candidateId
+          ? `Exact content duplicate of candidate ${duplicate.candidateId}`
+          : `Exact content already published as ${duplicate.publishedSkillSlug}`]
+      : license.status === 'missing' || license.status === 'restricted'
+        ? [`License is ${license.status}; automatic publication requires an unrestricted detected license`]
+        : decision.reasons,
+    has_executable_files: decision.hasExecutableFiles,
+    fast_track_eligible: status === 'fast_track',
+    requires_ai_review: status === 'review_required',
+    duplicate_of: duplicate?.candidateId || null,
+    discovery_source: parent.discovery_source,
+    discovery_payload: parent.discovery_payload || {},
+    validation_payload: {
+      parent_candidate_id: parent.id,
+      age_days: decision.ageDays,
+      tree_source: 'github-api',
+    },
+    validated_at: new Date().toISOString(),
+    last_seen_at: new Date().toISOString(),
+  }
+}
+
+async function validateRepositoryCandidate(candidate: SkillCandidateRow) {
+  try {
+    const reference = parseGitHubSkillReference(candidate.canonical_source_url)
+    if (!reference) throw new Error('Invalid canonical GitHub source')
+    const repository = await validateGitHubRepo(candidate.github_full_name, {
+      checkReadme: true,
+      checkSkillJson: false,
+    })
+    const discovery = await discoverGitHubSkills(reference, repository)
+
+    if (!discovery.skills.length) {
+      await updateCandidate(candidate.id, {
+        status: 'rejected',
+        risk_reasons: ['No valid SKILL.md document found'],
+        validated_at: new Date().toISOString(),
+        last_error: null,
+      })
+      return { expanded: 0, fastTrack: 0, reviewRequired: 0, duplicates: 0, rejected: 1, errors: 0 }
+    }
+
+    const rows = []
+    for (const skill of discovery.skills.slice(0, 20)) {
+      rows.push(await buildSkillCandidateRow(candidate, repository, skill))
+    }
+    const data = (await Promise.all(rows.map(insertExpandedCandidate))).flat()
+
+    await updateCandidate(candidate.id, {
+      status: 'expanded',
+      github_repository_id: repository.id || candidate.github_repository_id,
+      github_stars: repository.stars,
+      github_updated_at: repository.pushedAt || repository.updatedAt,
+      validated_at: new Date().toISOString(),
+      validation_payload: {
+        discovered_skills: discovery.skills.length,
+        inserted_skills: data.length,
+        tree_truncated: discovery.truncated,
+      },
+      last_error: null,
+    })
+
+    const inserted = data
+    return {
+      expanded: inserted.length,
+      fastTrack: inserted.filter((row) => row.status === 'fast_track').length,
+      reviewRequired: inserted.filter((row) => row.status === 'review_required').length,
+      duplicates: inserted.filter((row) => row.status === 'duplicate').length,
+      rejected: inserted.filter((row) => row.status === 'rejected').length,
+      errors: 0,
+    }
+  } catch (error) {
+    const rateLimited = isGitHubRateLimitError(error)
+    const delayMinutes = rateLimited ? 60 : Math.min(360, 5 * 2 ** Math.min(candidate.attempt_count, 6))
+    await updateCandidate(candidate.id, {
+      status: !rateLimited && candidate.attempt_count >= 4 ? 'rejected' : 'validation_error',
+      next_attempt_at: new Date(Date.now() + delayMinutes * 60_000).toISOString(),
+      last_error: error instanceof Error ? error.message.slice(0, 1000) : 'Candidate validation failed',
+    })
+    return { expanded: 0, fastTrack: 0, reviewRequired: 0, duplicates: 0, rejected: 0, errors: 1, rateLimited }
+  }
+}
+
+export async function runCandidateValidationBatch(limit = 12) {
+  const startedAt = Date.now()
+  const candidates = await claimCandidates(['discovered', 'validation_error'], limit, 'candidate-validator')
+  const totals = { claimed: candidates.length, processed: 0, expanded: 0, fastTrack: 0, reviewRequired: 0, duplicates: 0, rejected: 0, errors: 0, rateLimited: false, timeBudgetReached: false }
+
+  for (let offset = 0; offset < candidates.length; offset += VALIDATION_CONCURRENCY) {
+    if (Date.now() - startedAt >= WORKER_TIME_BUDGET_MS) {
+      totals.timeBudgetReached = true
+      await releaseCandidates(candidates.slice(offset).map((candidate) => candidate.id))
+      break
+    }
+    const chunk = candidates.slice(offset, offset + VALIDATION_CONCURRENCY)
+    const results = await Promise.all(chunk.map(validateRepositoryCandidate))
+    totals.processed += chunk.length
+    for (const result of results) {
+      for (const key of ['expanded', 'fastTrack', 'reviewRequired', 'duplicates', 'rejected', 'errors'] as const) {
+        totals[key] += result[key]
+      }
+      if ('rateLimited' in result && result.rateLimited) totals.rateLimited = true
+    }
+    if (totals.rateLimited) {
+      await releaseCandidates(candidates.slice(offset + chunk.length).map((candidate) => candidate.id))
+      break
+    }
+    if (offset + chunk.length < candidates.length) await sleep(VALIDATION_CHUNK_DELAY_MS)
+  }
+  return totals
+}
+
+async function publishCandidate(candidate: SkillCandidateRow) {
+  try {
+    await updateCandidate(candidate.id, { status: 'publishing', last_error: null })
+    const result = await syncRepositorySkills({
+      reference: candidate.canonical_source_url,
+      discoverySource: candidate.fast_track_eligible ? 'github-fast-track' : 'github-candidate-review',
+      maxSkills: 1,
+      reviewMode: candidate.fast_track_eligible ? 'fast-track' : 'ai',
+      discoveryMetadata: {
+        candidate_id: candidate.id,
+        risk_level: candidate.risk_level,
+        risk_reasons: candidate.risk_reasons,
+        fast_track: candidate.fast_track_eligible,
+      },
+    })
+    const successful = result.entries.find((entry) => entry.status === 'created' || entry.status === 'updated')
+    if (!successful) {
+      const reason = result.entries.find((entry) => entry.reason)?.reason || 'Candidate did not pass publication review'
+      await updateCandidate(candidate.id, { status: 'rejected', last_error: reason.slice(0, 1000) })
+      return { status: 'rejected' as const, slug: null }
+    }
+
+    await updateCandidate(candidate.id, {
+      status: 'published',
+      published_skill_slug: successful.slug,
+      published_at: new Date().toISOString(),
+      last_error: null,
+    })
+    return { status: 'published' as const, slug: successful.slug }
+  } catch (error) {
+    const rateLimited = isGitHubRateLimitError(error)
+    const delayMinutes = rateLimited ? 60 : Math.min(360, 5 * 2 ** Math.min(candidate.attempt_count, 6))
+    await updateCandidate(candidate.id, {
+      status: !rateLimited && candidate.attempt_count >= 4 ? 'rejected' : 'publication_error',
+      next_attempt_at: new Date(Date.now() + delayMinutes * 60_000).toISOString(),
+      last_error: error instanceof Error ? error.message.slice(0, 1000) : 'Candidate publication failed',
+    })
+    return { status: 'error' as const, slug: null, rateLimited }
+  }
+}
+
+export async function runCandidatePublicationBatch(options: { fastTrackLimit?: number; aiReviewLimit?: number } = {}) {
+  const startedAt = Date.now()
+  const fastTrackLimit = Math.min(Math.max(options.fastTrackLimit ?? 12, 1), 50)
+  const aiReviewLimit = Math.min(Math.max(options.aiReviewLimit ?? 4, 0), 25)
+  const fastTrack = await claimCandidates(['fast_track'], fastTrackLimit, 'candidate-fast-publisher')
+  const reviewed = aiReviewLimit > 0
+    ? await claimCandidates(['review_required'], aiReviewLimit, 'candidate-ai-publisher')
+    : []
+  const retries = await claimCandidates(['publication_error', 'publishing'], Math.min(10, fastTrackLimit), 'candidate-publication-retry')
+  const claimed = [...retries, ...fastTrack, ...reviewed]
+  const results = []
+  let timeBudgetReached = false
+  for (let index = 0; index < claimed.length; index += 1) {
+    if (Date.now() - startedAt >= WORKER_TIME_BUDGET_MS) {
+      timeBudgetReached = true
+      await releaseCandidates(claimed.slice(index).map((candidate) => candidate.id))
+      break
+    }
+    const result = await publishCandidate(claimed[index])
+    results.push(result)
+    if ('rateLimited' in result && result.rateLimited) {
+      await releaseCandidates(claimed.slice(index + 1).map((candidate) => candidate.id))
+      break
+    }
+    if (index + 1 < claimed.length) await sleep(PUBLICATION_DELAY_MS)
+  }
+
+  return {
+    claimed: claimed.length,
+    processed: results.length,
+    fastTrackClaimed: fastTrack.length,
+    aiReviewClaimed: reviewed.length,
+    retryClaimed: retries.length,
+    timeBudgetReached,
+    published: results.filter((result) => result.status === 'published').length,
+    rejected: results.filter((result) => result.status === 'rejected').length,
+    errors: results.filter((result) => result.status === 'error').length,
+    rateLimited: results.some((result) => 'rateLimited' in result && result.rateLimited),
+    slugs: results.map((result) => result.slug).filter((slug): slug is string => Boolean(slug)),
+  }
+}
+
+export async function getCandidatePipelineStats() {
+  const client = admin()
+  const statuses: SkillCandidateStatus[] = [
+    'discovered', 'fast_track', 'review_required', 'published', 'duplicate',
+    'rejected', 'validation_error', 'publication_error',
+  ]
+  const entries = await Promise.all(statuses.map(async (status) => {
+    const { count, error } = await client.from('skill_candidates').select('id', { count: 'exact', head: true }).eq('status', status)
+    if (error) throw new Error(error.message)
+    return [status, count || 0] as const
+  }))
+  return Object.fromEntries(entries) as Record<SkillCandidateStatus, number>
+}

--- a/lib/indexer/fast-track.ts
+++ b/lib/indexer/fast-track.ts
@@ -1,0 +1,95 @@
+// Explicit extension keeps the standalone Node regression test executable.
+// @ts-expect-error TS5097 is expected; the application build does not emit TypeScript.
+import { analyzeCode } from '../security/static-analysis.ts'
+
+const EXECUTABLE_EXTENSIONS = new Set([
+  '.sh', '.bash', '.zsh', '.ps1', '.bat', '.cmd', '.js', '.mjs', '.cjs',
+  '.ts', '.tsx', '.py', '.rb', '.go', '.rs', '.java', '.c', '.cpp', '.exe',
+])
+
+const DOCUMENT_RISKS: Array<{ pattern: RegExp; reason: string; level: 'medium' | 'high' | 'critical' }> = [
+  { pattern: /(?:curl|wget)[^\n|]{0,300}\|\s*(?:sh|bash|zsh|powershell|pwsh)/i, reason: 'Remote download is piped directly into a shell', level: 'critical' },
+  { pattern: /\brm\s+-rf\b|\bRemove-Item\b[^\n]{0,120}\b-Recurse\b/i, reason: 'Destructive recursive deletion instruction detected', level: 'critical' },
+  { pattern: /(?:seed phrase|private key|wallet key|browser cookies?|\.ssh\/|\.aws\/credentials)/i, reason: 'Sensitive credential or browser data access is requested', level: 'high' },
+  { pattern: /(?:read|collect|upload|send|exfiltrat)[^\n]{0,120}(?:api[_ -]?key|token|secret|password|\.env)/i, reason: 'Credential collection or transmission instruction detected', level: 'high' },
+  { pattern: /\b(?:sudo|runas|administrator privileges?|root privileges?)\b/i, reason: 'Elevated privilege instruction detected', level: 'high' },
+  { pattern: /\b(?:curl|wget|webhook|axios\.|requests\.(?:get|post)|fetch\s*\()\b/i, reason: 'Network execution requires deeper review', level: 'medium' },
+  { pattern: /\b(?:subprocess|child_process|os\.system|exec\s*\(|eval\s*\()\b/i, reason: 'Command execution requires deeper review', level: 'high' },
+]
+
+const RISK_ORDER = { low: 0, medium: 1, high: 2, critical: 3 } as const
+
+function fileExtension(path: string) {
+  const file = path.slice(path.lastIndexOf('/') + 1)
+  const dot = file.lastIndexOf('.')
+  return dot >= 0 ? file.slice(dot).toLowerCase() : ''
+}
+
+export interface FastTrackInput {
+  stars: number
+  licenseStatus: 'unknown' | 'missing' | 'restricted' | 'detected'
+  updatedAt: string | null | undefined
+  document: string
+  files: Array<{ path: string; content: string }>
+  packageTruncated?: boolean
+  hasUnreviewedFiles?: boolean
+  now?: Date
+}
+
+export interface FastTrackDecision {
+  eligible: boolean
+  requiresAiReview: boolean
+  riskLevel: 'low' | 'medium' | 'high' | 'critical'
+  reasons: string[]
+  hasExecutableFiles: boolean
+  ageDays: number | null
+}
+
+export function evaluateFastTrackCandidate(input: FastTrackInput): FastTrackDecision {
+  const reasons: string[] = []
+  const now = input.now || new Date()
+  const updatedTime = Date.parse(input.updatedAt || '')
+  const ageDays = Number.isFinite(updatedTime)
+    ? Math.max(0, Math.floor((now.getTime() - updatedTime) / 86_400_000))
+    : null
+  const hasExecutableFiles = input.files.some((file) => EXECUTABLE_EXTENSIONS.has(fileExtension(file.path)))
+  const staticAnalysis = analyzeCode(input.files)
+  let riskLevel: FastTrackDecision['riskLevel'] = staticAnalysis.riskLevel
+
+  if (input.stars < 100) reasons.push('Fewer than 100 GitHub stars')
+  if (input.licenseStatus !== 'detected') reasons.push(`License status is ${input.licenseStatus}`)
+  if (ageDays === null || ageDays > 365) reasons.push('Repository has not been updated within 12 months')
+  if (hasExecutableFiles) reasons.push('Executable or script files require deeper review')
+  if (input.packageTruncated) reasons.push('Package exceeds deterministic fast-track scan bounds')
+  if (input.hasUnreviewedFiles) reasons.push('Package contains file types outside the deterministic scanner')
+  if (!staticAnalysis.passed) reasons.push(...staticAnalysis.issues.slice(0, 4))
+
+  const searchableText = [input.document, ...input.files.map((file) => file.content)].join('\n')
+  for (const finding of DOCUMENT_RISKS) {
+    if (!finding.pattern.test(searchableText)) continue
+    reasons.push(finding.reason)
+    if (RISK_ORDER[finding.level] > RISK_ORDER[riskLevel]) riskLevel = finding.level
+  }
+
+  const uniqueReasons = Array.from(new Set(reasons))
+  const eligible =
+    input.stars >= 100 &&
+    input.licenseStatus === 'detected' &&
+    ageDays !== null &&
+    ageDays <= 365 &&
+    !hasExecutableFiles &&
+    !input.packageTruncated &&
+    !input.hasUnreviewedFiles &&
+    staticAnalysis.passed &&
+    riskLevel === 'low' &&
+    uniqueReasons.length === 0
+
+  return {
+    eligible,
+    requiresAiReview: !eligible,
+    riskLevel,
+    reasons: uniqueReasons,
+    hasExecutableFiles,
+    ageDays,
+  }
+}

--- a/lib/indexer/github-search.ts
+++ b/lib/indexer/github-search.ts
@@ -43,6 +43,8 @@ export interface CandidateDiscovery {
 }
 
 export interface CandidateRepo {
+  /** Stable GitHub repository id; preferred over owner/name for deduplication. */
+  githubId?: number
   owner: string
   repo: string
   fullName: string
@@ -51,6 +53,7 @@ export interface CandidateRepo {
   language: string | null
   topics?: string[]
   updatedAt: string
+  pushedAt?: string | null
   htmlUrl: string
   /** Exact GitHub tree/blob URL when discovery points to one SKILL.md package. */
   skillSourceUrl?: string

--- a/lib/indexer/hot-skill-discovery.ts
+++ b/lib/indexer/hot-skill-discovery.ts
@@ -9,6 +9,7 @@ interface HotSkillQuery {
 }
 
 interface GitHubRepoItem {
+  id: number
   name: string
   full_name: string
   description: string | null
@@ -45,11 +46,22 @@ export interface HotSkillDiscoveryResult {
   minStars: number
   lookbackDays: number
   since: string
+  rateLimited: boolean
+  retryAfterMs: number | null
 }
 
 const GITHUB_API_BASE = 'https://api.github.com'
 const GITHUB_SEARCH_TIMEOUT_MS = 10_000
 const GITHUB_SEARCH_RETRY_DELAYS_MS = [750, 1_750]
+const AUTHENTICATED_SEARCH_INTERVAL_MS = 2_100
+const UNAUTHENTICATED_SEARCH_INTERVAL_MS = 6_100
+
+class GitHubSearchRateLimitError extends Error {
+  constructor(message: string, public retryAfterMs: number | null) {
+    super(message)
+    this.name = 'GitHubSearchRateLimitError'
+  }
+}
 
 const HOT_SKILL_QUERIES: HotSkillQuery[] = [
   { q: '"agent skill"', sort: 'updated' },
@@ -96,6 +108,12 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function searchIntervalMs() {
+  return process.env.GITHUB_TOKEN
+    ? AUTHENTICATED_SEARCH_INTERVAL_MS
+    : UNAUTHENTICATED_SEARCH_INTERVAL_MS
+}
+
 function rotatedWindow<T>(items: readonly T[], count: number, offset: number) {
   if (!items.length || count <= 0) return []
 
@@ -120,6 +138,7 @@ function scoreHotRepo(repo: GitHubRepoItem) {
 
 function toCandidate(repo: GitHubRepoItem): CandidateRepo {
   return {
+    githubId: repo.id,
     owner: repo.owner.login,
     repo: repo.name,
     fullName: repo.full_name,
@@ -128,6 +147,7 @@ function toCandidate(repo: GitHubRepoItem): CandidateRepo {
     language: repo.language ?? null,
     topics: repo.topics || [],
     updatedAt: repo.updated_at,
+    pushedAt: repo.pushed_at,
     htmlUrl: repo.html_url,
   }
 }
@@ -153,7 +173,7 @@ async function searchHotQuery(query: HotSkillQuery, options: {
       })
     } catch (error) {
       if (attempt === GITHUB_SEARCH_RETRY_DELAYS_MS.length) throw error
-      await sleep(GITHUB_SEARCH_RETRY_DELAYS_MS[attempt])
+      await sleep(Math.max(GITHUB_SEARCH_RETRY_DELAYS_MS[attempt], searchIntervalMs()))
       continue
     }
 
@@ -162,9 +182,24 @@ async function searchHotQuery(query: HotSkillQuery, options: {
       return (data.items || []).filter((repo) => !repo.archived && !repo.fork)
     }
 
-    const retryable = [429, 502, 503, 504].includes(response.status)
+    const rateLimited = response.status === 403 || response.status === 429
     const body = await response.text().catch(() => '')
     const detail = body.replace(/\s+/g, ' ').slice(0, 180)
+    if (rateLimited) {
+      const retryAfterSeconds = Number(response.headers.get('retry-after'))
+      const resetSeconds = Number(response.headers.get('x-ratelimit-reset'))
+      const retryAfterMs = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+        ? Math.min(retryAfterSeconds * 1_000, 3_600_000)
+        : Number.isFinite(resetSeconds) && resetSeconds > 0
+          ? Math.min(Math.max(resetSeconds * 1_000 - Date.now(), 60_000), 3_600_000)
+          : 60_000
+      throw new GitHubSearchRateLimitError(
+        `GitHub search rate limit reached: ${response.status} ${detail}`,
+        retryAfterMs
+      )
+    }
+
+    const retryable = [502, 503, 504].includes(response.status)
     if (!retryable || attempt === GITHUB_SEARCH_RETRY_DELAYS_MS.length) {
       throw new Error(`GitHub hot search failed [${q}]: ${response.status} ${detail}`)
     }
@@ -174,7 +209,7 @@ async function searchHotQuery(query: HotSkillQuery, options: {
     const retryDelay = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
       ? Math.min(retryAfterSeconds * 1_000, 10_000)
       : fallbackDelay
-    await sleep(retryDelay)
+    await sleep(Math.max(retryDelay, searchIntervalMs()))
   }
 
   return []
@@ -183,16 +218,19 @@ async function searchHotQuery(query: HotSkillQuery, options: {
 export async function searchHotSkillRepos(
   options: HotSkillDiscoveryOptions = {}
 ): Promise<HotSkillDiscoveryResult> {
-  const limit = Math.min(Math.max(options.limit || 24, 1), 80)
+  const limit = Math.min(Math.max(options.limit || 24, 1), 2_000)
   const minStars = Math.max(Math.floor(options.minStars || 10), 10)
   const lookbackDays = Math.min(Math.max(Math.floor(options.lookbackDays || 21), 1), 90)
-  const perPage = Math.min(Math.max(options.perPage || 12, 5), 30)
-  const maxQueries = Math.min(Math.max(options.maxQueries || 12, 1), HOT_SKILL_QUERIES.length)
+  const perPage = Math.min(Math.max(options.perPage || 12, 5), 100)
+  const maxQueries = Math.min(Math.max(options.maxQueries || 12, 1), Math.min(HOT_SKILL_QUERIES.length, 22))
   const queryOffset = Math.max(0, Math.floor(options.queryOffset ?? 0))
   const since = isoDateDaysAgo(lookbackDays)
   const seen = new Set<string>()
   const repos: GitHubRepoItem[] = []
   let searchedQueries = 0
+  let rateLimited = false
+  let retryAfterMs: number | null = null
+  const requestIntervalMs = searchIntervalMs()
 
   for (const query of rotatedWindow(HOT_SKILL_QUERIES, maxQueries, queryOffset)) {
     if (repos.length >= limit * 3) break
@@ -201,7 +239,7 @@ export async function searchHotSkillRepos(
     // Repeating the first GitHub result page eventually only returns skills we
     // already know. Rotate through a small, recent result window so hourly
     // runs keep discovering fresh candidates without increasing API traffic.
-    const page = 1 + ((queryOffset + searchedQueries - 1) % 3)
+    const page = 1 + ((queryOffset + searchedQueries - 1) % 10)
 
     try {
       const items = await searchHotQuery(query, { minStars, since, perPage, page })
@@ -221,10 +259,16 @@ export async function searchHotSkillRepos(
         repos.push(repo)
       }
     } catch (error) {
+      if (error instanceof GitHubSearchRateLimitError) {
+        rateLimited = true
+        retryAfterMs = error.retryAfterMs
+        console.warn('[hot-skill-discovery] stopping this window after rate limit:', error.message)
+        break
+      }
       console.warn('[hot-skill-discovery] query skipped:', error)
     }
 
-    if (searchedQueries < maxQueries) await sleep(process.env.GITHUB_TOKEN ? 500 : 1200)
+    if (searchedQueries < maxQueries) await sleep(requestIntervalMs)
   }
 
   const candidates = repos
@@ -239,5 +283,7 @@ export async function searchHotSkillRepos(
     minStars,
     lookbackDays,
     since,
+    rateLimited,
+    retryAfterMs,
   }
 }

--- a/lib/indexer/repository-skill-sync.ts
+++ b/lib/indexer/repository-skill-sync.ts
@@ -7,7 +7,7 @@ import { fetchRepositoryCommitSha, validateGitHubRepo } from '@/lib/github/api'
 import {
   discoverGitHubSkills,
   fetchDelegatedGitHubSkill,
-  fetchSkillPackageFiles,
+  fetchSkillPackageSnapshot,
   parseGitHubSkillReference,
   type DiscoveredGitHubSkill,
 } from '@/lib/github/skill-source'
@@ -17,6 +17,7 @@ import { estimateSubmissionQuality } from '@/lib/skills/submission-quality'
 import { createPublicClient } from '@/lib/supabase/public'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { getLicenseEvidence } from '@/lib/creator-ownership'
+import { evaluateFastTrackCandidate } from '@/lib/indexer/fast-track'
 
 const DEFAULT_MAX_SKILLS_PER_REPOSITORY = 8
 const MAX_SKILLS_PER_REPOSITORY = 20
@@ -53,6 +54,8 @@ export interface RepositorySkillSyncOptions {
   skillNames?: string[]
   maxSkills?: number
   refreshExisting?: boolean
+  /** Fast-track is deterministic and is re-checked immediately before publication. */
+  reviewMode?: 'ai' | 'fast-track'
 }
 
 function slugPart(value: string) {
@@ -142,7 +145,7 @@ function payloadForExisting(
     github_stars: repository.stars,
     github_forks: repository.forks,
     github_language: repository.language || existing.github_language || null,
-    github_last_pushed_at: repository.updatedAt,
+    github_last_pushed_at: repository.pushedAt || repository.updatedAt,
     long_description: skill.document.slice(0, 12_000),
     version: normalizeVersion(skill.frontmatter.version || existing.version),
     license: license.license,
@@ -165,14 +168,18 @@ async function payloadForNew(
   skill: DiscoveredGitHubSkill,
   repository: Awaited<ReturnType<typeof validateGitHubRepo>>,
   discoverySource: string,
-  discoveryMetadata?: Record<string, unknown>
+  discoveryMetadata?: Record<string, unknown>,
+  reviewMode: 'ai' | 'fast-track' = 'ai',
+  slugOverride?: string
 ) {
   const delegatedSkill = await fetchDelegatedGitHubSkill(skill)
-  const packageGroups = await Promise.all([
-    fetchSkillPackageFiles(skill),
-    delegatedSkill ? fetchSkillPackageFiles(delegatedSkill) : Promise.resolve([]),
+  const packageSnapshots = await Promise.all([
+    fetchSkillPackageSnapshot(skill),
+    delegatedSkill ? fetchSkillPackageSnapshot(delegatedSkill) : Promise.resolve(null),
   ])
-  const codeFiles = packageGroups.flat()
+  const codeFiles = packageSnapshots.flatMap((snapshot) => snapshot?.files || [])
+  const packageTruncated = packageSnapshots.some((snapshot) => Boolean(snapshot?.truncated))
+  const hasUnreviewedFiles = packageSnapshots.some((snapshot) => Boolean(snapshot?.hasUnreviewedFiles))
   const reviewDocument = delegatedSkill
     ? [
         skill.document,
@@ -188,44 +195,77 @@ async function payloadForNew(
       reason: staticAnalysis.issues.slice(0, 2).join('; ') || 'Static security analysis rejected the skill.',
     }
   }
+  const license = getLicenseEvidence(skill.frontmatter.license, repository.license)
+  let reviewScores: { security: number; quality: number; usefulness: number; compliance: number }
+  let reviewTotal: number
+  let reviewSource: string
+  let reviewIssues: string[]
+  let reviewSuggestions: string[]
 
-  const review = await reviewSkill({
-    repository: skill.sourceUrl,
-    readmeContent: reviewDocument,
-    codeFiles,
-    manifestData: skill.frontmatter,
-    githubStats: {
+  if (reviewMode === 'fast-track') {
+    const decision = evaluateFastTrackCandidate({
       stars: repository.stars,
-      forks: repository.forks,
-      lastUpdated: repository.updatedAt,
-      license: skill.frontmatter.license || repository.license,
-      language: repository.language,
-    },
-  })
-  const policy = evaluateSkillSubmissionPolicy({
-    stars: repository.stars,
-    hasReadme: repository.hasReadme,
-    hasSkillDocument: true,
-    staticAnalysis,
-    review,
-  })
-  if (!policy.approved) {
-    return {
-      payload: null,
-      reason: policy.issues.slice(0, 2).join('; ') || 'Automated review did not approve this skill.',
+      licenseStatus: license.status,
+      updatedAt: repository.pushedAt || repository.updatedAt,
+      document: reviewDocument,
+      files: codeFiles,
+      packageTruncated,
+      hasUnreviewedFiles,
+    })
+    if (!decision.eligible) {
+      return {
+        payload: null,
+        reason: decision.reasons.slice(0, 3).join('; ') || 'Deterministic fast-track safety check failed.',
+      }
     }
+    reviewScores = { security: 9, quality: 8, usefulness: 8, compliance: 9 }
+    reviewTotal = 34
+    reviewSource = 'deterministic-fast-track-v1'
+    reviewIssues = []
+    reviewSuggestions = ['Creator ownership and identity remain unverified until the maintainer claims this skill.']
+  } else {
+    const review = await reviewSkill({
+      repository: skill.sourceUrl,
+      readmeContent: reviewDocument,
+      codeFiles,
+      manifestData: skill.frontmatter,
+      githubStats: {
+        stars: repository.stars,
+        forks: repository.forks,
+        lastUpdated: repository.pushedAt || repository.updatedAt,
+        license: skill.frontmatter.license || repository.license,
+        language: repository.language,
+      },
+    })
+    const policy = evaluateSkillSubmissionPolicy({
+      stars: repository.stars,
+      hasReadme: repository.hasReadme,
+      hasSkillDocument: true,
+      staticAnalysis,
+      review,
+    })
+    if (!policy.approved) {
+      return {
+        payload: null,
+        reason: policy.issues.slice(0, 2).join('; ') || 'Automated review did not approve this skill.',
+      }
+    }
+    reviewScores = review.scores
+    reviewTotal = review.totalScore
+    reviewSource = 'recursive-skill-source-sync'
+    reviewIssues = policy.issues
+    reviewSuggestions = policy.suggestions
   }
 
-  const slug = buildIndexedSkillSlug(repository.owner, skill.frontmatter.name)
+  const slug = slugOverride || buildIndexedSkillSlug(repository.owner, skill.frontmatter.name)
   const tags = normalizeTags(skill, delegatedSkill ? ['skill-alias', 'composed-skill'] : [])
   const quality = estimateSubmissionQuality({
     githubStars: repository.stars,
     githubRepo: repository.fullName,
-    githubUpdatedAt: repository.updatedAt,
-    reviewTotal: review.totalScore,
+    githubUpdatedAt: repository.pushedAt || repository.updatedAt,
+    reviewTotal,
     tags,
   })
-  const license = getLicenseEvidence(skill.frontmatter.license, repository.license)
 
   return {
     reason: null,
@@ -242,7 +282,7 @@ async function payloadForNew(
       github_stars: repository.stars,
       github_forks: repository.forks,
       github_language: repository.language || null,
-      github_last_pushed_at: repository.updatedAt,
+      github_last_pushed_at: repository.pushedAt || repository.updatedAt,
       category: inferIndexedSkillCategory(skill),
       tags,
       frameworks: skill.frontmatter.frameworks,
@@ -256,9 +296,9 @@ async function payloadForNew(
       submission_source: discoverySource,
       submitted_by_agent: 'open-agent-skill-source-sync',
       ai_review_score: {
-        ...review.scores,
-        total: review.totalScore,
-        source: 'recursive-skill-source-sync',
+        ...reviewScores,
+        total: reviewTotal,
+        source: reviewSource,
         source_url: skill.sourceUrl,
         source_ref: skill.ref,
         skill_path: skill.path,
@@ -272,12 +312,37 @@ async function payloadForNew(
           : {}),
       },
       ai_review_approved: true,
-      ai_review_issues: policy.issues,
-      ai_review_suggestions: policy.suggestions,
+      ai_review_issues: reviewIssues,
+      ai_review_suggestions: reviewSuggestions,
       quality_score: quality.score,
       quality_signals: quality.signals,
     },
   }
+}
+
+async function resolveIndexedSkillSlug(
+  client: ReturnType<typeof createPublicClient>,
+  baseSlug: string,
+  sourceUrl: string
+) {
+  const lookup = async (slug: string) => {
+    const { data, error } = await client
+      .from('skills')
+      .select('repository')
+      .eq('slug', slug)
+      .maybeSingle()
+    if (error) throw new Error(`Skill slug collision lookup failed: ${error.message}`)
+    return data as { repository?: string | null } | null
+  }
+
+  const current = await lookup(baseSlug)
+  if (!current || normalizeSourceUrl(current.repository) === normalizeSourceUrl(sourceUrl)) return baseSlug
+
+  const suffix = contentHash(sourceUrl).slice(0, 8)
+  const candidate = `${baseSlug.slice(0, 171)}-${suffix}`
+  const suffixed = await lookup(candidate)
+  if (!suffixed || normalizeSourceUrl(suffixed.repository) === normalizeSourceUrl(sourceUrl)) return candidate
+  return `${baseSlug.slice(0, 167)}-${contentHash(sourceUrl).slice(0, 12)}`
 }
 
 export async function syncRepositorySkills(
@@ -333,9 +398,30 @@ export async function syncRepositorySkills(
     }
 
     try {
+      if (existingSkill && options.reviewMode === 'fast-track') {
+        entries.push({
+          slug: fallbackSlug,
+          name: skill.frontmatter.name,
+          path: skill.path,
+          sourceUrl: skill.sourceUrl,
+          status: 'rejected',
+          reason: 'Fast-track does not update an existing listing; the version-sync pipeline owns existing skills.',
+        })
+        continue
+      }
+      const resolvedSlug = existingSkill
+        ? existingSkill.slug
+        : await resolveIndexedSkillSlug(supabase, fallbackSlug, skill.sourceUrl)
       const result = existingSkill
         ? { payload: payloadForExisting(existingSkill, skill, repository, discoverySource, options.discoveryMetadata), reason: null }
-        : await payloadForNew(skill, repository, discoverySource, options.discoveryMetadata)
+        : await payloadForNew(
+            skill,
+            repository,
+            discoverySource,
+            options.discoveryMetadata,
+            options.reviewMode || 'ai',
+            resolvedSlug
+          )
 
       if (!result.payload) {
         entries.push({

--- a/lib/schema/skill-schema.ts
+++ b/lib/schema/skill-schema.ts
@@ -83,6 +83,7 @@ export type SkillSubmission = z.infer<typeof SkillSubmissionSchema>
 
 // GitHub repo validation result
 export const GitHubRepoSchema = z.object({
+  id: z.number().int().positive().optional(),
   owner: z.string(),
   repo: z.string(),
   fullName: z.string(),
@@ -92,6 +93,7 @@ export const GitHubRepoSchema = z.object({
   language: z.string().optional(),
   license: z.string().optional(),
   updatedAt: z.string(),
+  pushedAt: z.string().nullable().optional(),
   defaultBranch: z.string(),
   hasReadme: z.boolean(),
   hasSkillJson: z.boolean(),

--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
     "test:x-automation": "node --experimental-strip-types scripts/test-x-automation-regressions.ts",
     "test:github-owner": "node --experimental-strip-types scripts/test-github-owner.ts",
     "test:performance": "node --experimental-strip-types scripts/test-performance-regressions.ts",
+    "test:candidate-intake": "node --experimental-strip-types scripts/test-candidate-intake.ts",
     "test:cli": "node packages/cli/openagentskill.mjs --help",
     "test:sdk": "node scripts/test-sdk.mjs",
     "test:links": "node scripts/check-repository-links.mjs",
     "test:links:external": "node scripts/check-repository-links.mjs --external",
-    "test": "pnpm run test:submission && pnpm run test:submission-discovery && pnpm run test:skill-issue-ingest && pnpm run test:supabase-circuit && pnpm run test:security && pnpm run test:x-automation && pnpm run test:github-owner && pnpm run test:performance && pnpm run test:cli && pnpm run test:sdk",
+    "test": "pnpm run test:submission && pnpm run test:submission-discovery && pnpm run test:skill-issue-ingest && pnpm run test:supabase-circuit && pnpm run test:security && pnpm run test:x-automation && pnpm run test:github-owner && pnpm run test:performance && pnpm run test:candidate-intake && pnpm run test:cli && pnpm run test:sdk",
     "typecheck": "next typegen && tsc --noEmit",
     "lint": "eslint ."
   },

--- a/scripts/test-candidate-intake.ts
+++ b/scripts/test-candidate-intake.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+// Node's type-stripping runner requires explicit TypeScript extensions.
+// @ts-expect-error TS5097 is expected for this standalone test entrypoint.
+import { evaluateFastTrackCandidate } from '../lib/indexer/fast-track.ts'
+// @ts-expect-error TS5097 is expected for this standalone test entrypoint.
+import { buildCandidateSourceKey, canonicalGitHubSourceUrl } from '../lib/indexer/candidate-identity.ts'
+
+const now = new Date('2026-09-01T00:00:00.000Z')
+const safe = {
+  stars: 100,
+  licenseStatus: 'detected' as const,
+  updatedAt: '2026-08-15T00:00:00.000Z',
+  document: '# Safe skill\nUse this documentation-only workflow.',
+  files: [{ path: 'SKILL.md', content: '# Safe skill' }],
+  now,
+}
+
+assert.equal(evaluateFastTrackCandidate(safe).eligible, true)
+assert.equal(evaluateFastTrackCandidate({ ...safe, stars: 99 }).eligible, false)
+assert.equal(evaluateFastTrackCandidate({
+  ...safe,
+  files: [...safe.files, { path: 'run.py', content: 'print("hello")' }],
+}).eligible, false)
+assert.equal(evaluateFastTrackCandidate({
+  ...safe,
+  document: 'Install with curl https://example.test/install.sh | bash',
+}).riskLevel, 'critical')
+assert.equal(evaluateFastTrackCandidate({ ...safe, licenseStatus: 'missing' }).eligible, false)
+assert.equal(evaluateFastTrackCandidate({ ...safe, updatedAt: '2024-01-01T00:00:00.000Z' }).eligible, false)
+assert.equal(evaluateFastTrackCandidate({ ...safe, packageTruncated: true }).eligible, false)
+assert.equal(evaluateFastTrackCandidate({ ...safe, hasUnreviewedFiles: true }).eligible, false)
+
+assert.equal(
+  buildCandidateSourceKey(12345, 'OldOwner/OldName', '/skills\\demo/SKILL.md/'),
+  buildCandidateSourceKey(12345, 'NewOwner/NewName', 'skills/demo/SKILL.md')
+)
+assert.notEqual(
+  buildCandidateSourceKey(12345, 'owner/repo', 'skills/one/SKILL.md'),
+  buildCandidateSourceKey(12345, 'owner/repo', 'skills/two/SKILL.md')
+)
+assert.equal(
+  canonicalGitHubSourceUrl('owner/repo', 'main', 'skills/demo/SKILL.md'),
+  'https://github.com/owner/repo/blob/main/skills/demo/SKILL.md'
+)
+
+const migration = readFileSync(
+  new URL('../supabase/migrations/20260901160000_skill_candidate_intake_pipeline.sql', import.meta.url),
+  'utf8'
+)
+for (const requirement of [
+  'enable row level security',
+  'for update skip locked',
+  'github_repository_id, source_path',
+  'lower(canonical_source_url)',
+  'source_content_hash',
+  'skill_candidates_active_content_unique',
+  'revoke all on table public.skill_candidates from public, anon, authenticated',
+]) {
+  assert.ok(migration.toLowerCase().includes(requirement), `migration must contain: ${requirement}`)
+}
+
+const recoveryMigration = readFileSync(
+  new URL('../supabase/migrations/20260901163000_skill_candidate_pipeline_recovery.sql', import.meta.url),
+  'utf8'
+)
+assert.ok(recoveryMigration.includes("'publishing'"), 'interrupted publication rows must be reclaimable')
+
+console.log('Candidate intake regression tests passed.')

--- a/supabase/migrations/20260901160000_skill_candidate_intake_pipeline.sql
+++ b/supabase/migrations/20260901160000_skill_candidate_intake_pipeline.sql
@@ -1,0 +1,154 @@
+-- Durable, server-only candidate intake for high-volume GitHub discovery.
+-- Candidates are deliberately separated from public.skills so discovery can
+-- scale without creating public/SEO pages before validation.
+
+create table if not exists public.skill_candidates (
+  id uuid primary key default gen_random_uuid(),
+  source_key text not null unique,
+  github_repository_id bigint,
+  github_full_name text not null,
+  github_owner text not null,
+  github_repo text not null,
+  source_ref text,
+  source_path text not null default '',
+  canonical_source_url text not null,
+  source_content_hash text,
+  skill_name text,
+  skill_description text,
+  github_stars integer not null default 0 check (github_stars >= 0),
+  github_updated_at timestamptz,
+  license text,
+  license_status text not null default 'unknown'
+    check (license_status in ('unknown', 'missing', 'restricted', 'detected')),
+  status text not null default 'discovered'
+    check (status in (
+      'discovered', 'validating', 'expanded', 'fast_track',
+      'review_required', 'publishing', 'published', 'rejected',
+      'duplicate', 'validation_error', 'publication_error'
+    )),
+  risk_level text not null default 'unknown'
+    check (risk_level in ('unknown', 'low', 'medium', 'high', 'critical')),
+  risk_reasons text[] not null default '{}',
+  has_executable_files boolean not null default false,
+  fast_track_eligible boolean not null default false,
+  requires_ai_review boolean not null default true,
+  duplicate_of uuid references public.skill_candidates(id) on delete set null,
+  published_skill_slug text references public.skills(slug) on delete set null,
+  discovery_source text not null default 'github-search',
+  discovery_payload jsonb not null default '{}'::jsonb,
+  validation_payload jsonb not null default '{}'::jsonb,
+  attempt_count integer not null default 0 check (attempt_count >= 0),
+  next_attempt_at timestamptz not null default now(),
+  lease_owner text,
+  lease_expires_at timestamptz,
+  last_error text,
+  discovered_at timestamptz not null default now(),
+  validated_at timestamptz,
+  published_at timestamptz,
+  last_seen_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.skill_candidates is
+  'Server-only GitHub discovery queue. Rows are not public listings and must never enter SEO surfaces before publication.';
+
+create unique index if not exists skill_candidates_repo_path_unique
+  on public.skill_candidates (github_repository_id, source_path)
+  where github_repository_id is not null;
+
+create unique index if not exists skill_candidates_canonical_source_unique
+  on public.skill_candidates (lower(canonical_source_url));
+
+create index if not exists skill_candidates_claim_idx
+  on public.skill_candidates (status, next_attempt_at, github_stars desc, discovered_at)
+  where status in (
+    'discovered', 'fast_track', 'review_required',
+    'validation_error', 'publication_error'
+  );
+
+create index if not exists skill_candidates_content_hash_idx
+  on public.skill_candidates (source_content_hash)
+  where source_content_hash is not null;
+
+-- Prevent concurrent workers from promoting the same exact package content.
+-- Rejected/duplicate rows are deliberately excluded so they remain auditable.
+create unique index if not exists skill_candidates_active_content_unique
+  on public.skill_candidates (source_content_hash)
+  where source_content_hash is not null
+    and status in ('fast_track', 'review_required', 'publishing', 'published', 'publication_error');
+
+create index if not exists skill_candidates_lease_idx
+  on public.skill_candidates (lease_expires_at)
+  where lease_expires_at is not null;
+
+alter table public.skill_candidates enable row level security;
+
+-- This queue is internal. It is intentionally invisible to browser clients.
+revoke all on table public.skill_candidates from public, anon, authenticated;
+grant select, insert, update, delete on table public.skill_candidates to service_role;
+
+create or replace function public.claim_skill_candidates(
+  p_statuses text[],
+  p_limit integer,
+  p_worker_id text,
+  p_lease_seconds integer default 240
+)
+returns setof public.skill_candidates
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if p_worker_id is null or length(trim(p_worker_id)) < 8 then
+    raise exception 'A stable worker id is required';
+  end if;
+
+  return query
+  with available as (
+    select candidate.id
+    from public.skill_candidates candidate
+    where candidate.status = any(p_statuses)
+      and candidate.next_attempt_at <= now()
+      and (candidate.lease_expires_at is null or candidate.lease_expires_at <= now())
+    order by candidate.github_stars desc, candidate.discovered_at asc
+    for update skip locked
+    limit least(greatest(coalesce(p_limit, 1), 1), 250)
+  )
+  update public.skill_candidates candidate
+  set
+    lease_owner = trim(p_worker_id),
+    lease_expires_at = now() + make_interval(secs => least(greatest(coalesce(p_lease_seconds, 240), 60), 900)),
+    attempt_count = candidate.attempt_count + 1,
+    updated_at = now()
+  from available
+  where candidate.id = available.id
+  returning candidate.*;
+end;
+$$;
+
+revoke all on function public.claim_skill_candidates(text[], integer, text, integer)
+  from public, anon, authenticated;
+grant execute on function public.claim_skill_candidates(text[], integer, text, integer)
+  to service_role;
+
+create or replace function public.touch_skill_candidates_updated_at()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+revoke all on function public.touch_skill_candidates_updated_at()
+  from public, anon, authenticated;
+grant execute on function public.touch_skill_candidates_updated_at()
+  to service_role;
+
+drop trigger if exists touch_skill_candidates_updated_at on public.skill_candidates;
+create trigger touch_skill_candidates_updated_at
+before update on public.skill_candidates
+for each row execute function public.touch_skill_candidates_updated_at();

--- a/supabase/migrations/20260901163000_skill_candidate_pipeline_recovery.sql
+++ b/supabase/migrations/20260901163000_skill_candidate_pipeline_recovery.sql
@@ -1,0 +1,10 @@
+-- Allow a later worker to recover a publication interrupted after the row was
+-- marked publishing. The lease predicate still prevents concurrent handling.
+drop index if exists public.skill_candidates_claim_idx;
+
+create index skill_candidates_claim_idx
+  on public.skill_candidates (status, next_attempt_at, github_stars desc, discovered_at)
+  where status in (
+    'discovered', 'fast_track', 'review_required', 'publishing',
+    'validation_error', 'publication_error'
+  );

--- a/vercel.json
+++ b/vercel.json
@@ -17,12 +17,24 @@
       "schedule": "5 * * * *"
     },
     {
+      "path": "/api/cron/skill-candidates-discover",
+      "schedule": "10 * * * *"
+    },
+    {
+      "path": "/api/cron/skill-candidates-validate",
+      "schedule": "20,50 * * * *"
+    },
+    {
       "path": "/api/cron/skill-radar",
       "schedule": "35 * * * *"
     },
     {
+      "path": "/api/cron/skill-candidates-publish",
+      "schedule": "40 * * * *"
+    },
+    {
       "path": "/api/cron/skill-source-sync",
-      "schedule": "50 */6 * * *"
+      "schedule": "0 */6 * * *"
     },
     {
       "path": "/api/cron/official-frontend-skills",


### PR DESCRIPTION
## Summary
- add a private Indexed Candidates queue with leased claims, RLS, and multi-layer deduplication
- add rate-safe GitHub discovery, light validation, 100-star deterministic fast track, and bounded AI publication
- add cron pacing, time budgets, interruption recovery, monitoring metadata, docs, and regression tests

## Safety
- GitHub search is capped at 22 requests per window and paced at 2.1s authenticated / 6.1s unauthenticated
- validation and publication skip without GITHUB_TOKEN and stop on 403/429
- fast-track requires detected unrestricted license, recent push, fully scanned documentation-only package, and low risk at validation and publication
- candidates are service-role-only and never enter public SEO surfaces before approval

## Verification
- pnpm test
- pnpm run typecheck
- pnpm run build
- Supabase migrations applied; RLS, grants, indexes, function ACLs, and advisors verified