### PR TITLE
Fix homepage skill count fallback caching

### DIFF
--- a/lib/home-page-data.ts
+++ b/lib/home-page-data.ts
@@ -9,39 +9,45 @@ import { getGitHubOwner } from '@/lib/github-owner'
 
 const HOME_STATS_SNAPSHOT = {
   // The last exact count observed before the registry stats cache was added.
-  // A fallback is explicitly rendered with "+" so an upstream timeout cannot
-  // look like the registry lost indexed skills.
+  // Keep this deploy-time safety net close to the latest verified production
+  // value. It is used only on a cold cache when the counter is unavailable.
   totalSkills: LAST_VERIFIED_APPROVED_SKILL_COUNT,
 }
 
-const HOME_STATS_QUERY_TIMEOUT_MS = 1_500
+const HOME_STATS_QUERY_TIMEOUT_MS = 2_000
 
 export interface HomeSkillCount {
   value: number
   exact: boolean
 }
 
-async function fetchApprovedSkillCount(): Promise<HomeSkillCount> {
+async function fetchExactApprovedSkillCount(): Promise<HomeSkillCount> {
   const result = await getApprovedRegistrySkillCount(HOME_STATS_QUERY_TIMEOUT_MS)
-  if (result === null) {
-    return { value: HOME_STATS_SNAPSHOT.totalSkills, exact: false }
-  }
-
-  if (!result.exact) {
-    return {
-      value: Math.max(result.count, HOME_STATS_SNAPSHOT.totalSkills),
-      exact: false,
-    }
+  if (!result?.exact) {
+    // Do not turn a timeout or planner estimate into a five-minute cached
+    // regression. Rejecting lets Next keep serving the last successful value
+    // during stale-while-revalidate; the caller owns the cold-cache fallback.
+    throw new Error('Exact approved skill count is temporarily unavailable')
   }
 
   return { value: result.count, exact: true }
 }
 
-const getCachedApprovedSkillCount = unstable_cache(
-  fetchApprovedSkillCount,
-  ['home-approved-skill-count-v2'],
+const getCachedExactApprovedSkillCount = unstable_cache(
+  fetchExactApprovedSkillCount,
+  ['home-approved-skill-count-v3'],
   { revalidate: 300 }
 )
+
+async function getStableApprovedSkillCount(): Promise<HomeSkillCount> {
+  try {
+    return await getCachedExactApprovedSkillCount()
+  } catch {
+    // This path is intentionally outside unstable_cache. A transient database
+    // failure can never overwrite a newer cached count with this snapshot.
+    return { value: HOME_STATS_SNAPSHOT.totalSkills, exact: false }
+  }
+}
 
 async function fetchEvidenceStats() {
   try {
@@ -79,7 +85,7 @@ const getCachedEvidenceStats = unstable_cache(
 
 export async function getHomePageData() {
   const [totalSkills, evidence, popularitySnapshot, trendingSnapshot] = await Promise.all([
-    getCachedApprovedSkillCount(),
+    getStableApprovedSkillCount(),
     getCachedEvidenceStats(),
     getLatestRankingSnapshot('most-starred-agent-skills'),
     getLatestRankingSnapshot('trending'),

--- a/lib/registry-stats.ts
+++ b/lib/registry-stats.ts
@@ -1,7 +1,7 @@
 import { withTimeout } from '@/lib/async'
 import { createPublicClient } from '@/lib/supabase/public'
 
-export const LAST_VERIFIED_APPROVED_SKILL_COUNT = 20_545
+export const LAST_VERIFIED_APPROVED_SKILL_COUNT = 23_569
 
 export interface RegistrySkillCount {
   count: number

--- a/scripts/test-performance-regressions.ts
+++ b/scripts/test-performance-regressions.ts
@@ -43,4 +43,26 @@ assert.match(rootLayout, /<SpeedInsights \/>/, 'real-user Core Web Vitals monito
 const siteHeader = read('components/site-header.tsx')
 assert.match(siteHeader, /onPointerDown=\{\(\) => warmRoute\(href\)\}/, 'touch navigation should warm primary routes before transition')
 
+const homePageData = read('lib/home-page-data.ts')
+assert.match(
+  homePageData,
+  /const getCachedExactApprovedSkillCount = unstable_cache\(\s*fetchExactApprovedSkillCount/,
+  'the homepage must cache only exact registry counts'
+)
+assert.match(
+  homePageData,
+  /throw new Error\('Exact approved skill count is temporarily unavailable'\)/,
+  'timeouts and planner estimates must reject instead of poisoning the homepage cache'
+)
+assert.match(
+  homePageData,
+  /async function getStableApprovedSkillCount[\s\S]+?getCachedExactApprovedSkillCount\(\)[\s\S]+?HOME_STATS_SNAPSHOT\.totalSkills/,
+  'the cold-cache snapshot fallback must remain outside unstable_cache'
+)
+assert.doesNotMatch(
+  homePageData,
+  /unstable_cache\(\s*fetchApprovedSkillCount/,
+  'fallback counts must never be stored in the homepage data cache'
+)
+
 console.log('Performance regression tests passed.')


### PR DESCRIPTION
## Summary
- cache only successful exact approved-skill counts
- keep the deploy-time snapshot outside the shared cache as a cold-cache fallback
- update the verified snapshot and add a regression test

## Verification
- performance regression tests
- TypeScript typecheck
- Next.js production build
- Supabase registry counter matched exact approved row count