### PR TITLE
Scale curated skill intake to 1,000 per day

### DIFF
--- a/app/api/agent/discovery/route.ts
+++ b/app/api/agent/discovery/route.ts
@@ -1,4 +1,9 @@
 import { NextResponse } from 'next/server'
+import {
+  AUTOMATIC_DISCOVERY_MIN_STARS,
+  PUBLICATION_DAILY_TARGET,
+  automaticPublicationCapacityPerDay,
+} from '@/lib/indexer/intake-policy'
 import { withTimeout } from '@/lib/async'
 import { INDEXNOW_KEY_LOCATION } from '@/lib/indexnow'
 import { createPublicClient } from '@/lib/supabase/public'
@@ -20,7 +25,7 @@ import { FEATURED_SKILL_CLUSTERS, SKILL_CLUSTERS } from '@/lib/seo/skill-cluster
 export const dynamic = 'force-dynamic'
 
 const DISCOVERY_QUERY_TIMEOUT_MS = 2500
-const SKILL_RADAR_CRON_MINUTE_UTC = 35
+const SKILL_RADAR_CRON_MINUTE_UTC = 45
 
 function getImportCronMinutesUtc() {
   return [SKILL_RADAR_CRON_MINUTE_UTC]
@@ -389,7 +394,10 @@ function buildProfileRunSummaries(runs: Array<Record<string, unknown>>) {
 export async function GET() {
   const generatedAt = new Date()
   const minStars = Number(process.env.INDEXER_MIN_STARS || 500)
-  const maintenanceMinStars = Math.max(parsePositiveNumber(process.env.SKILL_RADAR_MIN_STARS, 10), 10)
+  const maintenanceMinStars = Math.max(
+    parsePositiveNumber(process.env.SKILL_RADAR_MIN_STARS, AUTOMATIC_DISCOVERY_MIN_STARS),
+    AUTOMATIC_DISCOVERY_MIN_STARS
+  )
   const maintenanceTargetNew = Math.min(
     Math.max(parsePositiveNumber(process.env.SKILL_RADAR_TARGET_NEW, 2), 1),
     12
@@ -439,7 +447,7 @@ export async function GET() {
     excludes: ['mcp-only projects', 'archived repositories', 'forks', 'low-relevance repositories'],
   }
   const schedule = {
-    import_cron: '35 * * * *',
+    import_cron: '45 * * * *',
     import_frequency: 'hourly quality maintenance radar with rotating GitHub query windows; X signals use a separately budgeted schedule.',
     profile_crons: INDEXER_RUN_PROFILES.map((profile) => ({
       profile: profile.key,
@@ -456,15 +464,15 @@ export async function GET() {
     })),
     star_refresh_cron: '0 3 * * *',
     star_refresh_frequency: 'daily at 03:00 UTC',
-    skill_radar_cron: '35 * * * *',
+    skill_radar_cron: '45 * * * *',
     skill_radar_frequency: skillRadarXMaxQueries > 0
       ? `hourly GitHub scan; X hotspot scan every ${skillRadarXScanIntervalHours} hours`
       : 'hourly GitHub scan; X hotspot scan is disabled until an X search budget is configured',
     indexnow_cron: '15 3 * * *',
     indexnow_frequency: 'daily baseline submission plus automatic submission after new skill imports',
-    candidate_discovery_cron: '10 * * * *',
+    candidate_discovery_cron: '15 * * * *',
     candidate_validation_cron: '20,50 * * * *',
-    candidate_publication_cron: '40 * * * *',
+    candidate_publication_cron: '0,10,30,40 * * * *',
   }
   const estimatedDailyCapacity = scheduledHourlyTargetNew * 24
   const remainingToTarget =
@@ -508,7 +516,7 @@ export async function GET() {
       strategy:
         'Maintain a 20k+ skill registry with rotating, scenario-specific GitHub discovery, periodic social signals, MCP exclusion, trust metadata, eval metadata, and small high-quality hourly imports.',
       quality_gates: [
-        'GitHub stars threshold for repository-level discovery; explicit SKILL.md paths remain zero-star eligible',
+        'Automatic discovery requires at least 20 GitHub stars; direct user submissions remain zero-star eligible',
         'archived and fork exclusion',
         'skill relevance scoring',
         'MCP-only exclusion',
@@ -522,7 +530,7 @@ export async function GET() {
     github_discovery: {
       status: 'active',
       source: 'github_search',
-      strategy: 'high-star repository discovery plus recursive, zero-star-eligible SKILL.md source sync',
+      strategy: '20-star automatic discovery plus recursive SKILL.md source sync; direct submissions remain zero-star eligible',
       target_approved_skills: effectiveCoverageTarget,
       domain_count: HIGH_STAR_DISCOVERY_DOMAINS.length,
       domains: HIGH_STAR_DISCOVERY_DOMAINS,
@@ -532,7 +540,8 @@ export async function GET() {
         patterns: ['SKILL.md', 'skills/**/SKILL.md', '.agents/skills/**/SKILL.md', '**/SKILL.md'],
         exact_source_urls_preserved_from_social_radar: true,
         existing_repository_incremental_rescan: true,
-        zero_star_intake: true,
+        automatic_minimum_github_stars: AUTOMATIC_DISCOVERY_MIN_STARS,
+        user_submission_minimum_github_stars: 0,
         review_policy: 'static security analysis plus automated quality review before public approval',
       },
       targeted_import: {
@@ -605,7 +614,8 @@ export async function GET() {
       architecture: ['indexed_candidates', 'installable_skills'],
       discovery_capacity_per_day: 52_800,
       light_validation_capacity_per_day: 5_760,
-      publication_capacity_per_day: 984,
+      publication_daily_target: PUBLICATION_DAILY_TARGET,
+      publication_capacity_per_day: automaticPublicationCapacityPerDay(),
       fast_track: {
         minimum_github_stars: 100,
         requirements: [

--- a/app/api/cron/skill-candidates-discover/route.ts
+++ b/app/api/cron/skill-candidates-discover/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { enqueueRepositoryCandidates } from '@/lib/indexer/candidate-intake'
 import { searchHotSkillRepos } from '@/lib/indexer/hot-skill-discovery'
+import { AUTOMATIC_DISCOVERY_MIN_STARS } from '@/lib/indexer/intake-policy'
 import { isAutomationAuthorized } from '@/lib/security/route-auth'
 
 export const runtime = 'nodejs'
@@ -23,7 +24,12 @@ async function handleRun(request: NextRequest) {
   const limit = boundedInt(body.limit ?? process.env.CANDIDATE_DISCOVERY_LIMIT, 2_000, 1, 2_000)
   const maxQueries = boundedInt(body.maxQueries ?? process.env.CANDIDATE_DISCOVERY_MAX_QUERIES, 22, 1, 22)
   const perPage = boundedInt(body.perPage ?? process.env.CANDIDATE_DISCOVERY_PER_PAGE, 100, 5, 100)
-  const minStars = boundedInt(body.minStars ?? process.env.CANDIDATE_DISCOVERY_MIN_STARS, 10, 10, 100_000)
+  const minStars = boundedInt(
+    body.minStars ?? process.env.CANDIDATE_DISCOVERY_MIN_STARS,
+    AUTOMATIC_DISCOVERY_MIN_STARS,
+    AUTOMATIC_DISCOVERY_MIN_STARS,
+    100_000
+  )
   const lookbackDays = boundedInt(body.lookbackDays ?? process.env.CANDIDATE_DISCOVERY_LOOKBACK_DAYS, 90, 1, 90)
   const hourlyWindow = Math.floor(Date.now() / 3_600_000)
   const discovery = await searchHotSkillRepos({

--- a/app/api/cron/skill-candidates-publish/route.ts
+++ b/app/api/cron/skill-candidates-publish/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { buildIndexNowUrlsForSkill, submitIndexNowUrls } from '@/lib/indexnow'
 import { runCandidatePublicationBatch } from '@/lib/indexer/candidate-intake'
 import { isAutomationAuthorized } from '@/lib/security/route-auth'
+import {
+  PUBLICATION_AI_REVIEW_PER_RUN,
+  PUBLICATION_DAILY_TARGET,
+  PUBLICATION_FAST_TRACK_PER_RUN,
+} from '@/lib/indexer/intake-policy'
 
 export const runtime = 'nodejs'
 export const maxDuration = 300
@@ -26,9 +31,25 @@ async function handleRun(request: NextRequest) {
     })
   }
   const body = request.method === 'POST' ? await request.json().catch(() => ({})) : {}
-  const fastTrackLimit = boundedInt(body.fastTrackLimit ?? process.env.CANDIDATE_FAST_TRACK_LIMIT, 20, 1, 50)
-  const aiReviewLimit = boundedInt(body.aiReviewLimit ?? process.env.CANDIDATE_AI_REVIEW_LIMIT, 21, 0, 25)
-  const result = await runCandidatePublicationBatch({ fastTrackLimit, aiReviewLimit })
+  const fastTrackLimit = boundedInt(
+    body.fastTrackLimit ?? process.env.CANDIDATE_FAST_TRACK_LIMIT,
+    PUBLICATION_FAST_TRACK_PER_RUN,
+    1,
+    50
+  )
+  const aiReviewLimit = boundedInt(
+    body.aiReviewLimit ?? process.env.CANDIDATE_AI_REVIEW_LIMIT,
+    PUBLICATION_AI_REVIEW_PER_RUN,
+    0,
+    25
+  )
+  const dailyTarget = boundedInt(
+    body.dailyTarget ?? process.env.CANDIDATE_PUBLICATION_DAILY_TARGET,
+    PUBLICATION_DAILY_TARGET,
+    1,
+    10_000
+  )
+  const result = await runCandidatePublicationBatch({ fastTrackLimit, aiReviewLimit, dailyTarget })
   const indexing = await submitIndexNowUrls(result.slugs.flatMap(buildIndexNowUrlsForSkill))
 
   return NextResponse.json({

--- a/app/api/cron/skill-source-sync/route.ts
+++ b/app/api/cron/skill-source-sync/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { HIGH_SIGNAL_SKILL_SOURCES } from '@/lib/indexer/discovery-seeds'
 import { syncRepositorySkills } from '@/lib/indexer/repository-skill-sync'
+import { AUTOMATIC_DISCOVERY_MIN_STARS } from '@/lib/indexer/intake-policy'
 import { isAutomationAuthorized } from '@/lib/security/route-auth'
 import { createPublicClient } from '@/lib/supabase/public'
 
@@ -117,6 +118,7 @@ async function handleRun(request: NextRequest) {
       results.push(await syncRepositorySkills({
         reference: source.sourceUrl,
         discoverySource: source.discoverySource,
+        minimumStarsForNew: AUTOMATIC_DISCOVERY_MIN_STARS,
         maxSkills: source.discoverySource.includes('repository-rescan') ? 6 : 4,
       }))
     } catch (error) {

--- a/docs/candidate-intake-pipeline.md
+++ b/docs/candidate-intake-pipeline.md
@@ -9,12 +9,13 @@ OpenAgentSkill keeps discovery scale separate from public marketplace quality:
 
 | Stage | Schedule | Default bound | Daily bound |
 | --- | --- | ---: | ---: |
-| GitHub discovery | hourly at `:10` | 22 searches × 100 results | 52,800 result slots |
+| GitHub discovery | hourly at `:15` | 22 searches × 100 results; repositories require 20+ stars | 52,800 result slots |
 | Light validation | hourly at `:20` and `:50` | 120 candidates/run | 5,760 candidates |
-| 100-star deterministic fast track | hourly at `:40` | 20 skills/run | 480 skills |
-| AI review | hourly at `:40` | 21 skills/run | 504 skills |
+| Public publication | `:00`, `:10`, `:30`, and `:40` hourly | 8 fast-track + 8 AI/retry slots per run | 1,536 capacity; 1,000 rolling-24h target |
 
 These are ceilings, not promised insert counts. Repository relevance filtering, stable identifiers, source URLs, exact content hashes, licenses, security checks, and existing registry records reduce the number of unique public skills.
+
+The 20-star floor applies only to automatic discovery and automatic source sync. A creator or user can submit a valid zero-star repository through the public submission flow; it still must pass structure, license, security, quality, and duplicate checks.
 
 ## Fast-track policy
 
@@ -33,7 +34,7 @@ The policy runs once during validation and again immediately before the public u
 - Authenticated search requests are spaced by at least 2.1 seconds (under 30 requests/minute).
 - Unauthenticated search requests are spaced by at least 6.1 seconds (under 10 requests/minute).
 - Search stops for the current window on HTTP 403 or 429 and respects reset/retry headers.
-- Validation uses two workers with pacing between chunks; publication is sequential with a 2.5-second gap.
+- Validation uses two workers with pacing between chunks; publication is sequential with a 2.5-second gap and a rolling 24-hour target guard.
 - Validation and publication do not run without `GITHUB_TOKEN`.
 - Queue claims use leases and `FOR UPDATE SKIP LOCKED`, so overlapping invocations do not process the same row.
 - Validation and publication failures have separate retry states with exponential backoff.

--- a/lib/growth/daily.ts
+++ b/lib/growth/daily.ts
@@ -7,6 +7,7 @@ import {
   type IndexNowSubmitResult,
 } from '@/lib/indexnow'
 import { searchHotSkillRepos, type HotSkillDiscoveryResult } from '@/lib/indexer/hot-skill-discovery'
+import { AUTOMATIC_DISCOVERY_MIN_STARS } from '@/lib/indexer/intake-policy'
 import { bulkImportHighStarSkills, type BulkImportSummary } from '@/lib/indexer/high-star-import'
 import { processBatch, type ProcessResult } from '@/lib/indexer/processor'
 import type { XQueueBuildResult } from '@/lib/x/growth'
@@ -177,7 +178,10 @@ export async function runDailyGrowthAutomation(
 
   const hotDiscovery = await searchHotSkillRepos({
     limit: hotLimit,
-    minStars: options.hotMinStars ?? numberFromEnv('GROWTH_DAILY_HOT_MIN_STARS', 10),
+    minStars: Math.max(
+      options.hotMinStars ?? numberFromEnv('GROWTH_DAILY_HOT_MIN_STARS', AUTOMATIC_DISCOVERY_MIN_STARS),
+      AUTOMATIC_DISCOVERY_MIN_STARS
+    ),
     lookbackDays: options.hotLookbackDays ?? numberFromEnv('GROWTH_DAILY_LOOKBACK_DAYS', 21),
     maxQueries: options.hotMaxQueries ?? numberFromEnv('GROWTH_DAILY_HOT_MAX_QUERIES', 12),
   })

--- a/lib/growth/skill-radar.ts
+++ b/lib/growth/skill-radar.ts
@@ -10,6 +10,7 @@ import { searchHotSkillRepos, type HotSkillDiscoveryResult } from '@/lib/indexer
 import { searchXSkillRadarRepos, type XSkillRadarResult } from '@/lib/indexer/x-skill-radar'
 import { processRepo, type ProcessResult } from '@/lib/indexer/processor'
 import type { CandidateRepo } from '@/lib/indexer/github-search'
+import { AUTOMATIC_DISCOVERY_MIN_STARS } from '@/lib/indexer/intake-policy'
 import { createPublicClient } from '@/lib/supabase/public'
 import type { XQueueBuildResult } from '@/lib/x/growth'
 import type { XPostResult } from '@/lib/x/poster'
@@ -274,10 +275,13 @@ export async function runSkillRadarAutomation(options: SkillRadarOptions = {}): 
   const startedAt = new Date().toISOString()
   const runKey = new Date().toISOString().replace(/[:.]/g, '-')
   const targetNew = Math.min(Math.max(options.targetNew ?? numberFromEnv('SKILL_RADAR_TARGET_NEW', 2), 1), 12)
-  const minStars = Math.max(options.minStars ?? numberFromEnv('SKILL_RADAR_MIN_STARS', 10), 10)
+  const minStars = Math.max(
+    options.minStars ?? numberFromEnv('SKILL_RADAR_MIN_STARS', AUTOMATIC_DISCOVERY_MIN_STARS),
+    AUTOMATIC_DISCOVERY_MIN_STARS
+  )
   const xMinStars = Math.max(
-    options.xMinStars ?? nonNegativeNumberFromEnv('SKILL_RADAR_X_MIN_STARS', 0),
-    0
+    options.xMinStars ?? nonNegativeNumberFromEnv('SKILL_RADAR_X_MIN_STARS', AUTOMATIC_DISCOVERY_MIN_STARS),
+    AUTOMATIC_DISCOVERY_MIN_STARS
   )
   const seoPerRun = Math.min(
     Math.max(options.seoPerRun ?? 0, 0),

--- a/lib/indexer/candidate-intake.ts
+++ b/lib/indexer/candidate-intake.ts
@@ -19,6 +19,11 @@ import {
 } from './candidate-identity'
 import { evaluateFastTrackCandidate } from './fast-track'
 import { syncRepositorySkills } from './repository-skill-sync'
+import {
+  AUTOMATIC_DISCOVERY_MIN_STARS,
+  PUBLICATION_DAILY_TARGET,
+  meetsAutomaticDiscoveryStarFloor,
+} from './intake-policy'
 
 const DB_TIMEOUT_MS = 20_000
 const CANDIDATE_LEASE_SECONDS = 240
@@ -85,8 +90,13 @@ export async function enqueueRepositoryCandidates(
   discoverySource = 'github-search'
 ) {
   const unique = new Map<string, Record<string, unknown>>()
+  let belowStarFloor = 0
 
   for (const candidate of candidates) {
+    if (!meetsAutomaticDiscoveryStarFloor(candidate.stars)) {
+      belowStarFloor += 1
+      continue
+    }
     const sourcePath = candidate.skillSourceUrl ? parseGitHubSkillReference(candidate.skillSourceUrl)?.path || '' : ''
     const sourceKey = buildCandidateSourceKey(candidate.githubId, candidate.fullName, sourcePath)
     unique.set(sourceKey, {
@@ -113,7 +123,9 @@ export async function enqueueRepositoryCandidates(
   }
 
   const rows = Array.from(unique.values())
-  if (!rows.length) return { attempted: 0, inserted: 0, duplicates: 0 }
+  if (!rows.length) {
+    return { attempted: candidates.length, inserted: 0, duplicates: 0, belowStarFloor }
+  }
 
   const { data, error } = await admin()
     .from('skill_candidates')
@@ -122,7 +134,12 @@ export async function enqueueRepositoryCandidates(
   if (error) throw new Error(`Candidate enqueue failed: ${error.message}`)
 
   const inserted = data?.length || 0
-  return { attempted: rows.length, inserted, duplicates: rows.length - inserted }
+  return {
+    attempted: candidates.length,
+    inserted,
+    duplicates: rows.length - inserted,
+    belowStarFloor,
+  }
 }
 
 async function claimCandidates(statuses: SkillCandidateStatus[], limit: number, workerPrefix: string) {
@@ -323,6 +340,16 @@ async function validateRepositoryCandidate(candidate: SkillCandidateRow) {
       checkReadme: true,
       checkSkillJson: false,
     })
+    if (!meetsAutomaticDiscoveryStarFloor(repository.stars)) {
+      await updateCandidate(candidate.id, {
+        status: 'rejected',
+        github_stars: repository.stars,
+        risk_reasons: [`Automatic discovery requires at least ${AUTOMATIC_DISCOVERY_MIN_STARS} GitHub stars`],
+        validated_at: new Date().toISOString(),
+        last_error: null,
+      })
+      return { expanded: 0, fastTrack: 0, reviewRequired: 0, duplicates: 0, rejected: 1, errors: 0 }
+    }
     const discovery = await discoverGitHubSkills(reference, repository)
 
     if (!discovery.skills.length) {
@@ -412,6 +439,7 @@ async function publishCandidate(candidate: SkillCandidateRow) {
       reference: candidate.canonical_source_url,
       discoverySource: candidate.fast_track_eligible ? 'github-fast-track' : 'github-candidate-review',
       maxSkills: 1,
+      minimumStarsForNew: AUTOMATIC_DISCOVERY_MIN_STARS,
       reviewMode: candidate.fast_track_eligible ? 'fast-track' : 'ai',
       discoveryMetadata: {
         candidate_id: candidate.id,
@@ -456,15 +484,61 @@ async function publishCandidate(candidate: SkillCandidateRow) {
   }
 }
 
-export async function runCandidatePublicationBatch(options: { fastTrackLimit?: number; aiReviewLimit?: number } = {}) {
+async function countRecentApprovedSkills() {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+  const { count, error } = await admin()
+    .from('skills')
+    .select('id', { count: 'exact', head: true })
+    .eq('ai_review_approved', true)
+    .gte('created_at', since)
+  if (error) throw new Error(`Daily publication count failed: ${error.message}`)
+  return count || 0
+}
+
+export async function runCandidatePublicationBatch(options: {
+  fastTrackLimit?: number
+  aiReviewLimit?: number
+  dailyTarget?: number
+} = {}) {
   const startedAt = Date.now()
   const fastTrackLimit = Math.min(Math.max(options.fastTrackLimit ?? 12, 1), 50)
   const aiReviewLimit = Math.min(Math.max(options.aiReviewLimit ?? 4, 0), 25)
-  const fastTrack = await claimCandidates(['fast_track'], fastTrackLimit, 'candidate-fast-publisher')
-  const reviewed = aiReviewLimit > 0
-    ? await claimCandidates(['review_required'], aiReviewLimit, 'candidate-ai-publisher')
+  const dailyTarget = Math.min(Math.max(options.dailyTarget ?? PUBLICATION_DAILY_TARGET, 1), 10_000)
+  const publishedLast24Hours = await countRecentApprovedSkills()
+  const remainingDailyTarget = Math.max(dailyTarget - publishedLast24Hours, 0)
+  const batchBudget = Math.min(remainingDailyTarget, fastTrackLimit + aiReviewLimit)
+
+  if (batchBudget === 0) {
+    return {
+      claimed: 0,
+      processed: 0,
+      fastTrackClaimed: 0,
+      aiReviewClaimed: 0,
+      retryClaimed: 0,
+      timeBudgetReached: false,
+      published: 0,
+      rejected: 0,
+      retries: 0,
+      errors: 0,
+      rateLimited: false,
+      dailyTarget,
+      publishedLast24Hours,
+      remainingDailyTarget,
+      targetReached: true,
+      slugs: [] as string[],
+    }
+  }
+
+  const retryLimit = Math.min(4, batchBudget)
+  const retries = await claimCandidates(['publication_error', 'publishing'], retryLimit, 'candidate-publication-retry')
+  const fastTrackBudget = Math.min(fastTrackLimit, batchBudget - retries.length)
+  const fastTrack = fastTrackBudget > 0
+    ? await claimCandidates(['fast_track'], fastTrackBudget, 'candidate-fast-publisher')
     : []
-  const retries = await claimCandidates(['publication_error', 'publishing'], Math.min(10, fastTrackLimit), 'candidate-publication-retry')
+  const reviewBudget = Math.min(aiReviewLimit, batchBudget - retries.length - fastTrack.length)
+  const reviewed = reviewBudget > 0
+    ? await claimCandidates(['review_required'], reviewBudget, 'candidate-ai-publisher')
+    : []
   const claimed = [...retries, ...fastTrack, ...reviewed]
   const results = []
   let timeBudgetReached = false
@@ -483,6 +557,7 @@ export async function runCandidatePublicationBatch(options: { fastTrackLimit?: n
     if (index + 1 < claimed.length) await sleep(PUBLICATION_DELAY_MS)
   }
 
+  const published = results.filter((result) => result.status === 'published').length
   return {
     claimed: claimed.length,
     processed: results.length,
@@ -490,11 +565,15 @@ export async function runCandidatePublicationBatch(options: { fastTrackLimit?: n
     aiReviewClaimed: reviewed.length,
     retryClaimed: retries.length,
     timeBudgetReached,
-    published: results.filter((result) => result.status === 'published').length,
+    published,
     rejected: results.filter((result) => result.status === 'rejected').length,
     retries: results.filter((result) => result.status === 'retry').length,
     errors: results.filter((result) => result.status === 'error').length,
     rateLimited: results.some((result) => 'rateLimited' in result && result.rateLimited),
+    dailyTarget,
+    publishedLast24Hours,
+    remainingDailyTarget: Math.max(remainingDailyTarget - published, 0),
+    targetReached: publishedLast24Hours + published >= dailyTarget,
     slugs: results.map((result) => result.slug).filter((slug): slug is string => Boolean(slug)),
   }
 }

--- a/lib/indexer/hot-skill-discovery.ts
+++ b/lib/indexer/hot-skill-discovery.ts
@@ -1,5 +1,6 @@
 import { evaluateSkillCandidate } from './skill-filter'
 import type { CandidateRepo } from './github-search'
+import { AUTOMATIC_DISCOVERY_MIN_STARS } from './intake-policy'
 
 type GitHubSearchSort = 'stars' | 'updated'
 
@@ -219,7 +220,10 @@ export async function searchHotSkillRepos(
   options: HotSkillDiscoveryOptions = {}
 ): Promise<HotSkillDiscoveryResult> {
   const limit = Math.min(Math.max(options.limit || 24, 1), 2_000)
-  const minStars = Math.max(Math.floor(options.minStars || 10), 10)
+  const minStars = Math.max(
+    Math.floor(options.minStars || AUTOMATIC_DISCOVERY_MIN_STARS),
+    AUTOMATIC_DISCOVERY_MIN_STARS
+  )
   const lookbackDays = Math.min(Math.max(Math.floor(options.lookbackDays || 21), 1), 90)
   const perPage = Math.min(Math.max(options.perPage || 12, 5), 100)
   const maxQueries = Math.min(Math.max(options.maxQueries || 12, 1), Math.min(HOT_SKILL_QUERIES.length, 22))

--- a/lib/indexer/intake-policy.ts
+++ b/lib/indexer/intake-policy.ts
@@ -1,0 +1,16 @@
+export const AUTOMATIC_DISCOVERY_MIN_STARS = 20
+export const PUBLICATION_DAILY_TARGET = 1_000
+export const PUBLICATION_FAST_TRACK_PER_RUN = 8
+export const PUBLICATION_AI_REVIEW_PER_RUN = 8
+export const PUBLICATION_RUNS_PER_DAY = 96
+
+export function meetsAutomaticDiscoveryStarFloor(stars: number | null | undefined) {
+  return Number(stars || 0) >= AUTOMATIC_DISCOVERY_MIN_STARS
+}
+
+export function automaticPublicationCapacityPerDay() {
+  return (
+    (PUBLICATION_FAST_TRACK_PER_RUN + PUBLICATION_AI_REVIEW_PER_RUN) *
+    PUBLICATION_RUNS_PER_DAY
+  )
+}

--- a/lib/indexer/processor.ts
+++ b/lib/indexer/processor.ts
@@ -7,12 +7,14 @@
  *   3. Write to Supabase through a narrow INDEXER_SECRET-guarded RPC
  */
 
+import { createHash } from 'node:crypto'
 import { createPublicClient } from '@/lib/supabase/public'
 import { generateText } from 'ai'
 import type { CandidateRepo } from './github-search'
 import { evaluateSkillCandidate, isMcpCandidate } from './skill-filter'
 import { INDEXER_REVIEW_MODEL } from '@/lib/ai/models'
 import { syncRepositorySkills } from './repository-skill-sync'
+import { AUTOMATIC_DISCOVERY_MIN_STARS } from './intake-policy'
 
 const GITHUB_REQUEST_TIMEOUT_MS = 12_000
 const GITHUB_RETRY_DELAYS_MS = [750, 1_750]
@@ -173,7 +175,7 @@ Respond with JSON only, no markdown:
       language: candidate.language,
       stars: candidate.stars,
     })
-    const approved = candidate.stars >= 10 && evaluation.accepted && evaluation.skillLikenessScore >= 55
+    const approved = candidate.stars >= AUTOMATIC_DISCOVERY_MIN_STARS && evaluation.accepted && evaluation.skillLikenessScore >= 55
     return {
       approved,
       score: approved ? Math.max(60, evaluation.skillLikenessScore) : 30,
@@ -222,6 +224,7 @@ export async function processRepo(
       ...(candidate.discovery?.x ? { discoveryMetadata: { x_signal: candidate.discovery.x } } : {}),
       ...(candidate.requestedSkillName ? { skillNames: [candidate.requestedSkillName] } : {}),
       maxSkills: 8,
+      minimumStarsForNew: AUTOMATIC_DISCOVERY_MIN_STARS,
     })
     if (sourceSync.discovered > 0) {
       const successfulEntries = sourceSync.entries.filter((entry) => entry.status === 'created' || entry.status === 'updated')
@@ -297,8 +300,14 @@ export async function processRepo(
       return { repo: repoRef, slug, discoverySource, status: 'skipped', reason: 'MCP projects are excluded from skill-only imports' }
     }
 
-    if (stars < 10) {
-      return { repo: repoRef, slug, discoverySource, status: 'skipped', reason: 'Below 10-star quality gate' }
+    if (stars < AUTOMATIC_DISCOVERY_MIN_STARS) {
+      return {
+        repo: repoRef,
+        slug,
+        discoverySource,
+        status: 'skipped',
+        reason: `Below ${AUTOMATIC_DISCOVERY_MIN_STARS}-star automatic discovery gate`,
+      }
     }
 
     if (license === 'Unknown') {
@@ -391,6 +400,7 @@ export async function processRepo(
       ai_review_approved: true,
       ai_review_issues: [],
       ai_review_suggestions: [],
+      source_content_hash: createHash('sha256').update(readme).digest('hex'),
       downloads: 0,
       used_by: 0,
       rating: 0,

--- a/lib/indexer/repository-skill-sync.ts
+++ b/lib/indexer/repository-skill-sync.ts
@@ -59,6 +59,8 @@ export interface RepositorySkillSyncOptions {
   refreshExisting?: boolean
   /** Fast-track is deterministic and is re-checked immediately before publication. */
   reviewMode?: 'ai' | 'fast-track'
+  /** Automatic discovery may set a star floor; direct user submissions do not use this option. */
+  minimumStarsForNew?: number
 }
 
 function slugPart(value: string) {
@@ -397,6 +399,7 @@ export async function syncRepositorySkills(
   const selected = orderedSkills(matchedSkills, existing, maxSkills)
   const entries: RepositorySkillSyncEntry[] = []
   const discoverySource = options.discoverySource || 'recursive-skill-source-sync'
+  const minimumStarsForNew = Math.max(0, Math.floor(options.minimumStarsForNew || 0))
 
   for (const item of selected) {
     const { skill, existing: existingSkill } = item
@@ -407,6 +410,39 @@ export async function syncRepositorySkills(
     }
 
     try {
+      if (!existingSkill && repository.stars < minimumStarsForNew) {
+        entries.push({
+          slug: fallbackSlug,
+          name: skill.frontmatter.name,
+          path: skill.path,
+          sourceUrl: skill.sourceUrl,
+          status: 'rejected',
+          reason: `Automatic discovery requires at least ${minimumStarsForNew} GitHub stars.`,
+        })
+        continue
+      }
+      if (!existingSkill) {
+        const sourceHash = contentHash(skill.document)
+        const { data: duplicateContent, error: duplicateContentError } = await supabase
+          .from('skills')
+          .select('slug')
+          .eq('source_content_hash', sourceHash)
+          .eq('ai_review_approved', true)
+          .limit(1)
+          .maybeSingle()
+        if (duplicateContentError) throw new Error(`Published content dedupe lookup failed: ${duplicateContentError.message}`)
+        if (duplicateContent?.slug) {
+          entries.push({
+            slug: fallbackSlug,
+            name: skill.frontmatter.name,
+            path: skill.path,
+            sourceUrl: skill.sourceUrl,
+            status: 'rejected',
+            reason: `Exact content already exists as ${duplicateContent.slug}.`,
+          })
+          continue
+        }
+      }
       if (existingSkill && options.reviewMode === 'fast-track') {
         entries.push({
           slug: fallbackSlug,

--- a/lib/skills/open-submission.ts
+++ b/lib/skills/open-submission.ts
@@ -303,6 +303,7 @@ export async function reviewOpenSubmission(input: OpenSubmissionInput, submissio
       reviewTotal: review.totalScore,
       tags,
     })
+    const sourceContentHash = createHash('sha256').update(input.skill.document).digest('hex')
     const skillPayload = {
       slug,
       name: input.skill.frontmatter.name,
@@ -327,6 +328,7 @@ export async function reviewOpenSubmission(input: OpenSubmissionInput, submissio
       listing_status: 'reviewed',
       source_ref: input.skill.ref,
       source_path: input.skill.path,
+      source_content_hash: sourceContentHash,
       publisher_github: input.makerGithub || null,
       publisher_x: input.makerX || null,
       publisher_verified: false,
@@ -357,7 +359,8 @@ export async function reviewOpenSubmission(input: OpenSubmissionInput, submissio
       const { data: existing } = await supabase
         .from('skills')
         .select('id, slug')
-        .eq('slug', slug)
+        .or(`slug.eq.${slug},source_content_hash.eq.${sourceContentHash}`)
+        .limit(1)
         .maybeSingle()
       const { error: duplicateError } = await supabase
         .from('skill_submissions')

--- a/scripts/test-candidate-intake.ts
+++ b/scripts/test-candidate-intake.ts
@@ -8,6 +8,10 @@ import { evaluateFastTrackCandidate } from '../lib/indexer/fast-track.ts'
 import { buildCandidateSourceKey, canonicalGitHubSourceUrl } from '../lib/indexer/candidate-identity.ts'
 // @ts-expect-error TS5097 is expected for this standalone test entrypoint.
 import { shouldRetryAutomatedReview } from '../lib/indexer/review-retry.ts'
+// @ts-expect-error TS5097 is expected for this standalone test entrypoint.
+import { AUTOMATIC_DISCOVERY_MIN_STARS, PUBLICATION_DAILY_TARGET, automaticPublicationCapacityPerDay, meetsAutomaticDiscoveryStarFloor } from '../lib/indexer/intake-policy.ts'
+// @ts-expect-error TS5097 is expected for this standalone test entrypoint.
+import { SKILL_SUBMISSION_MIN_STARS } from '../lib/skills/submission-policy.ts'
 
 const now = new Date('2026-09-01T00:00:00.000Z')
 const safe = {
@@ -35,6 +39,12 @@ assert.equal(evaluateFastTrackCandidate({ ...safe, packageTruncated: true }).eli
 assert.equal(evaluateFastTrackCandidate({ ...safe, hasUnreviewedFiles: true }).eligible, false)
 assert.equal(shouldRetryAutomatedReview('heuristic-static-v2'), true)
 assert.equal(shouldRetryAutomatedReview('deepseek/deepseek-v4-flash'), false)
+assert.equal(AUTOMATIC_DISCOVERY_MIN_STARS, 20)
+assert.equal(meetsAutomaticDiscoveryStarFloor(19), false)
+assert.equal(meetsAutomaticDiscoveryStarFloor(20), true)
+assert.equal(SKILL_SUBMISSION_MIN_STARS, 0, 'direct user submissions must remain zero-star eligible')
+assert.equal(PUBLICATION_DAILY_TARGET, 1_000)
+assert.ok(automaticPublicationCapacityPerDay() > PUBLICATION_DAILY_TARGET)
 
 assert.equal(
   buildCandidateSourceKey(12345, 'OldOwner/OldName', '/skills\\demo/SKILL.md/'),
@@ -77,5 +87,23 @@ const skillSource = readFileSync(
 )
 assert.ok(skillSource.includes('mapGitHubReadsSerially(paths'), 'GitHub content reads must be serialized')
 assert.ok(skillSource.includes('repositoryTree?: GitHubTreeItem[] | null'), 'repository trees must be reusable')
+
+const growthMigration = readFileSync(
+  new URL('../supabase/migrations/20260901173000_daily_1000_minimum_star_gate.sql', import.meta.url),
+  'utf8'
+)
+assert.ok(growthMigration.includes('skills_approved_source_content_hash_unique'))
+assert.ok(growthMigration.includes('github_stars < 20'))
+
+const vercelConfig = JSON.parse(readFileSync(new URL('../vercel.json', import.meta.url), 'utf8')) as {
+  crons: Array<{ path: string; schedule: string }>
+}
+assert.equal(
+  vercelConfig.crons.find((cron) => cron.path === '/api/cron/skill-candidates-publish')?.schedule,
+  '0,10,30,40 * * * *'
+)
+
+const openSubmission = readFileSync(new URL('../lib/skills/open-submission.ts', import.meta.url), 'utf8')
+assert.ok(openSubmission.includes('source_content_hash: sourceContentHash'))
 
 console.log('Candidate intake regression tests passed.')

--- a/supabase/migrations/20260901173000_daily_1000_minimum_star_gate.sql
+++ b/supabase/migrations/20260901173000_daily_1000_minimum_star_gate.sql
@@ -1,0 +1,19 @@
+-- Keep automatic marketplace growth high-signal and globally deduplicated.
+
+create unique index if not exists skills_approved_source_content_hash_unique
+  on public.skills (source_content_hash)
+  where source_content_hash is not null
+    and ai_review_approved = true;
+
+update public.skill_candidates
+set status = 'rejected',
+    risk_reasons = array_append(
+      coalesce(risk_reasons, '{}'::text[]),
+      'Automatic discovery requires at least 20 GitHub stars'
+    ),
+    last_error = null,
+    lease_owner = null,
+    lease_expires_at = null,
+    updated_at = now()
+where github_stars < 20
+  and status in ('discovered', 'review_required', 'validation_error', 'publication_error');

--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
     },
     {
       "path": "/api/cron/skill-candidates-discover",
-      "schedule": "10 * * * *"
+      "schedule": "15 * * * *"
     },
     {
       "path": "/api/cron/skill-candidates-validate",
@@ -26,15 +26,15 @@
     },
     {
       "path": "/api/cron/skill-radar",
-      "schedule": "35 * * * *"
+      "schedule": "45 * * * *"
     },
     {
       "path": "/api/cron/skill-candidates-publish",
-      "schedule": "40 * * * *"
+      "schedule": "0,10,30,40 * * * *"
     },
     {
       "path": "/api/cron/skill-source-sync",
-      "schedule": "0 */6 * * *"
+      "schedule": "5 */6 * * *"
     },
     {
       "path": "/api/cron/official-frontend-skills",


### PR DESCRIPTION
## Summary
- raise the rolling 24-hour publication target to 1,000 using staggered small batches
- require at least 20 GitHub stars for every automatic discovery path while keeping direct user submissions at zero stars
- add source-content hash deduplication at application and database levels
- reject queued automatic candidates below the quality floor and document/advertise the new capacity

## Safety
- theoretical publication capacity: 1,536/day, capped at 1,000/day
- validation capacity: 5,760 repositories/day
- automatic discovery remains GitHub-rate-aware and is staggered away from validation/publication
- existing listings can still sync after falling below 20 stars; only new automatic listings are gated

## Verification
- pnpm run test:candidate-intake
- pnpm run typecheck
- pnpm test
- pnpm run build
- production migration applied successfully; 0 active automatic candidates below 20 stars and 0 duplicate approved content hashes