### PR TITLE
Fix duplicated locale fallback trees during streamed hydration

### DIFF
--- a/docs/featured-creators.md
+++ b/docs/featured-creators.md
@@ -63,3 +63,8 @@ typecheck, lint and production build. Browser checks cover 20 profiles, sorting,
 search, empty results, ownership notices, source/Gallery links, eight languages,
 mobile widths, navigation without login and the authenticated claim boundary.
 Do not execute listed Skills as part of these website checks.
+
+The locale provider suspends only its null-rendering route observer. Page children
+must not appear in a Suspense fallback: nested providers otherwise stream repeated
+page trees and can race with React hydration on real networks. Browser runtime
+errors are a release failure even when the visual/interaction assertions pass.

--- a/lib/i18n/context.tsx
+++ b/lib/i18n/context.tsx
@@ -45,14 +45,20 @@ const I18nContext = createContext<I18nContextType | undefined>(undefined)
 function I18nStateProvider({
   children,
   initialLocale = defaultLocale,
-  routeKey,
 }: {
   children: ReactNode
   initialLocale?: Locale
-  routeKey: string
 }) {
+  const [route, setRoute] = useState({ locale: initialLocale, key: 'initial' })
+  const routeKey = route.key
   const [override, setOverride] = useState<{ locale: Locale; routeKey: string } | null>(null)
-  const locale = override?.routeKey === routeKey ? override.locale : initialLocale
+  const locale = override?.routeKey === routeKey ? override.locale : route.locale
+
+  const onRoute = useCallback((nextLocale: Locale, key: string) => {
+    setRoute(current => current.key === key && current.locale === nextLocale
+      ? current
+      : { locale: nextLocale, key })
+  }, [])
 
   useEffect(() => {
     document.documentElement.lang = locale
@@ -77,17 +83,22 @@ function I18nStateProvider({
 
   return (
     <I18nContext.Provider value={value}>
+      {/* Only route observation may suspend. Keep the streamed page tree single
+          and mounted; repeating children in a fallback races with hydration. */}
+      <Suspense fallback={null}>
+        <LocaleRouteObserver initialLocale={initialLocale} onRoute={onRoute} />
+      </Suspense>
       {children}
     </I18nContext.Provider>
   )
 }
 
-function I18nProviderWithSearch({
-  children,
+function LocaleRouteObserver({
   initialLocale,
+  onRoute,
 }: {
-  children: ReactNode
   initialLocale?: Locale
+  onRoute: (locale: Locale, key: string) => void
 }) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -97,11 +108,8 @@ function I18nProviderWithSearch({
   const routeLocale = getLocaleFromRoute(pathname, searchParams.get('lang'), initialLocale)
   const routeKey = `${pathname || '/'}?${searchParams.toString()}`
 
-  return (
-    <I18nStateProvider initialLocale={routeLocale} routeKey={routeKey}>
-      {children}
-    </I18nStateProvider>
-  )
+  useEffect(() => onRoute(routeLocale, routeKey), [onRoute, routeLocale, routeKey])
+  return null
 }
 
 export function I18nProvider({
@@ -112,9 +120,7 @@ export function I18nProvider({
   initialLocale?: Locale
 }) {
   return (
-    <Suspense fallback={<I18nStateProvider initialLocale={initialLocale} routeKey="initial">{children}</I18nStateProvider>}>
-      <I18nProviderWithSearch initialLocale={initialLocale}>{children}</I18nProviderWithSearch>
-    </Suspense>
+    <I18nStateProvider initialLocale={initialLocale}>{children}</I18nStateProvider>
   )
 }
 

--- a/scripts/test-localization.mjs
+++ b/scripts/test-localization.mjs
@@ -47,6 +47,14 @@ const guarded = [
   ...readdirSync('components').filter(x=>/^showcase-.*\.tsx$/.test(x)).map(x=>`components/${x}`),
   'components/skill-submit-form.tsx', 'app/submit/page.tsx',
 ]
+// The route observer may suspend, but the page tree must never be duplicated in
+// a Suspense fallback. Duplicated streamed trees can race with hydration ($RS).
+const providerSource = readFileSync('lib/i18n/context.tsx', 'utf8')
+assert.ok(providerSource.includes('<Suspense fallback={null}>'))
+assert.ok(providerSource.includes('<LocaleRouteObserver'))
+assert.equal((providerSource.match(/\{children\}/g) || []).length, 2,
+  'Render page children once in the state provider and pass them once from the public wrapper')
+assert.ok(!providerSource.includes('fallback={<I18nStateProvider'))
 for(const path of guarded) {
   const source=readFileSync(path,'utf8'), ast=ts.createSourceFile(path,source,ts.ScriptTarget.Latest,true,ts.ScriptKind.TSX)
   function visit(n) {


### PR DESCRIPTION
## Cause
Production browser QA surfaced intermittent React stream parentNode errors. The shared locale provider rendered its whole page tree in both its Suspense fallback and resolved content; nested providers emitted 80 raw article elements for 20 creators.

## Fix
Keep one stable state provider and one copy of page children. Isolate only the null-rendering URL locale observer behind Suspense. Preserve immediate picker overrides and URL-driven synchronization without remounting content.

## Verification completed locally
- Full regression suite, typecheck, targeted lint and production build pass.
- Raw server HTML contains exactly 20 creator cards instead of 80.
- Added regression guards against page children in the locale Suspense fallback.
- All eight locales pass creator directory, profiles, real filters/search, empty state, mobile widths, source/Gallery links, homepage and claim/login boundary.
- Existing homepage, Gallery category/tag filtering, details, submission form and mobile widths pass in all eight locales.
- Real language picker preserves category and hash.
- Both browser suites report zero runtime errors. 20 profile URLs, sitemap, canonical and unknown-profile 404 pass.
- No auth, review, database or deployment settings changed.