### PR TITLE
Close the candidate publication target gap

### DIFF
--- a/app/api/agent/discovery/route.ts
+++ b/app/api/agent/discovery/route.ts
@@ -357,6 +357,10 @@ async function getRecentRuns(): Promise<Array<Record<string, unknown>>> {
     review_required: metadataValue(run, 'review_required'),
     duplicates: metadataValue(run, 'duplicates'),
     rejected: metadataValue(run, 'rejected'),
+    retries: metadataValue(run, 'retries'),
+    fast_track_claimed: metadataValue(run, 'fast_track_claimed'),
+    ai_review_claimed: metadataValue(run, 'ai_review_claimed'),
+    retry_claimed: metadataValue(run, 'retry_claimed'),
     published_last_24_hours: metadataValue(run, 'published_last_24_hours'),
     remaining_daily_target: metadataValue(run, 'remaining_daily_target'),
     target_reached: metadataValue(run, 'target_reached'),
@@ -536,7 +540,7 @@ export async function GET() {
     indexnow_frequency: 'daily baseline submission plus automatic submission after new skill imports',
     candidate_discovery_cron: '15 * * * *',
     candidate_validation_cron: '20,50 * * * *',
-    candidate_publication_cron: '0,10,30,40 * * * *',
+    candidate_publication_cron: '0,10,25,30,40,55 * * * *',
   }
   const estimatedDailyCapacity = scheduledHourlyTargetNew * 24
   const remainingToTarget =
@@ -683,7 +687,7 @@ export async function GET() {
         run_log_modes: ['candidate-discovery', 'candidate-validation', 'candidate-publication'],
         warning:
           candidatePipelineHealth?.state === 'backlogged'
-            ? 'The ready queue is more than 24 hours old and needs additional validation or publication throughput.'
+            ? 'The ready queue exceeds three daily publication targets or its oldest item is more than 24 hours old; additional validation or publication throughput is needed.'
             : candidatePipelineHealth?.state === 'degraded'
               ? 'At least 25% of the ready queue is waiting on validation or publication errors.'
               : candidatePipelineHealth?.state === 'idle'

--- a/app/api/cron/skill-candidates-publish/route.ts
+++ b/app/api/cron/skill-candidates-publish/route.ts
@@ -57,7 +57,13 @@ async function handleRun(request: NextRequest) {
 
     await recordIndexerRun({
       mode: 'candidate-publication',
-      status: result.rateLimited ? 'rate-limited' : result.errors > 0 ? 'completed-with-errors' : 'completed',
+      status: result.rateLimited
+        ? 'rate-limited'
+        : result.errors > 0
+          ? 'completed-with-errors'
+          : result.retries > 0
+            ? 'completed-with-retries'
+            : 'completed',
       started_at: startedAt,
       target_new: dailyTarget,
       candidates_found: result.claimed,

--- a/docs/candidate-intake-pipeline.md
+++ b/docs/candidate-intake-pipeline.md
@@ -11,7 +11,7 @@ OpenAgentSkill keeps discovery scale separate from public marketplace quality:
 | --- | --- | ---: | ---: |
 | GitHub discovery | hourly at `:15` | 22 searches × 100 results; repositories require 20+ stars | 52,800 result slots |
 | Light validation | hourly at `:20` and `:50` | 120 candidates/run | 5,760 candidates |
-| Public publication | `:00`, `:10`, `:30`, and `:40` hourly | 8 fast-track + 8 AI/retry slots per run | 1,536 capacity; 1,000 rolling-24h target |
+| Public publication | `:00`, `:10`, `:25`, `:30`, `:40`, and `:55` hourly | 8 fast-track + 8 AI/retry slots per run | 2,304 retry-aware capacity; 1,000 rolling-24h target |
 
 These are ceilings, not promised insert counts. Repository relevance filtering, stable identifiers, source URLs, exact content hashes, licenses, security checks, and existing registry records reduce the number of unique public skills.
 
@@ -51,6 +51,6 @@ Each scheduled stage writes a durable `indexer_runs` record using a stable mode:
 - `candidate-validation`
 - `candidate-publication`
 
-`GET /api/agent/discovery` exposes the recent stage runs plus a five-minute cached queue health snapshot. The snapshot includes per-status counts, ready backlog, retry errors, rolling 24-hour discovery/publication throughput, oldest ready age, and latest candidate/publication timestamps. Health is labelled `healthy`, `backlogged`, `degraded`, or `idle`; a theoretical daily capacity must not be treated as achieved throughput without these observed fields.
+`GET /api/agent/discovery` exposes the recent stage runs plus a five-minute cached queue health snapshot. The snapshot includes per-status counts, ready backlog, retry errors, rolling 24-hour discovery/publication throughput and target attainment, estimated drain time, oldest ready age, and latest candidate/publication timestamps. Health is labelled `healthy`, `backlogged`, `degraded`, or `idle`; a theoretical daily capacity must not be treated as achieved throughput without these observed fields.
 
 The same endpoint publishes a cached exact count of search-index-eligible Skill pages and Creator Claim activation. Search indexing remains stricter than registry inclusion: a page needs AI approval, a quality score of at least 50, and at least 3 GitHub stars. This keeps the full catalog available to people and agents while submitting only evidence-backed pages to crawlers. Sitemap shard counts use the same exact cached query so they cannot drift into empty or missing shards because of planner estimates.

--- a/lib/indexer/candidate-intake.ts
+++ b/lib/indexer/candidate-intake.ts
@@ -76,6 +76,10 @@ export interface CandidatePipelineHealth {
   errors_waiting_retry: number
   discovered_last_24_hours: number
   published_last_24_hours: number
+  publication_target_per_24_hours: number
+  publication_attainment_percent: number
+  publication_gap: number
+  estimated_days_to_clear_ready_backlog: number | null
   oldest_ready_candidate_at: string | null
   oldest_ready_age_hours: number | null
   latest_candidate_at: string | null
@@ -671,11 +675,18 @@ async function fetchCandidatePipelineHealth(now = new Date()): Promise<Candidate
     : null
   const discoveredLast24Hours = discoveredResult.count || 0
   const publishedLast24Hours = publishedResult.count || 0
+  const publicationAttainmentPercent = Number(
+    ((publishedLast24Hours / PUBLICATION_DAILY_TARGET) * 100).toFixed(1)
+  )
+  const estimatedDaysToClearReadyBacklog = publishedLast24Hours > 0
+    ? Number((readyBacklog / publishedLast24Hours).toFixed(1))
+    : null
   const errorShare = readyBacklog > 0 ? errorsWaitingRetry / readyBacklog : 0
   const state: CandidatePipelineHealth['state'] =
     errorsWaitingRetry >= 20 && errorShare >= 0.25
       ? 'degraded'
-      : readyBacklog >= 100 && (oldestReadyAgeHours || 0) >= 24
+      : readyBacklog >= PUBLICATION_DAILY_TARGET * 3 ||
+          (readyBacklog >= 100 && (oldestReadyAgeHours || 0) >= 24)
         ? 'backlogged'
         : discoveredLast24Hours === 0 && publishedLast24Hours === 0
           ? 'idle'
@@ -689,6 +700,10 @@ async function fetchCandidatePipelineHealth(now = new Date()): Promise<Candidate
     errors_waiting_retry: errorsWaitingRetry,
     discovered_last_24_hours: discoveredLast24Hours,
     published_last_24_hours: publishedLast24Hours,
+    publication_target_per_24_hours: PUBLICATION_DAILY_TARGET,
+    publication_attainment_percent: publicationAttainmentPercent,
+    publication_gap: Math.max(PUBLICATION_DAILY_TARGET - publishedLast24Hours, 0),
+    estimated_days_to_clear_ready_backlog: estimatedDaysToClearReadyBacklog,
     oldest_ready_candidate_at: oldestReadyCandidateAt,
     oldest_ready_age_hours: oldestReadyAgeHours,
     latest_candidate_at: latestCandidateResult.data?.discovered_at || null,

--- a/lib/indexer/intake-policy.ts
+++ b/lib/indexer/intake-policy.ts
@@ -2,7 +2,11 @@ export const AUTOMATIC_DISCOVERY_MIN_STARS = 20
 export const PUBLICATION_DAILY_TARGET = 1_000
 export const PUBLICATION_FAST_TRACK_PER_RUN = 8
 export const PUBLICATION_AI_REVIEW_PER_RUN = 8
-export const PUBLICATION_RUNS_PER_DAY = 96
+// Six windows per hour provide enough retry headroom to reach the rolling
+// 1,000/day target when some AI-reviewed candidates time out or are rejected.
+// The publication worker still stops at PUBLICATION_DAILY_TARGET, so this
+// increases resilience rather than raising the public release ceiling.
+export const PUBLICATION_RUNS_PER_DAY = 144
 
 export function meetsAutomaticDiscoveryStarFloor(stars: number | null | undefined) {
   return Number(stars || 0) >= AUTOMATIC_DISCOVERY_MIN_STARS

--- a/scripts/test-candidate-intake.ts
+++ b/scripts/test-candidate-intake.ts
@@ -9,7 +9,7 @@ import { buildCandidateSourceKey, canonicalGitHubSourceUrl } from '../lib/indexe
 // @ts-expect-error TS5097 is expected for this standalone test entrypoint.
 import { shouldRetryAutomatedReview } from '../lib/indexer/review-retry.ts'
 // @ts-expect-error TS5097 is expected for this standalone test entrypoint.
-import { AUTOMATIC_DISCOVERY_MIN_STARS, PUBLICATION_DAILY_TARGET, automaticPublicationCapacityPerDay, meetsAutomaticDiscoveryStarFloor } from '../lib/indexer/intake-policy.ts'
+import { AUTOMATIC_DISCOVERY_MIN_STARS, PUBLICATION_DAILY_TARGET, PUBLICATION_RUNS_PER_DAY, automaticPublicationCapacityPerDay, meetsAutomaticDiscoveryStarFloor } from '../lib/indexer/intake-policy.ts'
 // @ts-expect-error TS5097 is expected for this standalone test entrypoint.
 import { SKILL_SUBMISSION_MIN_STARS } from '../lib/skills/submission-policy.ts'
 // @ts-expect-error TS5097 is expected for this standalone test entrypoint.
@@ -46,6 +46,7 @@ assert.equal(meetsAutomaticDiscoveryStarFloor(19), false)
 assert.equal(meetsAutomaticDiscoveryStarFloor(20), true)
 assert.equal(SKILL_SUBMISSION_MIN_STARS, 0, 'direct user submissions must remain zero-star eligible')
 assert.equal(PUBLICATION_DAILY_TARGET, 1_000)
+assert.equal(PUBLICATION_RUNS_PER_DAY, 144)
 assert.ok(automaticPublicationCapacityPerDay() > PUBLICATION_DAILY_TARGET)
 assert.equal(SEARCH_INDEX_MIN_QUALITY_SCORE, 50)
 assert.equal(SEARCH_INDEX_MIN_GITHUB_STARS, 3)
@@ -104,7 +105,7 @@ const vercelConfig = JSON.parse(readFileSync(new URL('../vercel.json', import.me
 }
 assert.equal(
   vercelConfig.crons.find((cron) => cron.path === '/api/cron/skill-candidates-publish')?.schedule,
-  '0,10,30,40 * * * *'
+  '0,10,25,30,40,55 * * * *'
 )
 assert.equal(
   vercelConfig.crons.find((cron) => cron.path === '/api/indexer/refresh-stars')?.schedule,

--- a/vercel.json
+++ b/vercel.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "/api/cron/skill-candidates-publish",
-      "schedule": "0,10,30,40 * * * *"
+      "schedule": "0,10,25,30,40,55 * * * *"
     },
     {
       "path": "/api/cron/skill-source-sync",


### PR DESCRIPTION
## Summary
- add two retry-aware publication windows per hour while retaining the rolling 1,000/day hard stop
- report target attainment, publication gap, backlog drain estimate, and retry counts
- classify a queue above three daily targets as backlogged even before its oldest item reaches 24 hours
- distinguish successful batches that still scheduled safe retries

## Production evidence
The first observed batch processed 16 candidates in 3m19s: 11 published, 2 rejected, 3 retried, 0 hard errors, no rate limit, no time-budget exhaustion. Rolling 24h publication was 839/1,000.

## Validation
- pnpm run test:candidate-intake
- pnpm run typecheck
- pnpm run build

No schema or environment changes. The 1,000/day publication guard is unchanged.