### PR TITLE
Add growth pipeline observability and expand qualified indexing

### DIFF
--- a/app/api/agent/discovery/route.ts
+++ b/app/api/agent/discovery/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server'
+import { unstable_cache } from 'next/cache'
 import {
   AUTOMATIC_DISCOVERY_MIN_STARS,
   PUBLICATION_DAILY_TARGET,
   automaticPublicationCapacityPerDay,
 } from '@/lib/indexer/intake-policy'
+import { getCandidatePipelineHealth } from '@/lib/indexer/candidate-intake'
 import { withTimeout } from '@/lib/async'
 import { INDEXNOW_KEY_LOCATION } from '@/lib/indexnow'
 import { createPublicClient } from '@/lib/supabase/public'
@@ -21,6 +23,10 @@ import {
 import { AGENT_OUTCOMES } from '@/lib/agent-outcomes'
 import { INDEXER_RUN_PROFILES } from '@/lib/indexer/run-profiles'
 import { FEATURED_SKILL_CLUSTERS, SKILL_CLUSTERS } from '@/lib/seo/skill-clusters'
+import {
+  SEARCH_INDEX_MIN_GITHUB_STARS,
+  SEARCH_INDEX_MIN_QUALITY_SCORE,
+} from '@/lib/seo/search-indexability'
 
 export const dynamic = 'force-dynamic'
 
@@ -227,7 +233,7 @@ function buildIndexerHealth({
   }
 }
 
-async function getRecentRuns() {
+async function getRecentRuns(): Promise<Array<Record<string, unknown>>> {
   const serverSecret = process.env.INDEXER_SECRET
   if (!serverSecret) return []
 
@@ -235,7 +241,7 @@ async function getRecentRuns() {
   const { data, error } = await withTimeout(
     supabase.rpc('list_indexer_runs', {
       p_server_secret: serverSecret,
-      p_limit: 5,
+      p_limit: 20,
     }),
     DISCOVERY_QUERY_TIMEOUT_MS,
     'indexer run status query'
@@ -343,8 +349,54 @@ async function getRecentRuns() {
       ? (run.metadata as Record<string, unknown>).error_samples
       : undefined,
     maintenance_mode: metadataValue(run, 'maintenance_mode') === true,
+    pipeline_stage: metadataValue(run, 'stage'),
+    below_star_floor: metadataValue(run, 'below_star_floor'),
+    rate_limited: metadataValue(run, 'rate_limited'),
+    time_budget_reached: metadataValue(run, 'time_budget_reached'),
+    fast_track: metadataValue(run, 'fast_track'),
+    review_required: metadataValue(run, 'review_required'),
+    duplicates: metadataValue(run, 'duplicates'),
+    rejected: metadataValue(run, 'rejected'),
+    published_last_24_hours: metadataValue(run, 'published_last_24_hours'),
+    remaining_daily_target: metadataValue(run, 'remaining_daily_target'),
+    target_reached: metadataValue(run, 'target_reached'),
   }))
 }
+
+async function fetchGrowthSignals() {
+  const supabase = createPublicClient({ requestTimeoutMs: DISCOVERY_QUERY_TIMEOUT_MS })
+  const [indexableResult, approvedClaimsResult] = await Promise.all([
+    supabase
+      .from('skills')
+      .select('slug', { count: 'exact', head: true })
+      .eq('ai_review_approved', true)
+      .gte('quality_score', SEARCH_INDEX_MIN_QUALITY_SCORE)
+      .gte('github_stars', SEARCH_INDEX_MIN_GITHUB_STARS),
+    supabase
+      .from('skill_claims')
+      .select('user_id,verified_at')
+      .eq('status', 'approved')
+      .limit(1000),
+  ])
+
+  const approvedClaims = approvedClaimsResult.error ? [] : approvedClaimsResult.data || []
+  const eligibleCount =
+    !indexableResult.error && typeof indexableResult.count === 'number'
+      ? indexableResult.count
+      : null
+  return {
+    search_index_eligible_skills: eligibleCount,
+    search_index_count_source: eligibleCount === null ? 'temporarily_unavailable' : 'cached_database_exact_count',
+    approved_creator_claims: approvedClaims.length,
+    verified_creators: new Set(approvedClaims.map((claim) => claim.user_id)).size,
+  }
+}
+
+const getGrowthSignals = unstable_cache(
+  fetchGrowthSignals,
+  ['agent-discovery-growth-signals-v1'],
+  { revalidate: 900, tags: ['agent-discovery-growth-signals'] }
+)
 
 function buildProfileRunSummaries(runs: Array<Record<string, unknown>>) {
   return INDEXER_RUN_PROFILES.map((profile) => {
@@ -424,9 +476,21 @@ export async function GET() {
   const effectiveCoverageTarget = resolveHighStarCoverageTarget(
     parsePositiveNumber(process.env.INDEXER_TARGET_TOTAL, HIGH_STAR_SKILL_COVERAGE_TARGET)
   )
-  const [runs, approvedSkillCountResult] = await Promise.all([
+  const [runs, approvedSkillCountResult, candidatePipelineHealth, growthSignals] = await Promise.all([
     getRecentRuns(),
     getApprovedRegistrySkillCount(DISCOVERY_QUERY_TIMEOUT_MS),
+    withTimeout(
+      getCandidatePipelineHealth(),
+      8_000,
+      'candidate pipeline health query'
+    ).catch((error) => {
+      console.warn('Candidate pipeline health fallback:', error)
+      return null
+    }),
+    withTimeout(getGrowthSignals(), 5_000, 'growth signals query').catch((error) => {
+      console.warn('Growth signals fallback:', error)
+      return null
+    }),
   ])
   const approvedSkillCount =
     approvedSkillCountResult?.count ?? LAST_VERIFIED_APPROVED_SKILL_COUNT
@@ -462,13 +526,13 @@ export async function GET() {
       max_search_requests: profile.maxSearchRequests,
       duplicate_recovery_search_requests: profile.duplicateRecoverySearchRequests,
     })),
-    star_refresh_cron: '0 3 * * *',
-    star_refresh_frequency: 'daily at 03:00 UTC',
+    star_refresh_cron: '30 2 * * *',
+    star_refresh_frequency: 'daily at 02:30 UTC',
     skill_radar_cron: '45 * * * *',
     skill_radar_frequency: skillRadarXMaxQueries > 0
       ? `hourly GitHub scan; X hotspot scan every ${skillRadarXScanIntervalHours} hours`
       : 'hourly GitHub scan; X hotspot scan is disabled until an X search budget is configured',
-    indexnow_cron: '15 3 * * *',
+    indexnow_cron: '10 3 * * *',
     indexnow_frequency: 'daily baseline submission plus automatic submission after new skill imports',
     candidate_discovery_cron: '15 * * * *',
     candidate_validation_cron: '20,50 * * * *',
@@ -483,9 +547,11 @@ export async function GET() {
     remainingToTarget === null
       ? null
       : Math.ceil(remainingToTarget / Math.max(estimatedDailyCapacity, 1))
+  const maintenanceRuns = runs.filter((run) => run.mode === 'skill-radar' || run.maintenance_mode === true)
+  const candidateRuns = runs.filter((run) => typeof run.mode === 'string' && run.mode.startsWith('candidate-'))
   const indexerHealth = {
     ...buildIndexerHealth({
-      runs,
+      runs: maintenanceRuns,
       generatedAt,
       targetNew,
       maintenanceTargetNew,
@@ -610,6 +676,20 @@ export async function GET() {
     },
     candidate_pipeline: {
       status: 'active',
+      observed_health: candidatePipelineHealth,
+      recent_runs: candidateRuns.slice(0, 9),
+      observability: {
+        source: candidatePipelineHealth ? 'live_private_queue_counts' : 'temporarily_unavailable',
+        run_log_modes: ['candidate-discovery', 'candidate-validation', 'candidate-publication'],
+        warning:
+          candidatePipelineHealth?.state === 'backlogged'
+            ? 'The ready queue is more than 24 hours old and needs additional validation or publication throughput.'
+            : candidatePipelineHealth?.state === 'degraded'
+              ? 'At least 25% of the ready queue is waiting on validation or publication errors.'
+              : candidatePipelineHealth?.state === 'idle'
+                ? 'No candidate discovery or publication activity was observed in the last 24 hours.'
+                : null,
+      },
       kill_switch: 'CANDIDATE_PIPELINE_DISABLED=true',
       architecture: ['indexed_candidates', 'installable_skills'],
       discovery_capacity_per_day: 52_800,
@@ -674,6 +754,27 @@ export async function GET() {
       strategy:
         'Publish high-intent, task-first skill cluster pages so Google and AI search can map OpenAgentSkill to concrete agent workflows.',
       cluster_count: SKILL_CLUSTERS.length,
+      search_index_coverage: {
+        approved_registry_skills: approvedSkillCount,
+        eligible_skill_pages: growthSignals?.search_index_eligible_skills ?? null,
+        eligible_share_percent:
+          growthSignals?.search_index_eligible_skills !== null &&
+          growthSignals?.search_index_eligible_skills !== undefined &&
+          approvedSkillCount > 0
+            ? Number(((growthSignals.search_index_eligible_skills / approvedSkillCount) * 100).toFixed(1))
+            : null,
+        excluded_until_quality_evidence:
+          growthSignals?.search_index_eligible_skills !== null &&
+          growthSignals?.search_index_eligible_skills !== undefined
+            ? Math.max(approvedSkillCount - growthSignals.search_index_eligible_skills, 0)
+            : null,
+        count_source: growthSignals?.search_index_count_source || 'temporarily_unavailable',
+        policy: {
+          minimum_quality_score: SEARCH_INDEX_MIN_QUALITY_SCORE,
+          minimum_github_stars: SEARCH_INDEX_MIN_GITHUB_STARS,
+          ai_review_approval_required: true,
+        },
+      },
       featured_clusters: FEATURED_SKILL_CLUSTERS.map((cluster) => ({
         slug: cluster.slug,
         title: cluster.title,
@@ -779,6 +880,11 @@ export async function GET() {
     },
     creator_growth_loop: {
       status: 'active',
+      observed_activation: {
+        approved_claims: growthSignals?.approved_creator_claims ?? null,
+        verified_creators: growthSignals?.verified_creators ?? null,
+        source: growthSignals ? 'live_public_claims' : 'temporarily_unavailable',
+      },
       workflow: [
         'index public skill from repository or creator source',
         'show listing as community indexed until a maintainer claim is approved',

--- a/app/api/cron/skill-candidates-discover/route.ts
+++ b/app/api/cron/skill-candidates-discover/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { enqueueRepositoryCandidates } from '@/lib/indexer/candidate-intake'
 import { searchHotSkillRepos } from '@/lib/indexer/hot-skill-discovery'
 import { AUTOMATIC_DISCOVERY_MIN_STARS } from '@/lib/indexer/intake-policy'
+import { recordIndexerRun } from '@/lib/indexer/run-log'
 import { isAutomationAuthorized } from '@/lib/security/route-auth'
 
 export const runtime = 'nodejs'
@@ -20,6 +21,7 @@ async function handleRun(request: NextRequest) {
     return NextResponse.json({ success: true, skipped: true, reason: 'Candidate pipeline is disabled by configuration.' })
   }
 
+  const startedAt = new Date().toISOString()
   const body = request.method === 'POST' ? await request.json().catch(() => ({})) : {}
   const limit = boundedInt(body.limit ?? process.env.CANDIDATE_DISCOVERY_LIMIT, 2_000, 1, 2_000)
   const maxQueries = boundedInt(body.maxQueries ?? process.env.CANDIDATE_DISCOVERY_MAX_QUERIES, 22, 1, 22)
@@ -32,29 +34,67 @@ async function handleRun(request: NextRequest) {
   )
   const lookbackDays = boundedInt(body.lookbackDays ?? process.env.CANDIDATE_DISCOVERY_LOOKBACK_DAYS, 90, 1, 90)
   const hourlyWindow = Math.floor(Date.now() / 3_600_000)
-  const discovery = await searchHotSkillRepos({
-    limit,
-    maxQueries,
-    perPage,
-    minStars,
-    lookbackDays,
-    queryOffset: hourlyWindow * maxQueries,
-  })
-  const intake = await enqueueRepositoryCandidates(discovery.candidates, 'github-candidate-discovery')
+  try {
+    const discovery = await searchHotSkillRepos({
+      limit,
+      maxQueries,
+      perPage,
+      minStars,
+      lookbackDays,
+      queryOffset: hourlyWindow * maxQueries,
+    })
+    const intake = await enqueueRepositoryCandidates(discovery.candidates, 'github-candidate-discovery')
 
-  return NextResponse.json({
-    success: true,
-    mode: 'candidate-discovery',
-    discovery: {
-      searched_queries: discovery.searchedQueries,
-      candidates: discovery.candidates.length,
-      min_stars: discovery.minStars,
-      since: discovery.since,
-      rate_limited: discovery.rateLimited,
-      retry_after_ms: discovery.retryAfterMs,
-    },
-    intake,
-  })
+    await recordIndexerRun({
+      mode: 'candidate-discovery',
+      status: discovery.rateLimited ? 'rate-limited' : 'completed',
+      started_at: startedAt,
+      target_new: limit,
+      min_stars: minStars,
+      max_search_requests: maxQueries,
+      search_requests: discovery.searchedQueries,
+      candidates_found: discovery.candidates.length,
+      skipped_existing: intake.duplicates,
+      imported: intake.inserted,
+      errors: discovery.rateLimited ? 1 : 0,
+      metadata: {
+        stage: 'discovery',
+        below_star_floor: intake.belowStarFloor,
+        lookback_days: lookbackDays,
+        per_page: perPage,
+        rate_limited: discovery.rateLimited,
+        retry_after_ms: discovery.retryAfterMs,
+      },
+    })
+
+    return NextResponse.json({
+      success: !discovery.rateLimited,
+      mode: 'candidate-discovery',
+      discovery: {
+        searched_queries: discovery.searchedQueries,
+        candidates: discovery.candidates.length,
+        min_stars: discovery.minStars,
+        since: discovery.since,
+        rate_limited: discovery.rateLimited,
+        retry_after_ms: discovery.retryAfterMs,
+      },
+      intake,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Candidate discovery failed'
+    await recordIndexerRun({
+      mode: 'candidate-discovery',
+      status: 'failed',
+      started_at: startedAt,
+      target_new: limit,
+      min_stars: minStars,
+      max_search_requests: maxQueries,
+      errors: 1,
+      metadata: { stage: 'discovery', error: message.slice(0, 1000) },
+    })
+    console.error('[candidate-discovery]', error)
+    return NextResponse.json({ success: false, mode: 'candidate-discovery', error: message }, { status: 500 })
+  }
 }
 
 export async function GET(request: NextRequest) {

--- a/app/api/cron/skill-candidates-publish/route.ts
+++ b/app/api/cron/skill-candidates-publish/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { buildIndexNowUrlsForSkill, submitIndexNowUrls } from '@/lib/indexnow'
 import { runCandidatePublicationBatch } from '@/lib/indexer/candidate-intake'
 import { isAutomationAuthorized } from '@/lib/security/route-auth'
+import { recordIndexerRun } from '@/lib/indexer/run-log'
 import {
   PUBLICATION_AI_REVIEW_PER_RUN,
   PUBLICATION_DAILY_TARGET,
@@ -30,6 +31,7 @@ async function handleRun(request: NextRequest) {
       reason: 'GITHUB_TOKEN is required for candidate publication; no unauthenticated GitHub requests were sent.',
     })
   }
+  const startedAt = new Date().toISOString()
   const body = request.method === 'POST' ? await request.json().catch(() => ({})) : {}
   const fastTrackLimit = boundedInt(
     body.fastTrackLimit ?? process.env.CANDIDATE_FAST_TRACK_LIMIT,
@@ -49,15 +51,54 @@ async function handleRun(request: NextRequest) {
     1,
     10_000
   )
-  const result = await runCandidatePublicationBatch({ fastTrackLimit, aiReviewLimit, dailyTarget })
-  const indexing = await submitIndexNowUrls(result.slugs.flatMap(buildIndexNowUrlsForSkill))
+  try {
+    const result = await runCandidatePublicationBatch({ fastTrackLimit, aiReviewLimit, dailyTarget })
+    const indexing = await submitIndexNowUrls(result.slugs.flatMap(buildIndexNowUrlsForSkill))
 
-  return NextResponse.json({
-    success: !result.rateLimited && result.errors === 0,
-    mode: 'candidate-publication',
-    result,
-    indexing,
-  })
+    await recordIndexerRun({
+      mode: 'candidate-publication',
+      status: result.rateLimited ? 'rate-limited' : result.errors > 0 ? 'completed-with-errors' : 'completed',
+      started_at: startedAt,
+      target_new: dailyTarget,
+      candidates_found: result.claimed,
+      imported: result.published,
+      updated: result.processed,
+      errors: result.errors,
+      metadata: {
+        stage: 'publication',
+        fast_track_claimed: result.fastTrackClaimed,
+        ai_review_claimed: result.aiReviewClaimed,
+        retry_claimed: result.retryClaimed,
+        rejected: result.rejected,
+        retries: result.retries,
+        rate_limited: result.rateLimited,
+        time_budget_reached: result.timeBudgetReached,
+        published_last_24_hours: result.publishedLast24Hours,
+        remaining_daily_target: result.remainingDailyTarget,
+        target_reached: result.targetReached,
+        indexnow: indexing,
+      },
+    })
+
+    return NextResponse.json({
+      success: !result.rateLimited && result.errors === 0,
+      mode: 'candidate-publication',
+      result,
+      indexing,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Candidate publication failed'
+    await recordIndexerRun({
+      mode: 'candidate-publication',
+      status: 'failed',
+      started_at: startedAt,
+      target_new: dailyTarget,
+      errors: 1,
+      metadata: { stage: 'publication', error: message.slice(0, 1000) },
+    })
+    console.error('[candidate-publication]', error)
+    return NextResponse.json({ success: false, mode: 'candidate-publication', error: message }, { status: 500 })
+  }
 }
 
 export async function GET(request: NextRequest) {

--- a/app/api/cron/skill-candidates-validate/route.ts
+++ b/app/api/cron/skill-candidates-validate/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { runCandidateValidationBatch } from '@/lib/indexer/candidate-intake'
+import { recordIndexerRun } from '@/lib/indexer/run-log'
 import { isAutomationAuthorized } from '@/lib/security/route-auth'
 
 export const runtime = 'nodejs'
@@ -19,16 +20,51 @@ async function handleRun(request: NextRequest) {
       reason: 'GITHUB_TOKEN is required for high-volume validation; no unauthenticated GitHub requests were sent.',
     })
   }
+  const startedAt = new Date().toISOString()
   const body = request.method === 'POST' ? await request.json().catch(() => ({})) : {}
   const requested = Number(body.limit ?? request.nextUrl.searchParams.get('limit') ?? process.env.CANDIDATE_VALIDATION_LIMIT ?? 120)
   const limit = Number.isFinite(requested) ? Math.min(Math.max(Math.floor(requested), 1), 250) : 120
-  const result = await runCandidateValidationBatch(limit)
+  try {
+    const result = await runCandidateValidationBatch(limit)
+    await recordIndexerRun({
+      mode: 'candidate-validation',
+      status: result.rateLimited ? 'rate-limited' : result.errors > 0 ? 'completed-with-errors' : 'completed',
+      started_at: startedAt,
+      target_new: limit,
+      candidates_found: result.claimed,
+      imported: result.fastTrack + result.reviewRequired,
+      updated: result.processed,
+      errors: result.errors,
+      metadata: {
+        stage: 'validation',
+        expanded: result.expanded,
+        fast_track: result.fastTrack,
+        review_required: result.reviewRequired,
+        duplicates: result.duplicates,
+        rejected: result.rejected,
+        rate_limited: result.rateLimited,
+        time_budget_reached: result.timeBudgetReached,
+      },
+    })
 
-  return NextResponse.json({
-    success: !result.rateLimited,
-    mode: 'candidate-light-validation',
-    result,
-  })
+    return NextResponse.json({
+      success: !result.rateLimited && result.errors === 0,
+      mode: 'candidate-light-validation',
+      result,
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Candidate validation failed'
+    await recordIndexerRun({
+      mode: 'candidate-validation',
+      status: 'failed',
+      started_at: startedAt,
+      target_new: limit,
+      errors: 1,
+      metadata: { stage: 'validation', error: message.slice(0, 1000) },
+    })
+    console.error('[candidate-validation]', error)
+    return NextResponse.json({ success: false, mode: 'candidate-light-validation', error: message }, { status: 500 })
+  }
 }
 
 export async function GET(request: NextRequest) {

--- a/docs/candidate-intake-pipeline.md
+++ b/docs/candidate-intake-pipeline.md
@@ -42,3 +42,15 @@ The policy runs once during validation and again immediately before the public u
 - AI review is capped at 20 seconds per candidate so one provider timeout cannot exhaust the whole cron run.
 
 Set `CANDIDATE_PIPELINE_DISABLED=true` for an immediate pause. Cron endpoints remain authenticated by the existing automation secrets.
+
+## Growth and queue observability
+
+Each scheduled stage writes a durable `indexer_runs` record using a stable mode:
+
+- `candidate-discovery`
+- `candidate-validation`
+- `candidate-publication`
+
+`GET /api/agent/discovery` exposes the recent stage runs plus a five-minute cached queue health snapshot. The snapshot includes per-status counts, ready backlog, retry errors, rolling 24-hour discovery/publication throughput, oldest ready age, and latest candidate/publication timestamps. Health is labelled `healthy`, `backlogged`, `degraded`, or `idle`; a theoretical daily capacity must not be treated as achieved throughput without these observed fields.
+
+The same endpoint publishes a cached exact count of search-index-eligible Skill pages and Creator Claim activation. Search indexing remains stricter than registry inclusion: a page needs AI approval, a quality score of at least 50, and at least 3 GitHub stars. This keeps the full catalog available to people and agents while submitting only evidence-backed pages to crawlers. Sitemap shard counts use the same exact cached query so they cannot drift into empty or missing shards because of planner estimates.

--- a/lib/db/skills.ts
+++ b/lib/db/skills.ts
@@ -357,7 +357,7 @@ const getCachedApprovedSkillSitemapCount = unstable_cache(
       return getSitemapFallbackRecords(0, CURATED_SKILL_SNAPSHOT.length, minStars, minQualityScore).length
     }
   },
-  ['approved-sitemap-count-v7'],
+  ['approved-sitemap-count-v8'],
   {
     revalidate: SITEMAP_CACHE_REVALIDATE_SECONDS,
     tags: ['approved-sitemap-count'],
@@ -441,9 +441,9 @@ async function fetchApprovedSkillSitemapCount(minStars: number, minQualityScore:
 
   let query = supabase
     .from('skills')
-    // Planner counts are sufficient to determine sitemap shard capacity and
-    // remain cheap when crawlers request this endpoint concurrently.
-    .select('slug', { count: 'planned', head: true })
+    // This result is cached for 12 hours. An exact indexed count prevents the
+    // planner estimate from creating empty sitemap shards or hiding valid ones.
+    .select('slug', { count: 'exact', head: true })
     .eq('ai_review_approved', true)
 
   if (minStars > 0) {

--- a/lib/indexer/candidate-intake.ts
+++ b/lib/indexer/candidate-intake.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import { createHash, randomUUID } from 'node:crypto'
+import { unstable_cache } from 'next/cache'
 import { getLicenseEvidence } from '@/lib/creator-ownership'
 import { validateGitHubRepo } from '@/lib/github/api'
 import {
@@ -44,6 +45,42 @@ export type SkillCandidateStatus =
   | 'duplicate'
   | 'validation_error'
   | 'publication_error'
+
+const CANDIDATE_PIPELINE_STATUSES: SkillCandidateStatus[] = [
+  'discovered',
+  'validating',
+  'expanded',
+  'fast_track',
+  'review_required',
+  'publishing',
+  'published',
+  'rejected',
+  'duplicate',
+  'validation_error',
+  'publication_error',
+]
+
+const READY_CANDIDATE_STATUSES: SkillCandidateStatus[] = [
+  'discovered',
+  'fast_track',
+  'review_required',
+  'validation_error',
+  'publication_error',
+]
+
+export interface CandidatePipelineHealth {
+  state: 'healthy' | 'backlogged' | 'degraded' | 'idle'
+  counts: Record<SkillCandidateStatus, number>
+  total_candidates: number
+  ready_backlog: number
+  errors_waiting_retry: number
+  discovered_last_24_hours: number
+  published_last_24_hours: number
+  oldest_ready_candidate_at: string | null
+  oldest_ready_age_hours: number | null
+  latest_candidate_at: string | null
+  latest_publication_at: string | null
+}
 
 export interface SkillCandidateRow {
   id: string
@@ -578,16 +615,93 @@ export async function runCandidatePublicationBatch(options: {
   }
 }
 
-export async function getCandidatePipelineStats() {
-  const client = admin()
-  const statuses: SkillCandidateStatus[] = [
-    'discovered', 'fast_track', 'review_required', 'published', 'duplicate',
-    'rejected', 'validation_error', 'publication_error',
-  ]
-  const entries = await Promise.all(statuses.map(async (status) => {
+async function fetchCandidatePipelineHealth(now = new Date()): Promise<CandidatePipelineHealth> {
+  const client = createAdminClient({ requestTimeoutMs: 6_000 })
+  const since = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString()
+  const entriesPromise = Promise.all(CANDIDATE_PIPELINE_STATUSES.map(async (status) => {
     const { count, error } = await client.from('skill_candidates').select('id', { count: 'exact', head: true }).eq('status', status)
     if (error) throw new Error(error.message)
     return [status, count || 0] as const
   }))
-  return Object.fromEntries(entries) as Record<SkillCandidateStatus, number>
+  const [
+    entries,
+    discoveredResult,
+    publishedResult,
+    oldestReadyResult,
+    latestCandidateResult,
+    latestPublicationResult,
+  ] = await Promise.all([
+    entriesPromise,
+    client.from('skill_candidates').select('id', { count: 'exact', head: true }).gte('discovered_at', since),
+    client.from('skill_candidates').select('id', { count: 'exact', head: true }).eq('status', 'published').gte('published_at', since),
+    client
+      .from('skill_candidates')
+      .select('discovered_at')
+      .in('status', READY_CANDIDATE_STATUSES)
+      .lte('next_attempt_at', now.toISOString())
+      .order('discovered_at', { ascending: true })
+      .limit(1)
+      .maybeSingle(),
+    client
+      .from('skill_candidates')
+      .select('discovered_at')
+      .order('discovered_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    client
+      .from('skill_candidates')
+      .select('published_at')
+      .eq('status', 'published')
+      .not('published_at', 'is', null)
+      .order('published_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ])
+
+  for (const result of [discoveredResult, publishedResult, oldestReadyResult, latestCandidateResult, latestPublicationResult]) {
+    if (result.error) throw new Error(result.error.message)
+  }
+
+  const counts = Object.fromEntries(entries) as Record<SkillCandidateStatus, number>
+  const readyBacklog = READY_CANDIDATE_STATUSES.reduce((sum, status) => sum + counts[status], 0)
+  const errorsWaitingRetry = counts.validation_error + counts.publication_error
+  const oldestReadyCandidateAt = oldestReadyResult.data?.discovered_at || null
+  const oldestReadyAgeHours = oldestReadyCandidateAt
+    ? Math.max(0, Math.round((now.getTime() - Date.parse(oldestReadyCandidateAt)) / 3_600_000))
+    : null
+  const discoveredLast24Hours = discoveredResult.count || 0
+  const publishedLast24Hours = publishedResult.count || 0
+  const errorShare = readyBacklog > 0 ? errorsWaitingRetry / readyBacklog : 0
+  const state: CandidatePipelineHealth['state'] =
+    errorsWaitingRetry >= 20 && errorShare >= 0.25
+      ? 'degraded'
+      : readyBacklog >= 100 && (oldestReadyAgeHours || 0) >= 24
+        ? 'backlogged'
+        : discoveredLast24Hours === 0 && publishedLast24Hours === 0
+          ? 'idle'
+          : 'healthy'
+
+  return {
+    state,
+    counts,
+    total_candidates: CANDIDATE_PIPELINE_STATUSES.reduce((sum, status) => sum + counts[status], 0),
+    ready_backlog: readyBacklog,
+    errors_waiting_retry: errorsWaitingRetry,
+    discovered_last_24_hours: discoveredLast24Hours,
+    published_last_24_hours: publishedLast24Hours,
+    oldest_ready_candidate_at: oldestReadyCandidateAt,
+    oldest_ready_age_hours: oldestReadyAgeHours,
+    latest_candidate_at: latestCandidateResult.data?.discovered_at || null,
+    latest_publication_at: latestPublicationResult.data?.published_at || null,
+  }
+}
+
+export const getCandidatePipelineHealth = unstable_cache(
+  fetchCandidatePipelineHealth,
+  ['candidate-pipeline-health-v1'],
+  { revalidate: 300, tags: ['candidate-pipeline-health'] }
+)
+
+export async function getCandidatePipelineStats() {
+  return (await getCandidatePipelineHealth()).counts
 }

--- a/lib/indexer/run-log.ts
+++ b/lib/indexer/run-log.ts
@@ -1,0 +1,52 @@
+import 'server-only'
+
+import { createPublicClient } from '@/lib/supabase/public'
+
+export interface IndexerRunLog {
+  mode: string
+  status: string
+  started_at: string
+  completed_at?: string
+  filter_mode?: string
+  target_new?: number
+  min_stars?: number
+  max_search_requests?: number
+  search_requests?: number
+  candidates_found?: number
+  skipped_existing?: number
+  skipped_mcp?: number
+  skipped_low_relevance?: number
+  imported?: number
+  updated?: number
+  errors?: number
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Best-effort shared run logging for cron and indexer jobs. A telemetry outage
+ * must never turn a successful intake run into a failed run.
+ */
+export async function recordIndexerRun(run: IndexerRunLog) {
+  const serverSecret = process.env.INDEXER_SECRET?.trim()
+  if (!serverSecret) {
+    console.warn(`[indexer] Skipped ${run.mode} run log because INDEXER_SECRET is not configured.`)
+    return false
+  }
+
+  const supabase = createPublicClient({ requestTimeoutMs: 8_000 })
+  const { error } = await supabase.rpc('record_indexer_run', {
+    p_server_secret: serverSecret,
+    p_run: {
+      ...run,
+      completed_at: run.completed_at || new Date().toISOString(),
+      filter_mode: run.filter_mode || 'candidate-pipeline',
+      metadata: run.metadata || {},
+    },
+  })
+
+  if (error) {
+    console.error(`[indexer] Failed to record ${run.mode} run log:`, error.message)
+    return false
+  }
+  return true
+}

--- a/lib/seo/search-indexability.ts
+++ b/lib/seo/search-indexability.ts
@@ -4,7 +4,12 @@ import type { SkillRecord } from '@/lib/db/skills'
 // own. The full catalog stays available to people and agents, while this
 // threshold controls only public search surfaces such as sitemaps and detail
 // page robots metadata.
-export const SEARCH_INDEX_MIN_QUALITY_SCORE = 55
+// Production sampling showed that approved 50–54 records already carry
+// substantial repository evidence (typically 80+ GitHub stars, a concrete
+// description, and an installable source). Keeping the AI-review and adoption
+// gates while using 50 as the quality floor expands useful long-tail coverage
+// without turning the sitemap into a raw inventory dump.
+export const SEARCH_INDEX_MIN_QUALITY_SCORE = 50
 export const SEARCH_INDEX_MIN_GITHUB_STARS = 3
 
 type SearchIndexCandidate = Pick<

--- a/scripts/test-candidate-intake.ts
+++ b/scripts/test-candidate-intake.ts
@@ -12,6 +12,8 @@ import { shouldRetryAutomatedReview } from '../lib/indexer/review-retry.ts'
 import { AUTOMATIC_DISCOVERY_MIN_STARS, PUBLICATION_DAILY_TARGET, automaticPublicationCapacityPerDay, meetsAutomaticDiscoveryStarFloor } from '../lib/indexer/intake-policy.ts'
 // @ts-expect-error TS5097 is expected for this standalone test entrypoint.
 import { SKILL_SUBMISSION_MIN_STARS } from '../lib/skills/submission-policy.ts'
+// @ts-expect-error TS5097 is expected for this standalone test entrypoint.
+import { SEARCH_INDEX_MIN_GITHUB_STARS, SEARCH_INDEX_MIN_QUALITY_SCORE } from '../lib/seo/search-indexability.ts'
 
 const now = new Date('2026-09-01T00:00:00.000Z')
 const safe = {
@@ -45,6 +47,8 @@ assert.equal(meetsAutomaticDiscoveryStarFloor(20), true)
 assert.equal(SKILL_SUBMISSION_MIN_STARS, 0, 'direct user submissions must remain zero-star eligible')
 assert.equal(PUBLICATION_DAILY_TARGET, 1_000)
 assert.ok(automaticPublicationCapacityPerDay() > PUBLICATION_DAILY_TARGET)
+assert.equal(SEARCH_INDEX_MIN_QUALITY_SCORE, 50)
+assert.equal(SEARCH_INDEX_MIN_GITHUB_STARS, 3)
 
 assert.equal(
   buildCandidateSourceKey(12345, 'OldOwner/OldName', '/skills\\demo/SKILL.md/'),
@@ -102,10 +106,38 @@ assert.equal(
   vercelConfig.crons.find((cron) => cron.path === '/api/cron/skill-candidates-publish')?.schedule,
   '0,10,30,40 * * * *'
 )
+assert.equal(
+  vercelConfig.crons.find((cron) => cron.path === '/api/indexer/refresh-stars')?.schedule,
+  '30 2 * * *'
+)
+assert.equal(
+  vercelConfig.crons.find((cron) => cron.path === '/api/indexnow/submit')?.schedule,
+  '10 3 * * *'
+)
 
 const discoveryStatusRoute = readFileSync(new URL('../app/api/agent/discovery/route.ts', import.meta.url), 'utf8')
 assert.ok(discoveryStatusRoute.includes('schedule: `${SKILL_RADAR_CRON_MINUTE_UTC} * * * *`'))
 assert.ok(!discoveryStatusRoute.includes('at least 10 GitHub stars'))
+assert.ok(discoveryStatusRoute.includes("star_refresh_cron: '30 2 * * *'"))
+assert.ok(discoveryStatusRoute.includes("indexnow_cron: '10 3 * * *'"))
+assert.ok(discoveryStatusRoute.includes('observed_health: candidatePipelineHealth'))
+assert.ok(discoveryStatusRoute.includes('search_index_coverage:'))
+assert.ok(discoveryStatusRoute.includes("count: 'exact'"))
+
+const skillDatabase = readFileSync(new URL('../lib/db/skills.ts', import.meta.url), 'utf8')
+assert.ok(skillDatabase.includes("['approved-sitemap-count-v8']"))
+assert.ok(skillDatabase.includes("select('slug', { count: 'exact', head: true })"))
+
+for (const [route, mode] of [
+  ['../app/api/cron/skill-candidates-discover/route.ts', 'candidate-discovery'],
+  ['../app/api/cron/skill-candidates-validate/route.ts', 'candidate-validation'],
+  ['../app/api/cron/skill-candidates-publish/route.ts', 'candidate-publication'],
+] as const) {
+  const source = readFileSync(new URL(route, import.meta.url), 'utf8')
+  assert.ok(source.includes('recordIndexerRun({'), `${mode} must emit a durable run log`)
+  assert.ok(source.includes(`mode: '${mode}'`), `${mode} must use a stable log mode`)
+  assert.ok(source.includes("status: 'failed'"), `${mode} must record uncaught failures`)
+}
 
 const xStatusRoute = readFileSync(new URL('../app/api/x/status/route.ts', import.meta.url), 'utf8')
 assert.ok(xStatusRoute.includes("skillRadarCron: '45 * * * *'"))


### PR DESCRIPTION
## Summary
- log candidate discovery, validation, and publication runs with stable modes and failure telemetry
- expose cached live queue health, search coverage, and Creator Claim activation through the Agent discovery API
- expand evidence-backed sitemap eligibility from quality 55 to 50 and use cached exact counts to avoid empty or missing shards
- align documented cron schedules with Vercel configuration and document the operational contract

## Validation
- pnpm run test
- pnpm run lint (0 errors; existing warnings only)
- pnpm run typecheck
- pnpm run build
- local production HTTP verification: discovery API 200, 8,230 eligible Skill pages, 14 sitemap sections, final shard 230 URLs

## Deployment
No database migration or new environment variable is required. Candidate queue health uses the existing service-role credentials; when unavailable it fails closed to a clearly labelled temporarily_unavailable state.