### PR TITLE
fix: pace candidate GitHub reads

### DIFF
--- a/lib/blog/generate.ts
+++ b/lib/blog/generate.ts
@@ -283,10 +283,18 @@ export async function getBlogPostBySlug(slug: string) {
 }
 
 export async function getBlogHubData(): Promise<BlogHubData> {
-  const [rows, totalCount] = await Promise.all([
-    fetchApprovedSkillRows(1200),
-    fetchApprovedSkillCount(),
-  ])
+  let rows: BlogSkillRow[] = []
+  let totalCount: number | null = null
+  try {
+    const snapshot = await Promise.all([
+      fetchApprovedSkillRows(1200),
+      fetchApprovedSkillCount(),
+    ])
+    rows = snapshot[0]
+    totalCount = snapshot[1]
+  } catch (error) {
+    console.warn('[blog] using an empty hub snapshot after a transient registry query failure:', error)
+  }
   const previews = rows.map(toSkillPreview)
   const launchWindowHours = 24
   const recentCutoff = Date.now() - launchWindowHours * 60 * 60 * 1000

--- a/lib/github/skill-source.ts
+++ b/lib/github/skill-source.ts
@@ -4,6 +4,7 @@ const GITHUB_API = 'https://api.github.com'
 const MAX_DISCOVERED_SKILLS = 50
 const MAX_PACKAGE_FILES = 30
 const MAX_FILE_BYTES = 120_000
+const GITHUB_READ_DELAY_MS = 100
 
 export interface GitHubSkillReference {
   owner: string
@@ -70,6 +71,17 @@ function githubHeaders() {
     'User-Agent': 'OpenAgentSkill-Submission/2.0',
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
   }
+}
+
+async function mapGitHubReadsSerially<T, R>(items: T[], mapper: (item: T) => Promise<R>) {
+  const results: R[] = []
+  for (let index = 0; index < items.length; index += 1) {
+    results.push(await mapper(items[index]))
+    if (index + 1 < items.length) {
+      await new Promise((resolve) => setTimeout(resolve, GITHUB_READ_DELAY_MS))
+    }
+  }
+  return results
 }
 
 function cleanSegment(value: string) {
@@ -265,7 +277,7 @@ function sourceUrl(owner: string, repo: string, ref: string, path: string) {
 export async function discoverGitHubSkills(
   reference: GitHubSkillReference,
   repository: GitHubRepo
-): Promise<{ skills: DiscoveredGitHubSkill[]; truncated: boolean }> {
+): Promise<{ skills: DiscoveredGitHubSkill[]; truncated: boolean; tree: GitHubTreeItem[] | null }> {
   const ref = reference.ref || repository.defaultBranch
   const requestedPath = normalizePath(reference.path)
   const exactSkillPath = requestedPath && /(^|\/)SKILL\.md$/i.test(requestedPath)
@@ -274,16 +286,18 @@ export async function discoverGitHubSkills(
 
   let paths: string[] = []
   let truncated = false
+  let tree: GitHubTreeItem[] | null = null
   if (exactSkillPath) {
     paths = [exactSkillPath]
   } else {
     const treeResult = await fetchRepositoryTree(reference.owner, reference.repo, ref)
     truncated = treeResult.truncated
+    tree = treeResult.tree
     paths = selectSkillDocumentPaths(treeResult.tree, requestedPath, MAX_DISCOVERED_SKILLS)
   }
 
   const skills = (
-    await Promise.all(paths.map(async (path) => {
+    await mapGitHubReadsSerially(paths, async (path) => {
       try {
         const document = await fetchRepositoryFile(reference.owner, reference.repo, ref, path)
         const frontmatter = parseSkillDocument(document)
@@ -302,19 +316,20 @@ export async function discoverGitHubSkills(
       } catch {
         return null
       }
-    }))
+    })
   ).filter((skill): skill is DiscoveredGitHubSkill => Boolean(skill))
 
-  return { skills, truncated }
+  return { skills, truncated, tree }
 }
 
 export async function fetchDelegatedGitHubSkill(
-  skill: DiscoveredGitHubSkill
+  skill: DiscoveredGitHubSkill,
+  repositoryTree?: GitHubTreeItem[] | null
 ): Promise<DelegatedGitHubSkill | null> {
   const delegatedName = detectSkillDelegationName(skill.document)
   if (!delegatedName || delegatedName.toLowerCase() === skill.frontmatter.name.toLowerCase()) return null
 
-  const { tree } = await fetchRepositoryTree(skill.owner, skill.repo, skill.ref)
+  const tree = repositoryTree || (await fetchRepositoryTree(skill.owner, skill.repo, skill.ref)).tree
   const parentDirectory = skill.directory.includes('/')
     ? skill.directory.slice(0, skill.directory.lastIndexOf('/'))
     : ''
@@ -366,9 +381,9 @@ function extension(path: string) {
 
 export async function fetchSkillPackageSnapshot(
   skill: DiscoveredGitHubSkill,
-  options: { maxFiles?: number } = {}
+  options: { maxFiles?: number; repositoryTree?: GitHubTreeItem[] | null } = {}
 ) {
-  const { tree } = await fetchRepositoryTree(skill.owner, skill.repo, skill.ref)
+  const tree = options.repositoryTree || (await fetchRepositoryTree(skill.owner, skill.repo, skill.ref)).tree
   const prefix = skill.directory ? `${skill.directory}/` : ''
   const packageItems = tree
     .filter((item) => item.type === 'blob')
@@ -386,12 +401,12 @@ export async function fetchSkillPackageSnapshot(
   const maxFiles = Math.min(Math.max(Math.floor(options.maxFiles || MAX_PACKAGE_FILES), 1), MAX_PACKAGE_FILES)
   const paths = reviewablePaths.slice(0, maxFiles)
 
-  const files = await Promise.all(paths.map(async (path) => ({
+  const files = await mapGitHubReadsSerially(paths, async (path) => ({
     path,
     content: path === skill.path
       ? skill.document
       : await fetchRepositoryFile(skill.owner, skill.repo, skill.ref, path).catch(() => ''),
-  })))
+  }))
   const unreviewedPaths = packageItems
     .map((item) => item.path)
     .filter((path) => {

--- a/lib/indexer/candidate-intake.ts
+++ b/lib/indexer/candidate-intake.ts
@@ -8,6 +8,7 @@ import {
   fetchSkillPackageSnapshot,
   parseGitHubSkillReference,
   type DiscoveredGitHubSkill,
+  type GitHubTreeItem,
 } from '@/lib/github/skill-source'
 import { createAdminClient } from '@/lib/supabase/admin'
 import type { CandidateRepo } from './github-search'
@@ -238,7 +239,8 @@ async function insertExpandedCandidate(row: Record<string, unknown>) {
 async function buildSkillCandidateRow(
   parent: SkillCandidateRow,
   repository: Awaited<ReturnType<typeof validateGitHubRepo>>,
-  skill: DiscoveredGitHubSkill
+  skill: DiscoveredGitHubSkill,
+  repositoryTree: GitHubTreeItem[] | null
 ) {
   const hash = contentHash(skill.document)
   const sourceKey = buildCandidateSourceKey(repository.id || parent.github_repository_id, repository.fullName, skill.path)
@@ -249,7 +251,7 @@ async function buildSkillCandidateRow(
   let hasUnreviewedFiles = false
 
   if (!duplicate && repository.stars >= 100 && license.status === 'detected') {
-    const snapshot = await fetchSkillPackageSnapshot(skill, { maxFiles: 4 })
+    const snapshot = await fetchSkillPackageSnapshot(skill, { maxFiles: 4, repositoryTree })
     files = snapshot.files
     packageTruncated = snapshot.truncated
     hasUnreviewedFiles = snapshot.hasUnreviewedFiles
@@ -335,7 +337,7 @@ async function validateRepositoryCandidate(candidate: SkillCandidateRow) {
 
     const rows = []
     for (const skill of discovery.skills.slice(0, 20)) {
-      rows.push(await buildSkillCandidateRow(candidate, repository, skill))
+      rows.push(await buildSkillCandidateRow(candidate, repository, skill, discovery.tree))
     }
     const data = (await Promise.all(rows.map(insertExpandedCandidate))).flat()
 

--- a/lib/indexer/repository-skill-sync.ts
+++ b/lib/indexer/repository-skill-sync.ts
@@ -10,6 +10,7 @@ import {
   fetchSkillPackageSnapshot,
   parseGitHubSkillReference,
   type DiscoveredGitHubSkill,
+  type GitHubTreeItem,
 } from '@/lib/github/skill-source'
 import { analyzeCode } from '@/lib/security/static-analysis'
 import { evaluateSkillSubmissionPolicy } from '@/lib/skills/submission-policy'
@@ -172,13 +173,15 @@ async function payloadForNew(
   discoverySource: string,
   discoveryMetadata?: Record<string, unknown>,
   reviewMode: 'ai' | 'fast-track' = 'ai',
-  slugOverride?: string
+  slugOverride?: string,
+  repositoryTree?: GitHubTreeItem[] | null
 ) {
-  const delegatedSkill = await fetchDelegatedGitHubSkill(skill)
-  const packageSnapshots = await Promise.all([
-    fetchSkillPackageSnapshot(skill),
-    delegatedSkill ? fetchSkillPackageSnapshot(delegatedSkill) : Promise.resolve(null),
-  ])
+  const delegatedSkill = await fetchDelegatedGitHubSkill(skill, repositoryTree)
+  const primarySnapshot = await fetchSkillPackageSnapshot(skill, { repositoryTree })
+  const delegatedSnapshot = delegatedSkill
+    ? await fetchSkillPackageSnapshot(delegatedSkill, { repositoryTree })
+    : null
+  const packageSnapshots = [primarySnapshot, delegatedSnapshot]
   const codeFiles = packageSnapshots.flatMap((snapshot) => snapshot?.files || [])
   const packageTruncated = packageSnapshots.some((snapshot) => Boolean(snapshot?.truncated))
   const hasUnreviewedFiles = packageSnapshots.some((snapshot) => Boolean(snapshot?.hasUnreviewedFiles))
@@ -426,7 +429,8 @@ export async function syncRepositorySkills(
             discoverySource,
             options.discoveryMetadata,
             options.reviewMode || 'ai',
-            resolvedSlug
+            resolvedSlug,
+            discovery.tree
           )
 
       if (!result.payload) {

--- a/scripts/test-candidate-intake.ts
+++ b/scripts/test-candidate-intake.ts
@@ -71,4 +71,11 @@ const recoveryMigration = readFileSync(
 )
 assert.ok(recoveryMigration.includes("'publishing'"), 'interrupted publication rows must be reclaimable')
 
+const skillSource = readFileSync(
+  new URL('../lib/github/skill-source.ts', import.meta.url),
+  'utf8'
+)
+assert.ok(skillSource.includes('mapGitHubReadsSerially(paths'), 'GitHub content reads must be serialized')
+assert.ok(skillSource.includes('repositoryTree?: GitHubTreeItem[] | null'), 'repository trees must be reusable')
+
 console.log('Candidate intake regression tests passed.')


### PR DESCRIPTION
## Summary
- serialize GitHub content reads to avoid burst-triggering secondary limits
- reuse one repository tree throughout discovery, validation, delegated-skill inspection, and publication
- retain existing batch stop and one-hour backoff on GitHub 403/429 responses

## Verification
- candidate intake regression tests
- full regression suite
- typecheck and targeted lint
- production build