### PR TITLE
Fix radar cron status format

### DIFF
--- a/app/api/agent/discovery/route.ts
+++ b/app/api/agent/discovery/route.ts
@@ -644,7 +644,7 @@ export async function GET() {
     skill_radar: {
       status: 'active',
       private_endpoint: '/api/cron/skill-radar',
-      schedule: SKILL_RADAR_CRON_MINUTE_UTC,
+      schedule: `${SKILL_RADAR_CRON_MINUTE_UTC} * * * *`,
       sources: ['X posts with GitHub links', 'GitHub hot skill search'],
       strategy:
         'Use social and GitHub freshness as candidate signals only; every repo still passes GitHub metadata checks, MCP exclusion, AI review, Trust/Audit surfaces, SEO drip, IndexNow, and X queue guards.',

--- a/scripts/test-candidate-intake.ts
+++ b/scripts/test-candidate-intake.ts
@@ -104,7 +104,7 @@ assert.equal(
 )
 
 const discoveryStatusRoute = readFileSync(new URL('../app/api/agent/discovery/route.ts', import.meta.url), 'utf8')
-assert.ok(discoveryStatusRoute.includes('schedule: SKILL_RADAR_CRON_MINUTE_UTC'))
+assert.ok(discoveryStatusRoute.includes('schedule: `${SKILL_RADAR_CRON_MINUTE_UTC} * * * *`'))
 assert.ok(!discoveryStatusRoute.includes('at least 10 GitHub stars'))
 
 const xStatusRoute = readFileSync(new URL('../app/api/x/status/route.ts', import.meta.url), 'utf8')


### PR DESCRIPTION
Return the radar schedule as a complete cron expression in the public discovery status API and lock the format with a regression assertion.