### PR TITLE
Align intake status metadata

### DIFF
--- a/app/api/agent/discovery/route.ts
+++ b/app/api/agent/discovery/route.ts
@@ -644,7 +644,7 @@ export async function GET() {
     skill_radar: {
       status: 'active',
       private_endpoint: '/api/cron/skill-radar',
-      schedule: '35 * * * *',
+      schedule: SKILL_RADAR_CRON_MINUTE_UTC,
       sources: ['X posts with GitHub links', 'GitHub hot skill search'],
       strategy:
         'Use social and GitHub freshness as candidate signals only; every repo still passes GitHub metadata checks, MCP exclusion, AI review, Trust/Audit surfaces, SEO drip, IndexNow, and X queue guards.',
@@ -665,7 +665,7 @@ export async function GET() {
         'requires a GitHub repository URL',
         'excludes generic foundation repositories',
         'requires skill, workflow, agent, or concrete use-case signals',
-        'requires at least 10 GitHub stars by default',
+        `requires at least ${AUTOMATIC_DISCOVERY_MIN_STARS} GitHub stars for automatic intake`,
         'falls back to existing high-quality X queue candidates when no new radar candidate is imported',
       ],
     },

--- a/app/api/x/status/route.ts
+++ b/app/api/x/status/route.ts
@@ -88,7 +88,7 @@ export async function GET(request: NextRequest) {
       dailyAutoPostsTarget: '3-5',
       postDailyCron: '30 15,19,23 * * *',
       growthRunCron: '30 14 * * *',
-      skillRadarCron: '35 * * * *',
+      skillRadarCron: '45 * * * *',
       postQueueBuildLimit: 3,
       growthQueueLimit: numberFromEnv('X_DAILY_SCENARIO_POSTS', 3),
       metricsSyncLimit: numberFromEnv('X_METRICS_SYNC_LIMIT', 12),

--- a/scripts/test-candidate-intake.ts
+++ b/scripts/test-candidate-intake.ts
@@ -103,6 +103,13 @@ assert.equal(
   '0,10,30,40 * * * *'
 )
 
+const discoveryStatusRoute = readFileSync(new URL('../app/api/agent/discovery/route.ts', import.meta.url), 'utf8')
+assert.ok(discoveryStatusRoute.includes('schedule: SKILL_RADAR_CRON_MINUTE_UTC'))
+assert.ok(!discoveryStatusRoute.includes('at least 10 GitHub stars'))
+
+const xStatusRoute = readFileSync(new URL('../app/api/x/status/route.ts', import.meta.url), 'utf8')
+assert.ok(xStatusRoute.includes("skillRadarCron: '45 * * * *'"))
+
 const openSubmission = readFileSync(new URL('../lib/skills/open-submission.ts', import.meta.url), 'utf8')
 assert.ok(openSubmission.includes('source_content_hash: sourceContentHash'))
 


### PR DESCRIPTION
Follow-up to #96: align the public agent discovery and X status metadata with the deployed 45-minute radar schedule and 20-star automatic intake gate. Adds regression assertions to prevent status drift.