### PR TITLE
fix(i18n): localize global analytics consent UI

### DIFF
--- a/components/analytics-preference-controls.tsx
+++ b/components/analytics-preference-controls.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useI18n } from '@/lib/i18n/context'
+import { siteCopy } from '@/lib/i18n/site-copy'
 import {
   ANALYTICS_CONSENT_STORAGE_KEY,
   updateAnalyticsConsent,
@@ -8,6 +10,7 @@ import {
 } from '@/lib/analytics'
 
 export function AnalyticsPreferenceControls() {
+  const { locale } = useI18n()
   const [consent, setConsent] = useState<AnalyticsConsent | null>(null)
 
   useEffect(() => {
@@ -36,7 +39,7 @@ export function AnalyticsPreferenceControls() {
         onClick={() => choose('denied')}
         className="h-11 border border-border bg-background px-5 text-sm font-semibold transition-colors hover:border-foreground/45 aria-pressed:border-foreground aria-pressed:bg-card"
       >
-        Necessary only
+        {siteCopy(locale, 'Necessary only')}
       </button>
       <button
         type="button"
@@ -44,7 +47,7 @@ export function AnalyticsPreferenceControls() {
         onClick={() => choose('granted')}
         className="h-11 bg-[#006b4f] px-5 text-sm font-semibold text-white transition-opacity hover:opacity-90 aria-pressed:outline aria-pressed:outline-2 aria-pressed:outline-offset-2 aria-pressed:outline-[#006b4f]"
       >
-        Allow analytics
+        {siteCopy(locale, 'Allow analytics')}
       </button>
     </div>
   )

--- a/components/google-analytics.tsx
+++ b/components/google-analytics.tsx
@@ -4,6 +4,9 @@ import Link from 'next/link'
 import Script from 'next/script'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
+import { getLocaleFromRoute } from '@/lib/i18n/config'
+import { siteCopy } from '@/lib/i18n/site-copy'
+import { getLocalizedNavigationHref } from '@/lib/i18n/market-routing'
 import {
   ANALYTICS_CONSENT_STORAGE_KEY,
   trackAnalyticsPageView,
@@ -14,6 +17,7 @@ import {
 export function GoogleAnalytics({ measurementId }: { measurementId: string }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const locale = getLocaleFromRoute(pathname, searchParams.get('lang'))
   const search = searchParams.toString()
   const [consent, setConsent] = useState<AnalyticsConsent | null | undefined>(undefined)
 
@@ -94,29 +98,30 @@ export function GoogleAnalytics({ measurementId }: { measurementId: string }) {
       {consent === null && (
         <aside
           className="fixed inset-x-0 bottom-0 z-[100] border-t border-border bg-background/95 px-4 py-4 shadow-[0_-12px_32px_rgba(26,24,20,0.08)] backdrop-blur sm:px-6"
-          aria-label="Analytics preferences"
+          aria-label={siteCopy(locale, 'Analytics preferences')}
+          lang={locale}
         >
           <div className="mx-auto flex max-w-6xl flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <p className="max-w-3xl text-sm leading-6 text-secondary">
-              OpenAgentSkill uses privacy-conscious analytics to understand which pages and product flows are useful. No task text or private repository data is sent to Google.{' '}
-              <Link href="/privacy" className="font-medium text-foreground underline underline-offset-4">
-                Privacy details
+              {locale === 'en' ? 'OpenAgentSkill uses privacy-conscious analytics to understand which pages and product flows are useful. No task text or private repository data is sent to Google.' : siteCopy(locale, 'Analytics notice')}{' '}
+              <Link href={getLocalizedNavigationHref('/privacy', locale)} className="font-medium text-foreground underline underline-offset-4">
+                {siteCopy(locale, 'Privacy details')}
               </Link>
             </p>
             <div className="flex shrink-0 flex-col gap-2 min-[420px]:flex-row">
               <button
                 type="button"
                 onClick={() => chooseConsent('denied')}
-                className="h-10 border border-border bg-background px-4 text-sm font-semibold text-foreground transition-colors hover:border-foreground/45"
+                className="min-h-10 border border-border bg-background px-4 py-2 text-sm font-semibold text-foreground transition-colors hover:border-foreground/45"
               >
-                Necessary only
+                {siteCopy(locale, 'Necessary only')}
               </button>
               <button
                 type="button"
                 onClick={() => chooseConsent('granted')}
-                className="h-10 bg-[#006b4f] px-4 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+                className="min-h-10 bg-[#006b4f] px-4 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
               >
-                Allow analytics
+                {siteCopy(locale, 'Allow analytics')}
               </button>
             </div>
           </div>

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -3,6 +3,13 @@ export type Locale = (typeof locales)[number]
 
 export const defaultLocale: Locale = 'en'
 
+/** Route language wins over a query preference, including public consent UI
+ * mounted outside a page-level provider. Never infer locale from browser state. */
+export function getLocaleFromRoute(pathname: string | null, preference?: string | null, initial: Locale = defaultLocale): Locale {
+  const prefix = pathname?.split('/').filter(Boolean)[0]
+  return isLocale(prefix) ? prefix : isLocale(preference) ? preference : initial
+}
+
 export const localeNames: Record<Locale, string> = {
   en: 'English',
   zh: 'Chinese',

--- a/lib/i18n/context.tsx
+++ b/lib/i18n/context.tsx
@@ -3,7 +3,7 @@
 import { createContext, ReactNode, Suspense, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { usePathname, useSearchParams } from 'next/navigation'
 import type { Locale } from './config'
-import { defaultLocale, isLocale } from './config'
+import { defaultLocale, getLocaleFromRoute } from './config'
 import en from './dictionaries/en'
 import zh from './dictionaries/zh'
 import ja from './dictionaries/ja'
@@ -32,15 +32,6 @@ const dictionaries: Record<Locale, Dictionary> = {
   de,
   fr,
   id,
-}
-
-function getLocaleFromPath(pathname: string): Locale | null {
-  const firstSegment = pathname.split('/').filter(Boolean)[0]
-  return isLocale(firstSegment) ? firstSegment : null
-}
-
-function getLocaleFromSearch(value: string | null): Locale | null {
-  return isLocale(value) ? value : null
 }
 
 interface I18nContextType {
@@ -103,11 +94,7 @@ function I18nProviderWithSearch({
   // The route is authoritative when it specifies a locale. The provider syncs
   // this value in place so route changes preserve the already-rendered page
   // tree instead of tearing it down and mounting it again.
-  const routeLocale =
-    getLocaleFromPath(pathname || '') ||
-    getLocaleFromSearch(searchParams.get('lang')) ||
-    initialLocale ||
-    defaultLocale
+  const routeLocale = getLocaleFromRoute(pathname, searchParams.get('lang'), initialLocale)
   const routeKey = `${pathname || '/'}?${searchParams.toString()}`
 
   return (

--- a/lib/i18n/site-copy.ts
+++ b/lib/i18n/site-copy.ts
@@ -3,6 +3,11 @@ import type { Locale } from './config'
 // EN is the key. Tuple order follows the remaining supported locales.
 type Row = readonly [zh: string, ja: string, ko: string, es: string, de: string, fr: string, id: string]
 export const siteTranslations = {
+  'Analytics preferences': ['统计偏好设置', 'アクセス解析の設定', '분석 설정', 'Preferencias de analítica', 'Analyseeinstellungen', 'Préférences d’analyse', 'Preferensi analitik'],
+  'Necessary only': ['仅必要功能', '必要な機能のみ', '필수 기능만', 'Solo lo necesario', 'Nur notwendige Funktionen', 'Fonctions nécessaires uniquement', 'Hanya yang diperlukan'],
+  'Allow analytics': ['允许统计分析', 'アクセス解析を許可', '분석 허용', 'Permitir analítica', 'Analyse erlauben', 'Autoriser l’analyse', 'Izinkan analitik'],
+  'Privacy details': ['隐私详情', 'プライバシーの詳細', '개인정보 안내', 'Detalles de privacidad', 'Datenschutzdetails', 'Détails de confidentialité', 'Detail privasi'],
+  'Analytics notice': ['OpenAgentSkill 使用注重隐私的统计分析，了解哪些页面和产品流程更有帮助。不会向 Google 发送任务文本或私有仓库数据。', 'OpenAgentSkill はプライバシーに配慮したアクセス解析で、役立つページや機能を把握します。タスクの本文や非公開リポジトリのデータを Google に送信しません。', 'OpenAgentSkill은 개인정보를 고려한 분석으로 유용한 페이지와 기능을 파악합니다. 작업 텍스트나 비공개 저장소 데이터는 Google에 전송하지 않습니다.', 'OpenAgentSkill utiliza analítica respetuosa con la privacidad para conocer qué páginas y funciones son útiles. No enviamos a Google texto de tareas ni datos de repositorios privados.', 'OpenAgentSkill nutzt datenschutzbewusste Analysen, um hilfreiche Seiten und Abläufe zu erkennen. Aufgabentexte und private Repository-Daten werden nicht an Google gesendet.', 'OpenAgentSkill utilise des analyses respectueuses de la vie privée pour identifier les pages et fonctions utiles. Aucun texte de tâche ni donnée de dépôt privé n’est envoyé à Google.', 'OpenAgentSkill menggunakan analitik yang memperhatikan privasi untuk memahami halaman dan alur yang berguna. Teks tugas atau data repositori privat tidak dikirim ke Google.'],
   'Current language: {language}': ['当前语言：{language}', '現在の言語：{language}', '현재 언어: {language}', 'Idioma actual: {language}', 'Aktuelle Sprache: {language}', 'Langue actuelle : {language}', 'Bahasa saat ini: {language}'],
   'Select language': ['选择语言', '言語を選択', '언어 선택', 'Elegir idioma', 'Sprache wählen', 'Choisir la langue', 'Pilih bahasa'],
   'RAG and knowledge': ['RAG 与知识库', 'RAG・ナレッジ', 'RAG 및 지식', 'RAG y conocimiento', 'RAG und Wissen', 'RAG et connaissances', 'RAG dan pengetahuan'],

--- a/scripts/test-localization.mjs
+++ b/scripts/test-localization.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync, readdirSync } from 'node:fs'
 import ts from 'typescript'
-import { locales } from '../lib/i18n/config.ts'
+import { locales, getLocaleFromRoute } from '../lib/i18n/config.ts'
 import { galleryTranslations, galleryCopy, localizeEditorialText } from '../lib/i18n/gallery-copy.ts'
 import { siteTranslations, siteCopy } from '../lib/i18n/site-copy.ts'
 import { submissionTranslations, submissionCopy } from '../lib/i18n/submission-copy.ts'
@@ -19,6 +19,9 @@ for (const [dictionary, size] of [[galleryTranslations, 6], [siteTranslations, 7
   }
 }
 for (const locale of locales) {
+  assert.equal(getLocaleFromRoute(`/${locale}/submit`, 'invalid'), locale)
+  assert.equal(getLocaleFromRoute('/showcase', locale), locale)
+  for (const key of ['Analytics preferences', 'Necessary only', 'Allow analytics', 'Privacy details']) assert.ok(siteCopy(locale, key).trim())
   assert.ok(galleryCopy(locale, 'Play preview', '播放预览'))
   assert.ok(siteCopy(locale, 'View all rankings'))
   assert.ok(submissionCopy(locale, 'Reviewed and published', '已通过审核并发布'))
@@ -30,6 +33,9 @@ for (const locale of locales) {
   assert.ok(getShowcaseAccessLabel({access:'open-source'}, locale))
   assert.ok(getShowcaseEvidenceLabel(SHOWCASE_CASES[0], locale))
 }
+assert.equal(getLocaleFromRoute('/ja/submit', 'de'), 'ja', 'Path locale must override query locale')
+assert.equal(getLocaleFromRoute('/showcase', 'invalid'), 'en')
+assert.equal(getLocaleFromRoute(null, null, 'fr'), 'fr')
 assert.equal(localizeEditorialText({ en: 'npx skills add owner/repo', zh: 'npx skills add owner/repo'}, 'ja'), 'npx skills add owner/repo')
 assert.equal(galleryCopy('invalid', 'Play preview', '播放预览'), 'Play preview')
 assert.ok(filterShowcaseCases('all', '成長する余白').some(x=>x.slug==='room-to-grow-poster'))


### PR DESCRIPTION
Follow-up to #121: translate the global analytics consent banner and preference buttons in all eight locales. Share route-language resolution with the page provider; preserve localized privacy links. Consent defaults, event handling, and analytics loading remain unchanged. Verified typecheck, full regression suite (273 localized messages), lint for changed files, and production build (582 routes).