### PR TITLE
fix: retry transient candidate reviews

### DIFF
--- a/lib/indexer/candidate-intake.ts
+++ b/lib/indexer/candidate-intake.ts
@@ -420,8 +420,18 @@ async function publishCandidate(candidate: SkillCandidateRow) {
     })
     const successful = result.entries.find((entry) => entry.status === 'created' || entry.status === 'updated')
     if (!successful) {
-      const reason = result.entries.find((entry) => entry.reason)?.reason || 'Candidate did not pass publication review'
-      await updateCandidate(candidate.id, { status: 'rejected', last_error: reason.slice(0, 1000) })
+      const failure = result.entries.find((entry) => entry.reason)
+      const reason = failure?.reason || 'Candidate did not pass publication review'
+      const retryable = Boolean(failure?.retryable)
+      const shouldRetry = retryable && candidate.attempt_count < 4
+      await updateCandidate(candidate.id, {
+        status: shouldRetry ? 'publication_error' : 'rejected',
+        next_attempt_at: shouldRetry
+          ? new Date(Date.now() + Math.min(360, 15 * 2 ** Math.min(candidate.attempt_count, 4)) * 60_000).toISOString()
+          : new Date().toISOString(),
+        last_error: reason.slice(0, 1000),
+      })
+      if (shouldRetry) return { status: 'retry' as const, slug: null }
       return { status: 'rejected' as const, slug: null }
     }
 
@@ -480,6 +490,7 @@ export async function runCandidatePublicationBatch(options: { fastTrackLimit?: n
     timeBudgetReached,
     published: results.filter((result) => result.status === 'published').length,
     rejected: results.filter((result) => result.status === 'rejected').length,
+    retries: results.filter((result) => result.status === 'retry').length,
     errors: results.filter((result) => result.status === 'error').length,
     rateLimited: results.some((result) => 'rateLimited' in result && result.rateLimited),
     slugs: results.map((result) => result.slug).filter((slug): slug is string => Boolean(slug)),

--- a/lib/indexer/repository-skill-sync.ts
+++ b/lib/indexer/repository-skill-sync.ts
@@ -18,6 +18,7 @@ import { createPublicClient } from '@/lib/supabase/public'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { getLicenseEvidence } from '@/lib/creator-ownership'
 import { evaluateFastTrackCandidate } from '@/lib/indexer/fast-track'
+import { shouldRetryAutomatedReview } from '@/lib/indexer/review-retry'
 
 const DEFAULT_MAX_SKILLS_PER_REPOSITORY = 8
 const MAX_SKILLS_PER_REPOSITORY = 20
@@ -32,6 +33,7 @@ export interface RepositorySkillSyncEntry {
   sourceUrl: string
   status: RepositorySkillSyncEntryStatus
   reason?: string
+  retryable?: boolean
 }
 
 export interface RepositorySkillSyncResult {
@@ -193,6 +195,7 @@ async function payloadForNew(
     return {
       payload: null,
       reason: staticAnalysis.issues.slice(0, 2).join('; ') || 'Static security analysis rejected the skill.',
+      retryable: false,
     }
   }
   const license = getLicenseEvidence(skill.frontmatter.license, repository.license)
@@ -216,6 +219,7 @@ async function payloadForNew(
       return {
         payload: null,
         reason: decision.reasons.slice(0, 3).join('; ') || 'Deterministic fast-track safety check failed.',
+        retryable: false,
       }
     }
     reviewScores = { security: 9, quality: 8, usefulness: 8, compliance: 9 }
@@ -248,6 +252,7 @@ async function payloadForNew(
       return {
         payload: null,
         reason: policy.issues.slice(0, 2).join('; ') || 'Automated review did not approve this skill.',
+        retryable: shouldRetryAutomatedReview(review.reviewModel),
       }
     }
     reviewScores = review.scores
@@ -269,6 +274,7 @@ async function payloadForNew(
 
   return {
     reason: null,
+    retryable: false,
     payload: {
       slug,
       name: skill.frontmatter.name,
@@ -431,6 +437,7 @@ export async function syncRepositorySkills(
           sourceUrl: skill.sourceUrl,
           status: 'rejected',
           reason: result.reason || 'Automated review rejected the skill.',
+          retryable: result.retryable,
         })
         continue
       }

--- a/lib/indexer/review-retry.ts
+++ b/lib/indexer/review-retry.ts
@@ -1,0 +1,3 @@
+export function shouldRetryAutomatedReview(reviewModel: string | null | undefined) {
+  return Boolean(reviewModel?.startsWith('heuristic'))
+}

--- a/scripts/test-candidate-intake.ts
+++ b/scripts/test-candidate-intake.ts
@@ -6,6 +6,8 @@ import { readFileSync } from 'node:fs'
 import { evaluateFastTrackCandidate } from '../lib/indexer/fast-track.ts'
 // @ts-expect-error TS5097 is expected for this standalone test entrypoint.
 import { buildCandidateSourceKey, canonicalGitHubSourceUrl } from '../lib/indexer/candidate-identity.ts'
+// @ts-expect-error TS5097 is expected for this standalone test entrypoint.
+import { shouldRetryAutomatedReview } from '../lib/indexer/review-retry.ts'
 
 const now = new Date('2026-09-01T00:00:00.000Z')
 const safe = {
@@ -31,6 +33,8 @@ assert.equal(evaluateFastTrackCandidate({ ...safe, licenseStatus: 'missing' }).e
 assert.equal(evaluateFastTrackCandidate({ ...safe, updatedAt: '2024-01-01T00:00:00.000Z' }).eligible, false)
 assert.equal(evaluateFastTrackCandidate({ ...safe, packageTruncated: true }).eligible, false)
 assert.equal(evaluateFastTrackCandidate({ ...safe, hasUnreviewedFiles: true }).eligible, false)
+assert.equal(shouldRetryAutomatedReview('heuristic-static-v2'), true)
+assert.equal(shouldRetryAutomatedReview('deepseek/deepseek-v4-flash'), false)
 
 assert.equal(
   buildCandidateSourceKey(12345, 'OldOwner/OldName', '/skills\\demo/SKILL.md/'),


### PR DESCRIPTION
## Summary
- classify heuristic review fallbacks as transient provider failures
- retry publication with bounded exponential backoff instead of permanently rejecting candidates
- preserve permanent rejection for deterministic policy and security failures

## Verification
- pnpm run test:candidate-intake
- pnpm run typecheck
- pnpm test
- pnpm run build