### PR TITLE
Add Gallery logo tag and curated product video skills

### DIFF
--- a/app/showcase/page.tsx
+++ b/app/showcase/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { ShowcaseGallery } from '@/components/showcase-gallery'
 import { I18nProvider } from '@/lib/i18n/context'
 import { getLocaleFromSearchParam } from '@/lib/i18n/config'
-import { filterShowcaseCases, getShowcasePage, localizeShowcase, SHOWCASE_CASES, SHOWCASE_CATEGORIES, SHOWCASE_SKILLS } from '@/lib/showcase'
+import { filterShowcaseCases, getShowcasePage, localizeShowcase, SHOWCASE_CASES, SHOWCASE_CATEGORIES, SHOWCASE_SKILLS, SHOWCASE_TAGS } from '@/lib/showcase'
 
 const BASE_URL = 'https://www.openagentskill.com'
 type Props = { searchParams: Promise<Record<string, string | string[] | undefined>> }
@@ -12,7 +12,7 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
   const zh = getLocaleFromSearchParam(params.lang) === 'zh'
   const rawPage = Array.isArray(params.page) ? params.page[0] : params.page
   const { page } = getShowcasePage(SHOWCASE_CASES, rawPage)
-  const filtered = Boolean(params.q || params.category || params.creator || params.lang || params.sort)
+  const filtered = Boolean(params.q || params.category || params.creator || params.lang || params.sort || params.tag)
   const canonical = `${BASE_URL}/showcase${!filtered && page > 1 ? `?page=${page}` : ''}`
   const pageLabel = page > 1 ? (zh ? ` — 第 ${page} 页` : ` — Page ${page}`) : ''
   const title = zh ? `Skill Gallery — 技能作品集与作者${pageLabel} | OpenAgentSkill` : `Skill Gallery — Agent Skills, Creative Work & Creators${pageLabel} | OpenAgentSkill`
@@ -31,7 +31,9 @@ export default async function ShowcasePage({ searchParams }: Props) {
   const query = (Array.isArray(params.q) ? params.q[0] : params.q) || ''
   const rawCreator = (Array.isArray(params.creator) ? params.creator[0] : params.creator) || ''
   const creatorId = SHOWCASE_SKILLS.some((skill) => skill.creatorId === rawCreator) ? rawCreator : ''
-  const cases = filterShowcaseCases(category, query, creatorId)
+  const rawTag = Array.isArray(params.tag) ? params.tag[0] : params.tag
+  const tagId = SHOWCASE_TAGS.find((tag) => tag.id === rawTag)?.id || ''
+  const cases = filterShowcaseCases(category, query, creatorId, tagId)
   const pagination = getShowcasePage(cases, Array.isArray(params.page) ? params.page[0] : params.page)
   const schema = {
     '@context': 'https://schema.org', '@type': 'CollectionPage', name: 'Skill Gallery', url: `${BASE_URL}/showcase`,

--- a/components/showcase-card.tsx
+++ b/components/showcase-card.tsx
@@ -8,7 +8,7 @@ import { getLocalizedNavigationHref } from '@/lib/i18n/market-routing'
 import { trackAnalyticsEvent } from '@/lib/analytics'
 import { ShowcaseCreatorCredit } from '@/components/showcase-creator'
 import { ShowcaseActions } from '@/components/showcase-engagement'
-import { getShowcaseAccessLabel, getShowcaseEvidenceLabel, getShowcaseImageSrc, getShowcaseSkill, localizeShowcase, SHOWCASE_CATEGORIES, type ShowcaseCase } from '@/lib/showcase'
+import { getShowcaseAccessLabel, getShowcaseEvidenceLabel, getShowcaseImageSrc, getShowcaseSkill, getShowcaseTags, localizeShowcase, SHOWCASE_CATEGORIES, type ShowcaseCase } from '@/lib/showcase'
 
 export function ShowcaseCard({ item, placement = 'gallery', priority = false }: {
   item: ShowcaseCase
@@ -53,6 +53,7 @@ export function ShowcaseCard({ item, placement = 'gallery', priority = false }: 
           <p className="mt-2 line-clamp-2 min-h-[2.875rem] text-sm leading-relaxed text-[#6d675e]">{localizeShowcase(item.description, locale)}</p>
         </div>
       </Link>
+      {getShowcaseTags(item).map((tag) => <Link key={tag.id} prefetch={false} href={`/showcase?tag=${tag.id}${locale === 'zh' ? '&lang=zh' : ''}`} className="mt-3 inline-flex min-h-9 items-center rounded-full border border-[#e4e0d8] px-3 text-xs text-[#006b4f] hover:border-[#006b4f]">{localizeShowcase(tag.label, locale)}</Link>)}
       <div className="mt-4 flex min-w-0 items-center justify-between gap-3 border-t border-[#e4e0d8] pt-3">
         <ShowcaseCreatorCredit creatorId={skill.creatorId} label={locale === 'zh' ? '技能作者' : 'Skill by'} />
         <Link href={getLocalizedNavigationHref(`/skills/${item.skillSlug}`, locale)} className="shrink-0 rounded border border-[#e4e0d8] px-2 py-1 text-[10px] text-[#6d675e] hover:border-[#006b4f] hover:text-[#006b4f]" title={`${skill.name} · ${skill.sourceLicense}`}>

--- a/components/showcase-detail.tsx
+++ b/components/showcase-detail.tsx
@@ -13,7 +13,7 @@ import { useI18n } from '@/lib/i18n/context'
 import { getLocalizedNavigationHref } from '@/lib/i18n/market-routing'
 import { copyText } from '@/lib/copy-text'
 import { trackAnalyticsEvent } from '@/lib/analytics'
-import { getShowcaseAccessLabel, getShowcaseCreator, getShowcaseEvidenceLabel, getShowcaseHandoff, getShowcaseImageSrc, getShowcaseSkill, localizeShowcase, SHOWCASE_CASES, SHOWCASE_CATEGORIES, type ShowcaseCase } from '@/lib/showcase'
+import { getShowcaseAccessLabel, getShowcaseCreator, getShowcaseEvidenceLabel, getShowcaseHandoff, getShowcaseImageSrc, getShowcaseSkill, getShowcaseTags, localizeShowcase, SHOWCASE_CASES, SHOWCASE_CATEGORIES, type ShowcaseCase } from '@/lib/showcase'
 
 export function ShowcaseDetail({ item }: { item: ShowcaseCase }) {
   return <ShowcaseEngagementProvider><DetailContent key={item.slug} item={item} /></ShowcaseEngagementProvider>
@@ -92,6 +92,7 @@ function DetailContent({ item }: { item: ShowcaseCase }) {
             <Link href={getLocalizedNavigationHref(`/skills/${item.skillSlug}`, locale)} className="inline-flex items-center gap-1.5 rounded border border-[#e4e0d8] px-3 py-2 text-xs text-[#006b4f]">{getShowcaseAccessLabel(skill, locale)} · {skill.sourceLicense}<ArrowUpRight className="h-3 w-3" aria-hidden="true" /></Link>
           </div>
           <ShowcaseActions item={item} />
+          {getShowcaseTags(item).map((tag) => <Link key={tag.id} prefetch={false} href={`/showcase?tag=${tag.id}${zh ? '&lang=zh' : ''}`} className="mt-3 inline-flex min-h-11 items-center rounded-full border border-[#e4e0d8] px-3 text-xs text-[#006b4f] hover:border-[#006b4f]">{localizeShowcase(tag.label, locale)}</Link>)}
           <a href="#make-your-own" className="mt-5 inline-flex min-h-11 items-center gap-2 rounded-md bg-[#006b4f] px-4 text-sm font-semibold text-white hover:bg-[#005640] lg:hidden">
             {zh ? '复制任务并开始使用' : 'Copy task & get started'}<ArrowRight className="h-4 w-4" aria-hidden="true" />
           </a>

--- a/components/showcase-gallery.tsx
+++ b/components/showcase-gallery.tsx
@@ -109,7 +109,7 @@ function GalleryContent() {
             {SHOWCASE_TAGS.map((tag) => <button key={tag.id} type="button" aria-pressed={tagId === tag.id} onClick={() => filter(category, query, creatorId, sort, tagId === tag.id ? '' : tag.id)} className={`inline-flex min-h-11 items-center gap-2 rounded-full border px-3 text-xs ${tagId === tag.id ? 'border-[#006b4f] bg-[#edf3ee] text-[#006b4f]' : 'border-[#e4e0d8] text-[#6d675e] hover:border-[#006b4f]'}`}>
               {localizeShowcase(tag.label, locale)}<span className="font-mono text-[10px]">{filterShowcaseCases(category, query, creatorId, tag.id).length}</span>
             </button>)}
-            <Link prefetch={false} href={`/showcase?category=video${zh ? '&lang=zh' : ''}#video-skills`} className="inline-flex min-h-11 items-center gap-2 px-2 text-xs text-[#006b4f] underline-offset-4 hover:underline">{zh ? 'AI 产品视频与剪辑技能' : 'AI product video & editing skills'}<ArrowRight className="h-3 w-3" aria-hidden="true" /></Link>
+            <Link prefetch={false} href={`/showcase?category=video${zh ? '&lang=zh' : ''}#video-skills`} onClick={() => document.getElementById('video-skills')?.scrollIntoView({ block: 'start' })} className="inline-flex min-h-11 items-center gap-2 px-2 text-xs text-[#006b4f] underline-offset-4 hover:underline">{zh ? 'AI 产品视频与剪辑技能' : 'AI product video & editing skills'}<ArrowRight className="h-3 w-3" aria-hidden="true" /></Link>
           </div>
           <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
             <div className="flex flex-wrap items-center gap-3">

--- a/components/showcase-gallery.tsx
+++ b/components/showcase-gallery.tsx
@@ -7,12 +7,13 @@ import { ArrowRight, Search, X } from 'lucide-react'
 import { SiteHeader } from '@/components/site-header'
 import { SiteFooter } from '@/components/site-footer'
 import { ShowcaseCard } from '@/components/showcase-card'
+import { ShowcaseVideoSkills } from '@/components/showcase-video-skills'
 import { ShowcaseEngagementProvider, useShowcaseEngagement } from '@/components/showcase-engagement'
 import { sortShowcaseCases, type ShowcaseSort } from '@/lib/showcase-engagement'
 import { useI18n } from '@/lib/i18n/context'
 import { getLocalizedNavigationHref } from '@/lib/i18n/market-routing'
 import { trackAnalyticsEvent } from '@/lib/analytics'
-import { filterShowcaseCases, getShowcaseCreator, getShowcasePage, localizeShowcase, SHOWCASE_CASES, SHOWCASE_CATEGORIES, SHOWCASE_SKILLS } from '@/lib/showcase'
+import { filterShowcaseCases, getShowcaseCreator, getShowcasePage, localizeShowcase, SHOWCASE_CASES, SHOWCASE_CATEGORIES, SHOWCASE_SKILLS, SHOWCASE_TAGS } from '@/lib/showcase'
 
 export function ShowcaseGallery() {
   return <ShowcaseEngagementProvider><GalleryContent /></ShowcaseEngagementProvider>
@@ -26,12 +27,13 @@ function GalleryContent() {
   const rawCategory = params.get('category') || 'all'
   const category = SHOWCASE_CATEGORIES.some((entry) => entry.id === rawCategory) ? rawCategory : 'all'
   const query = params.get('q') || ''
+  const tagId = SHOWCASE_TAGS.find((tag) => tag.id === params.get('tag'))?.id || ''
   const rawCreator = params.get('creator') || ''
   const creatorId = SHOWCASE_SKILLS.some((skill) => skill.creatorId === rawCreator) ? rawCreator : ''
   const viewed = useRef(false)
   const { stats, ready, failed, refresh } = useShowcaseEngagement()
   const sort: ShowcaseSort = params.get('sort') === 'top' ? 'top' : 'curated'
-  const cases = sortShowcaseCases(filterShowcaseCases(category, query, creatorId), ready ? sort : 'curated', stats)
+  const cases = sortShowcaseCases(filterShowcaseCases(category, query, creatorId, tagId), ready ? sort : 'curated', stats)
   const pagination = getShowcasePage(cases, params.get('page'))
   const workflowCount = new Set(SHOWCASE_CASES.map((item) => item.skillSlug)).size
 
@@ -41,9 +43,11 @@ function GalleryContent() {
     trackAnalyticsEvent('showcase_view', { placement: 'gallery' })
   }, [])
 
-  function filter(nextCategory: string, nextQuery: string, nextCreator = creatorId, nextSort = sort) {
+  function filter(nextCategory: string, nextQuery: string, nextCreator = creatorId, nextSort = sort, nextTag = tagId) {
     const next = new URLSearchParams(params.toString())
     next.delete('page')
+    if (nextTag) next.set('tag', nextTag)
+    else next.delete('tag')
     if (nextCategory === 'all') next.delete('category')
     else next.set('category', nextCategory)
     if (nextQuery.trim()) next.set('q', nextQuery.trim())
@@ -53,7 +57,7 @@ function GalleryContent() {
     if (nextSort === 'curated') next.delete('sort')
     else next.set('sort', nextSort)
     router.push(`/showcase${next.size ? `?${next}` : ''}`, { scroll: false })
-    trackAnalyticsEvent('showcase_filter', { category: nextCategory, has_query: Boolean(nextQuery.trim()), creator_id: nextCreator || undefined, sort: nextSort })
+    trackAnalyticsEvent('showcase_filter', { category: nextCategory, has_query: Boolean(nextQuery.trim()), creator_id: nextCreator || undefined, sort: nextSort, tag: nextTag || undefined })
   }
 
   function pageHref(page: number) {
@@ -100,10 +104,17 @@ function GalleryContent() {
               <button type="submit" aria-label={zh ? '搜索' : 'Search'} className="flex h-11 w-11 shrink-0 items-center justify-center text-[#006b4f]"><ArrowRight className="h-4 w-4" aria-hidden="true" /></button>
             </form>
           </div>
+          <div className="mt-4 flex flex-wrap items-center gap-2" aria-label={zh ? '用途标签' : 'Use-case tags'}>
+            <span className="mr-1 text-xs text-[#6d675e]">{zh ? '用途' : 'Use case'}</span>
+            {SHOWCASE_TAGS.map((tag) => <button key={tag.id} type="button" aria-pressed={tagId === tag.id} onClick={() => filter(category, query, creatorId, sort, tagId === tag.id ? '' : tag.id)} className={`inline-flex min-h-11 items-center gap-2 rounded-full border px-3 text-xs ${tagId === tag.id ? 'border-[#006b4f] bg-[#edf3ee] text-[#006b4f]' : 'border-[#e4e0d8] text-[#6d675e] hover:border-[#006b4f]'}`}>
+              {localizeShowcase(tag.label, locale)}<span className="font-mono text-[10px]">{filterShowcaseCases(category, query, creatorId, tag.id).length}</span>
+            </button>)}
+            <Link prefetch={false} href={`/showcase?category=video${zh ? '&lang=zh' : ''}#video-skills`} className="inline-flex min-h-11 items-center gap-2 px-2 text-xs text-[#006b4f] underline-offset-4 hover:underline">{zh ? 'AI 产品视频与剪辑技能' : 'AI product video & editing skills'}<ArrowRight className="h-3 w-3" aria-hidden="true" /></Link>
+          </div>
           <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
             <div className="flex flex-wrap items-center gap-3">
               <p aria-live="polite" role="status" className="text-xs text-[#6d675e]">{zh ? `${cases.length} 个案例${cases.length ? ` · 当前 ${pagination.offset + 1}–${pagination.offset + pagination.items.length}` : ''}${query ? `，搜索“${query}”` : ''}` : `${cases.length} ${cases.length === 1 ? 'example' : 'examples'}${cases.length ? ` · Showing ${pagination.offset + 1}–${pagination.offset + pagination.items.length}` : ''}${query ? ` for “${query}”` : ''}`}</p>
-              {(query || category !== 'all' || creatorId) && <button type="button" onClick={() => filter('all', '', '')} className="inline-flex min-h-11 items-center gap-1 text-xs text-[#006b4f]"><X className="h-3 w-3" aria-hidden="true" />{zh ? '清除筛选' : 'Clear filters'}</button>}
+              {(query || category !== 'all' || creatorId || tagId) && <button type="button" onClick={() => filter('all', '', '', sort, '')} className="inline-flex min-h-11 items-center gap-1 text-xs text-[#006b4f]"><X className="h-3 w-3" aria-hidden="true" />{zh ? '清除筛选' : 'Clear filters'}</button>}
             </div>
             <div className="flex max-w-full flex-wrap gap-2">
             <select value={creatorId} onChange={(event) => filter(category, query, event.target.value)} aria-label={zh ? '按技能作者筛选' : 'Filter by skill creator'} className="min-h-11 max-w-full rounded-md border border-[#e4e0d8] bg-transparent px-3 text-base text-[#6d675e] focus-visible:outline-[#006b4f] sm:text-xs">
@@ -120,13 +131,14 @@ function GalleryContent() {
           {cases.length ? <div className="mt-5 grid gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-3">{pagination.items.map((item, index) => <ShowcaseCard key={item.slug} item={item} priority={index < 3} />)}</div> : <div className="py-24 text-center">
             <h2 className="font-display text-3xl">{zh ? '还没有匹配的作品' : 'No examples just yet.'}</h2>
             <p className="mt-3 text-sm text-[#6d675e]">{zh ? '试试其他关键词，或清除筛选查看全部作品。' : 'Try a different search, or clear the filters to see all work.'}</p>
-            <button type="button" onClick={() => filter('all', '', '')} className="mt-6 rounded-md bg-[#006b4f] px-5 py-3 text-sm font-semibold text-white">{zh ? '查看全部作品' : 'See all work'}</button>
+            <button type="button" onClick={() => filter('all', '', '', sort, '')} className="mt-6 rounded-md bg-[#006b4f] px-5 py-3 text-sm font-semibold text-white">{zh ? '查看全部作品' : 'See all work'}</button>
           </div>}
           {pagination.pageCount > 1 && <nav aria-label={zh ? '作品分页' : 'Gallery pagination'} className="mt-12 flex flex-wrap items-center justify-center gap-2">
             {pagination.page > 1 && <Link prefetch={false} href={pageHref(pagination.page - 1)} className="inline-flex min-h-11 items-center rounded-md border border-[#e4e0d8] px-4 text-sm">{zh ? '上一页' : 'Previous'}</Link>}
             {Array.from({ length: pagination.pageCount }, (_, index) => index + 1).map((page) => <Link key={page} prefetch={false} href={pageHref(page)} aria-current={page === pagination.page ? 'page' : undefined} aria-label={zh ? `第 ${page} 页` : `Page ${page}`} className={`inline-flex h-11 min-w-11 items-center justify-center rounded-md border px-3 text-sm ${page === pagination.page ? 'border-[#006b4f] bg-[#006b4f] text-white' : 'border-[#e4e0d8] text-[#6d675e] hover:border-[#006b4f]'}`}>{page}</Link>)}
             {pagination.page < pagination.pageCount && <Link prefetch={false} href={pageHref(pagination.page + 1)} className="inline-flex min-h-11 items-center rounded-md border border-[#e4e0d8] px-4 text-sm">{zh ? '下一页' : 'Next'}</Link>}
           </nav>}
+          {category === 'video' && !tagId && !query && !creatorId && <ShowcaseVideoSkills locale={locale} />}
           <div className="mt-16 flex flex-col gap-4 border-t border-[#e4e0d8] pt-7 sm:flex-row sm:items-center sm:justify-between">
             <p className="max-w-xl text-sm leading-relaxed text-[#6d675e]">{zh ? '精选作者作品、可复用模板与风格示例，分别标注，另有本站实际制作。每项注明来源、使用条件和提示词性质；作者预览不代表本站复测成功，同一作品的多张截图仅计一项。' : 'Curated work, reusable templates and style studies are labeled separately, alongside work made here. Each names its source, requirements and prompt status. Author previews are not platform retests; multiple views of one work count once.'}</p>
             <Link href={getLocalizedNavigationHref('/skills', locale)} className="inline-flex shrink-0 items-center gap-2 text-sm font-semibold text-[#006b4f]">{zh ? '浏览全部技能' : 'Explore the skill registry'}<ArrowRight className="h-4 w-4" aria-hidden="true" /></Link>

--- a/components/showcase-video-skills.tsx
+++ b/components/showcase-video-skills.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+import { SHOWCASE_VIDEO_SKILLS } from '@/lib/showcase-video-skills'
+import { localizeShowcase } from '@/lib/showcase'
+import { getLocalizedNavigationHref } from '@/lib/i18n/market-routing'
+import type { Locale } from '@/lib/i18n/config'
+
+export function ShowcaseVideoSkills({ locale }: { locale: Locale }) {
+  const zh = locale === 'zh'
+  return <section id="video-skills" aria-labelledby="video-skills-heading" className="mt-12 scroll-mt-24 border-t border-[#e4e0d8] pt-8">
+    <p className="font-mono text-[10px] uppercase tracking-widest text-[#006b4f]">{zh ? '技能精选 · 非作品案例' : 'Skill selection · separate from examples'}</p>
+    <h2 id="video-skills-heading" className="mt-3 font-display text-3xl">{zh ? 'AI 产品视频与剪辑' : 'AI product video & editing'}</h2>
+    <p className="mt-3 max-w-3xl text-sm leading-relaxed text-[#6d675e]">{zh ? '按任务选择工具。以下是技能目录入口，不计入作品数量，也不代表本站运行验证；安装前请查看详情页的当前审核状态与使用条件。' : 'Choose by task. These registry links are not extra Gallery examples or runtime verification. Read the detail page for current review status and requirements before installing.'}</p>
+    <ul className="mt-6 divide-y divide-[#e4e0d8]">
+      {SHOWCASE_VIDEO_SKILLS.map((skill) => <li key={skill.slug} className="grid gap-2 py-5 first:pt-0 sm:grid-cols-[1fr_2fr] sm:gap-8">
+        <div><Link prefetch={false} href={getLocalizedNavigationHref(`/skills/${skill.slug}`, locale)} className="inline-flex min-h-11 items-center text-sm font-semibold text-[#006b4f] underline-offset-4 hover:underline">{skill.name} <span aria-hidden="true" className="ml-2">→</span></Link></div>
+        <div>
+          <p className="text-sm leading-relaxed">{localizeShowcase(skill.purpose, locale)}</p>
+          <p className="mt-2 text-xs leading-relaxed text-[#6d675e]">{localizeShowcase(skill.requirements, locale)}</p>
+          <a href={skill.source} target="_blank" rel="noreferrer noopener" className="inline-flex min-h-11 items-center text-xs text-[#6d675e] underline underline-offset-4">{zh ? '查看来源版本' : 'View inspected source'}</a>
+        </div>
+      </li>)}
+    </ul>
+  </section>
+}

--- a/components/showcase-video-skills.tsx
+++ b/components/showcase-video-skills.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
 import Link from 'next/link'
 import { SHOWCASE_VIDEO_SKILLS } from '@/lib/showcase-video-skills'
 import { localizeShowcase } from '@/lib/showcase'
@@ -6,7 +9,13 @@ import type { Locale } from '@/lib/i18n/config'
 
 export function ShowcaseVideoSkills({ locale }: { locale: Locale }) {
   const zh = locale === 'zh'
-  return <section id="video-skills" aria-labelledby="video-skills-heading" className="mt-12 scroll-mt-24 border-t border-[#e4e0d8] pt-8">
+  const sectionRef = useRef<HTMLElement>(null)
+  useEffect(() => {
+    // The target is mounted after the query transition, so native hash scrolling
+    // can run before it exists. Also covers a shared URL opened directly.
+    if (window.location.hash === '#video-skills') sectionRef.current?.scrollIntoView({ block: 'start' })
+  }, [])
+  return <section ref={sectionRef} id="video-skills" aria-labelledby="video-skills-heading" className="mt-12 scroll-mt-24 border-t border-[#e4e0d8] pt-8">
     <p className="font-mono text-[10px] uppercase tracking-widest text-[#006b4f]">{zh ? '技能精选 · 非作品案例' : 'Skill selection · separate from examples'}</p>
     <h2 id="video-skills-heading" className="mt-3 font-display text-3xl">{zh ? 'AI 产品视频与剪辑' : 'AI product video & editing'}</h2>
     <p className="mt-3 max-w-3xl text-sm leading-relaxed text-[#6d675e]">{zh ? '按任务选择工具。以下是技能目录入口，不计入作品数量，也不代表本站运行验证；安装前请查看详情页的当前审核状态与使用条件。' : 'Choose by task. These registry links are not extra Gallery examples or runtime verification. Read the detail page for current review status and requirements before installing.'}</p>

--- a/docs/showcase.md
+++ b/docs/showcase.md
@@ -9,6 +9,8 @@
 
 - `/showcase`：Skill Gallery，分类、作者筛选、搜索与案例列表；`?lang=zh` 为中文。
 - `/showcase/[slug]`：成品、任务、条件、来源和使用指引。
+- `/showcase?tag=logo`：Logo 与品牌标识用途标签，可与媒体分类、作者和搜索组合；当前包含静态吉祥物与 Logo 动画各 1 项。筛选页 noindex 并 canonical 到 Gallery 根页，不变更已有案例 URL。
+- `/showcase?category=video#video-skills`：5 个产品视频生成/剪辑技能入口；3 个新站长收录、2 个复用已有记录。它们与 100 个作品案例分开计数，不暗示实际运行成功。当前审核状态以技能详情为准。
 - 首页主视觉之后：三个精选作品，连接完整作品页。
 - 桌面导航、手机菜单、页脚：作品展示入口。
 - mono-color、Taste Skill、Vox Director、Guizang PPT Skill、Open Design
@@ -45,6 +47,8 @@ mono-color 仓库原有作品有单独的限制性许可，因此本站重新制
 稳定 slug、站内 canonical skillSlug、类型、中英文标题和描述、输入、
 实际交付格式、工具及费用条件、提示词性质、作品作者 `creatorId`、来源版本、许可、图片尺寸。
 同一个技能可以关联多个案例，不需要修改详情页模板或数据库表。
+
+用途标签在 `SHOWCASE_TAGS` / `SHOWCASE_CASE_TAGS` 维护，只标注真实相关案例。产品视频目录在 `lib/showcase-video-skills.ts` 维护，每项注明用途、依赖/费用和固定版本来源，不在前端复制或伪造审核评分。
 
 作者资料集中在 `SHOWCASE_CREATORS`，技能展示资料集中在 `SHOWCASE_SKILLS`；
 案例通过 `creatorId` 和 `skillSlug` 引用它们。不要把作者姓名和技能名称复制到每个案例。

--- a/lib/showcase-video-skills.ts
+++ b/lib/showcase-video-skills.ts
@@ -1,0 +1,39 @@
+// Registry selections are not Gallery artwork, additional cases or runtime evidence.
+// Sources inspected on 2026-09-08; the linked detail page owns current review status.
+export const SHOWCASE_VIDEO_SKILLS = [
+  {
+    slug: 'noamdorr-saas-product-demo-video-saas-product-demo-video',
+    name: 'SaaS Product Demo Video',
+    purpose: { en: 'Turn product screenshots, brand assets and a soundtrack into a short Remotion product demo.', zh: '将产品截图、品牌素材与配乐制作成简短的 Remotion 产品演示视频。' },
+    requirements: { en: 'Node.js, Python and Remotion. Check Remotion licensing; optional AI analysis or voice services may cost extra.', zh: '需要 Node.js、Python 与 Remotion；需核对 Remotion 许可，可选 AI 分析或配音服务可能收费。' },
+    source: 'https://github.com/noamdorr/saas-product-demo-video/blob/6ddaee236ea94fc2ff6d6abfddb663fdef4fe72e/saas-product-demo-video/SKILL.md',
+  },
+  {
+    slug: 'heygen-com-hyperframes-product-launch-video',
+    name: 'HyperFrames · Product Launch Video',
+    purpose: { en: 'Build a product launch, feature reveal or website promo from a URL or brief.', zh: '从产品网址或需求简报制作发布视频、功能介绍与网站宣传片。' },
+    requirements: { en: 'Requires the HyperFrames toolchain and companion skills. Hosted media services may charge. Inspect command-execution and environment-access findings before use.', zh: '需要 HyperFrames 工具链及配套技能；托管媒体服务可能收费。使用前请检查命令执行、环境文件访问等告警。' },
+    source: 'https://github.com/heygen-com/hyperframes/blob/e5d89f770fbe01d8c243999dac59f3c39a62d66d/skills/product-launch-video/SKILL.md',
+  },
+  {
+    slug: 'heygen-com-hyperframes-general-video',
+    name: 'HyperFrames · General Video',
+    purpose: { en: 'Create or edit multi-scene compositions, brand reels and footage remixes.', zh: '创建或编辑多场景视频、品牌短片与素材混剪。' },
+    requirements: { en: 'Requires HyperFrames and its companion skills. Local media can be reused; hosted generation, voice and media providers have separate terms and fees.', zh: '需要 HyperFrames 及配套技能；可复用本地素材，托管生成、配音与媒体服务各有使用条款和费用。' },
+    source: 'https://github.com/heygen-com/hyperframes/blob/e5d89f770fbe01d8c243999dac59f3c39a62d66d/skills/general-video/SKILL.md',
+  },
+  {
+    slug: 'remotion-dev-skills',
+    name: 'Remotion Agent Skills',
+    purpose: { en: 'Author React-based product videos, animated UI scenes and reusable compositions.', zh: '用 React 编写产品视频、动态 UI 场景与可复用视频组件。' },
+    requirements: { en: 'Requires a Node.js / Remotion project. Check Remotion’s separate commercial license and any generation-provider fees.', zh: '需要 Node.js / Remotion 项目；商业使用请核对 Remotion 单独许可及生成服务费用。' },
+    source: 'https://github.com/remotion-dev/skills/blob/11986e44eeb672b083354e68967f2b194df73b7c/README.md',
+  },
+  {
+    slug: 'browser-use-video-use',
+    name: 'Video Use',
+    purpose: { en: 'Edit existing demos and tutorials: trim filler, add captions and refine audio or visuals.', zh: '剪辑已有的产品演示与教程：去除口癖、添加字幕、调整声音和画面。' },
+    requirements: { en: 'Local editing dependencies plus an ElevenLabs key for transcription. Hosted transcription can incur fees and sends audio to the provider.', zh: '需要本地剪辑依赖；转录需 ElevenLabs 密钥，可能产生费用，并将音频发送给服务商。' },
+    source: 'https://github.com/browser-use/video-use/blob/9575612f066aa517354790a645fd90f9f95a743b/README.md',
+  },
+] as const

--- a/lib/showcase.ts
+++ b/lib/showcase.ts
@@ -21,6 +21,15 @@ export const SHOWCASE_CATEGORIES: { id: ShowcaseCategory; label: ShowcaseText }[
   { id: 'document', label: showcaseText('Documents', '文档与指南') },
 ]
 
+// Uses cross media categories: a logo can be a still mascot or a motion ident.
+export const SHOWCASE_TAGS = [{ id: 'logo', label: showcaseText('Logo & identity', 'Logo 与品牌标识'), aliases: 'logo mascot brand identity 标志 标识 吉祥物 品牌' }] as const
+export type ShowcaseTag = typeof SHOWCASE_TAGS[number]['id']
+const SHOWCASE_CASE_TAGS: Partial<Record<string, ShowcaseTag[]>> = {
+  'ip-mascot-directions': ['logo'],
+  'motion-logo-outro': ['logo'],
+}
+export const getShowcaseTags = (item: { slug: string }) => SHOWCASE_TAGS.filter((tag) => SHOWCASE_CASE_TAGS[item.slug]?.includes(tag.id))
+
 export interface ShowcaseCreator {
   /** Stable curation identity; never infer a seller account from a display name. */
   id: string
@@ -329,14 +338,15 @@ export function isMissingShowcasePath(pathname: string) {
   return pathname.startsWith('/showcase/') && !casePaths.has(pathname) && !assetPaths.has(pathname)
 }
 
-export function filterShowcaseCases(category: string, query: string, skillCreatorId = '') {
+export function filterShowcaseCases(category: string, query: string, skillCreatorId = '', tagId = '') {
   const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
   return SHOWCASE_CASES.filter((item) => {
     const skill = getShowcaseSkill(item.skillSlug)
     const skillCreator = getShowcaseCreator(skill.creatorId)
     const artworkCreator = getShowcaseCreator(item.creatorId)
-    const searchable = [item.title.en, item.title.zh, item.description.en, item.description.zh, skill.name, item.category, skillCreator.name, skillCreator.githubUsername, artworkCreator.name].join(' ').toLowerCase()
-    return (category === 'all' || item.category === category) && (!skillCreatorId || skill.creatorId === skillCreatorId) && terms.every((term) => searchable.includes(term))
+    const tags = getShowcaseTags(item)
+    const searchable = [item.title.en, item.title.zh, item.description.en, item.description.zh, skill.name, item.category, skillCreator.name, skillCreator.githubUsername, artworkCreator.name, ...tags.map((tag) => tag.aliases)].join(' ').toLowerCase()
+    return (category === 'all' || item.category === category) && (!skillCreatorId || skill.creatorId === skillCreatorId) && (!tagId || tags.some((tag) => tag.id === tagId)) && terms.every((term) => searchable.includes(term))
   })
 }
 

--- a/scripts/test-showcase.mjs
+++ b/scripts/test-showcase.mjs
@@ -5,6 +5,8 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { getShowcasePage, getShowcaseEvidenceLabel } from '../lib/showcase.ts'
+import { SHOWCASE_TAGS, getShowcaseTags } from '../lib/showcase.ts'
+import { SHOWCASE_VIDEO_SKILLS } from '../lib/showcase-video-skills.ts'
 import { SHOWCASE_CASES, SHOWCASE_CATEGORIES, SHOWCASE_CREATORS, SHOWCASE_SKILLS, FEATURED_SHOWCASE_SLUGS, filterShowcaseCases, getShowcaseCase, getShowcaseCreator, getShowcaseCreatorHref, getShowcaseHandoff, getShowcaseImageSrc, getShowcaseSkill, getShowcaseAccessLabel, isMissingShowcasePath } from '../lib/showcase.ts'
 
 const require = createRequire(import.meta.url)
@@ -61,6 +63,27 @@ for (const item of SHOWCASE_CASES) {
   if (item.videoUrl) assert.ok(item.videoUrl.startsWith('https://raw.githubusercontent.com/') && item.videoUrl.includes(item.sourceRevision))
 }
 assert.equal(filterShowcaseCases('all', '').length, SHOWCASE_CASES.length)
+assert.equal(new Set(SHOWCASE_TAGS.map((tag) => tag.id)).size, SHOWCASE_TAGS.length)
+const logoSlugs = ['ip-mascot-directions', 'motion-logo-outro']
+assert.deepEqual(filterShowcaseCases('all', '', '', 'logo').map((item) => item.slug).sort(), logoSlugs)
+assert.equal(filterShowcaseCases('image', '', '', 'logo').length, 1)
+assert.equal(filterShowcaseCases('video', '', '', 'logo').length, 1)
+assert.equal(filterShowcaseCases('slides', '', '', 'logo').length, 0)
+assert.equal(filterShowcaseCases('all', '', 'yanliudesign', 'logo').length, 0)
+assert.equal(getShowcasePage(filterShowcaseCases('all', '', '', 'logo'), '5').page, 1)
+for (const slug of logoSlugs) {
+  assert.ok(getShowcaseCase(slug))
+  assert.equal(getShowcaseTags({ slug })[0].id, 'logo')
+  for (const query of ['logo', '标识', '吉祥物']) assert.ok(filterShowcaseCases('all', query).some((item) => item.slug === slug))
+}
+assert.equal(getShowcaseTags({ slug: 'room-to-grow-poster' }).length, 0, 'Do not label all image work as a logo')
+assert.equal(SHOWCASE_VIDEO_SKILLS.length, 5)
+assert.equal(new Set(SHOWCASE_VIDEO_SKILLS.map((skill) => skill.slug)).size, 5)
+for (const skill of SHOWCASE_VIDEO_SKILLS) {
+  assert.match(skill.slug, /^[a-z0-9-]+$/)
+  assert.match(skill.source, /^https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[a-f0-9]{40}\//)
+  for (const locale of ['en', 'zh']) assert.ok(skill.purpose[locale] && skill.requirements[locale])
+}
 assert.deepEqual(filterShowcaseCases('image', 'mono').map((item) => item.slug), ['room-to-grow-poster'])
 assert.ok(filterShowcaseCases('all', '  花艺  ').some((item) => item.slug === 'floria-floral-studio'))
 assert.equal(filterShowcaseCases('video', 'botanical').length, 0)


### PR DESCRIPTION
## Summary
- Add a cross-category Logo & identity use-case tag to Gallery filters, search, cards and detail pages.
- Preserve existing 100 case URLs/counts and SSR canonical/noindex policy for filtered views.
- Add a bilingual, separate product video/editing skill selection with five real registry links, source revisions and cost/dependency notes.
- Three new records were published through the documented owner API with pinned source hashes and retained advisory findings (not AI approved or runtime verified). Remotion and Video Use reuse existing listings. No community approval states, review scores or installation outcomes were changed.

## Verification
- Full regression suite: passed.
- TypeScript: passed.
- ESLint: 0 errors; 22 pre-existing warnings.
- Production build: passed (local database/cache availability warnings remain outside this change).
- Gallery tag tests: 2 logo cases; image/video intersections; empty state; bilingual search; independent five-skill directory.
- HTTP: tag views return noindex/canonical and accurate JSON-LD counts; normal page 5 remains indexable.
- Five public skill pages return 200; three owner entries have ai_review_approved=false and no score.

No source skill was executed. HyperFrames product-launch-video retains command/environment-access warnings and requires review before unattended installation.
