### PR TITLE
Fix Skill version provenance, risk hints and review reconciliation

### DIFF
--- a/.github/workflows/skill-issue-ingest.yml
+++ b/.github/workflows/skill-issue-ingest.yml
@@ -1,6 +1,8 @@
 name: Import Skill Issue
 
 on:
+  schedule:
+    - cron: '20 12 * * *'
   issues:
     types: [opened, reopened]
   issue_comment:
@@ -30,7 +32,7 @@ permissions:
 jobs:
   import:
     name: Validate, review, and publish
-    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.issue.title, '[Skill]:') && (github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/oas ')))
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (startsWith(github.event.issue.title, '[Skill]:') && (github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/oas ')))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/skill-issue-ingest.yml
+++ b/.github/workflows/skill-issue-ingest.yml
@@ -3,9 +3,24 @@ name: Import Skill Issue
 on:
   issues:
     types: [opened, reopened]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Skill submission Issue number'
+        required: true
+      operation:
+        description: 'Reconcile publication or review a new immutable commit'
+        type: choice
+        options: [reconcile, review]
+        default: reconcile
+      revision:
+        description: 'Full 40-character commit SHA (required for review)'
+        required: false
 
 concurrency:
-  group: skill-issue-${{ github.event.issue.number }}
+  group: skill-issue-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: false
 
 permissions:
@@ -15,12 +30,15 @@ permissions:
 jobs:
   import:
     name: Validate, review, and publish
-    if: startsWith(github.event.issue.title, '[Skill]:')
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.issue.title, '[Skill]:') && (github.event_name != 'issue_comment' || startsWith(github.event.comment.body, '/oas ')))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: main
+          persist-credentials: false
       - name: Process Skill submission
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/api/agent/skills/[slug]/route.ts
+++ b/app/api/agent/skills/[slug]/route.ts
@@ -14,6 +14,8 @@ import { getSkillBySlugOrFallbackStrict, getSkillSuggestionsForSlug, isCuratedSk
 import { getSkillSupplyProfile } from '@/lib/supply'
 import { getSkillTrustProfile, getSkillTrustProfileV5 } from '@/lib/trust'
 import { getUseCasesForSkill } from '@/lib/use-cases'
+import { getStoredSkillVersionEvidence } from '@/lib/skills/version-evidence'
+import { getReviewEvidence } from '@/lib/skills/review-evidence'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -262,6 +264,10 @@ OpenAgentSkill — ${skill.verified ? 'Verified' : 'Unverified'} skill.`
         repository: skill.repository,
         github_repo: skill.github_repo,
         version: skill.version,
+        version_provenance: getStoredSkillVersionEvidence(skill),
+        source: { path: skill.source_path || null, ref: skill.source_ref || null, commit: skill.source_commit_sha || null, content_hash: skill.source_content_hash || null },
+        review_evidence: getReviewEvidence(skill),
+        listing_status: skill.listing_status || 'legacy',
         license: skill.license,
         urls: {
           web: `https://www.openagentskill.com/skills/${skill.slug}`,

--- a/app/api/skills/lookup/route.ts
+++ b/app/api/skills/lookup/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
   }
   const { data, error } = await createPublicClient({ requestTimeoutMs: 8000 })
     .from('skills').select('slug,name,github_repo,source_path,source_commit_sha,listing_status,ai_review_score,publisher_verified,source_sync_status,license')
-    .ilike('github_repo', repository.replace(/_/g, '\\_')).eq('source_path', path).or(PUBLIC_SKILL_FILTER).order('created_at', { ascending: true }).limit(1).maybeSingle()
+    .ilike('github_repo', repository.replace(/[\\%_]/g, '\\$&')).eq('source_path', path).or(PUBLIC_SKILL_FILTER).order('created_at', { ascending: true }).limit(1).maybeSingle()
   if (error) return NextResponse.json({ error: 'Public source lookup unavailable.' }, { status: 503, headers })
   return NextResponse.json({ skill: data ? { name: data.name, slug: data.slug, repository: data.github_repo,
     path: data.source_path, commit: data.source_commit_sha, listingStatus: data.listing_status,

--- a/app/api/skills/lookup/route.ts
+++ b/app/api/skills/lookup/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createPublicClient } from '@/lib/supabase/public'
+import { PUBLIC_SKILL_FILTER } from '@/lib/skills/publication'
+import { getReviewEvidence } from '@/lib/skills/review-evidence'
+
+export const dynamic = 'force-dynamic'
+const headers = { 'Cache-Control': 'no-store', 'X-Robots-Tag': 'noindex' }
+
+/** Exact public source identity lookup; never exposes pending/private submission data. */
+export async function GET(request: NextRequest) {
+  const repository = request.nextUrl.searchParams.get('repository') || ''
+  const path = request.nextUrl.searchParams.get('path') || ''
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository) || path.length > 500 ||
+    !/(^|\/)SKILL\.md$/i.test(path) || /[\x00-\x1f\\]/.test(path) || path.startsWith('/') || path.split('/').some(p => p === '..' || p === '.')) {
+    return NextResponse.json({ error: 'Invalid repository or Skill path.' }, { status: 400, headers })
+  }
+  const { data, error } = await createPublicClient({ requestTimeoutMs: 8000 })
+    .from('skills').select('slug,name,github_repo,source_path,source_commit_sha,listing_status,ai_review_score,publisher_verified,source_sync_status,license')
+    .ilike('github_repo', repository.replace(/_/g, '\\_')).eq('source_path', path).or(PUBLIC_SKILL_FILTER).order('created_at', { ascending: true }).limit(1).maybeSingle()
+  if (error) return NextResponse.json({ error: 'Public source lookup unavailable.' }, { status: 503, headers })
+  return NextResponse.json({ skill: data ? { name: data.name, slug: data.slug, repository: data.github_repo,
+    path: data.source_path, commit: data.source_commit_sha, listingStatus: data.listing_status,
+    license: data.license, reviewEvidence: getReviewEvidence(data), url: `https://www.openagentskill.com/skills/${data.slug}` } : null }, { headers })
+}

--- a/app/api/skills/submissions/[id]/route.ts
+++ b/app/api/skills/submissions/[id]/route.ts
@@ -65,6 +65,10 @@ export async function GET(
       },
       identityVerified: Boolean(data.identity_verified),
       review: {
+        method: typeof review.method === 'string' ? review.method : 'legacy_unclassified',
+        approved: review.approved === true,
+        policyVersion: typeof review.policyVersion === 'string' ? review.policyVersion : null,
+        packageFingerprint: typeof review.packageFingerprint === 'string' ? review.packageFingerprint : null,
         scores: review.scores || null,
         totalScore: review.totalScore || null,
         issues: Array.isArray(review.issues) ? review.issues.slice(0, 20) : [],

--- a/app/api/skills/submit/route.ts
+++ b/app/api/skills/submit/route.ts
@@ -1,6 +1,6 @@
 import { after, NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
-import { validateGitHubRepo, GitHubAPIError } from '@/lib/github/api'
+import { validateGitHubRepo, fetchRepositoryCommitSha, GitHubAPIError } from '@/lib/github/api'
 import {
   discoverGitHubSkills,
   fetchSkillPackageSnapshot,
@@ -65,7 +65,9 @@ export async function POST(request: NextRequest) {
       checkReadme: false,
       checkSkillJson: false,
     })
-    const discovery = await discoverGitHubSkills(selectedReference, repository)
+    const commit = await fetchRepositoryCommitSha(reference.owner, reference.repo, selectedReference.ref || repository.defaultBranch)
+    if (!commit) return NextResponse.json({ error: 'Unable to pin the source revision. Please retry later.' }, { status: 503 })
+    const discovery = await discoverGitHubSkills({ ...selectedReference, ref: commit }, repository)
     const skill = discovery.skills.find((candidate) => candidate.path === body.skillPath)
     if (!skill) {
       return NextResponse.json(

--- a/app/api/skills/submit/route.ts
+++ b/app/api/skills/submit/route.ts
@@ -65,6 +65,7 @@ export async function POST(request: NextRequest) {
       checkReadme: false,
       checkSkillJson: false,
     })
+    if (repository.isPrivate) return NextResponse.json({ error: 'Only public repositories can be submitted.' }, { status: 400 })
     const commit = await fetchRepositoryCommitSha(reference.owner, reference.repo, selectedReference.ref || repository.defaultBranch)
     if (!commit) return NextResponse.json({ error: 'Unable to pin the source revision. Please retry later.' }, { status: 503 })
     const discovery = await discoverGitHubSkills({ ...selectedReference, ref: commit }, repository)

--- a/app/api/skills/validate/route.ts
+++ b/app/api/skills/validate/route.ts
@@ -37,6 +37,12 @@ export async function POST(request: NextRequest) {
       checkReadme: false,
       checkSkillJson: false,
     })
+    if (repoData.isPrivate) {
+      return NextResponse.json(
+        { valid: false, code: 'PRIVATE_REPOSITORY', error: 'Only public GitHub repositories can be submitted.' },
+        { status: 400 }
+      )
+    }
     const discovery = await discoverGitHubSkills(reference, repoData)
     if (discovery.skills.length === 0) {
       return NextResponse.json(

--- a/docs/skill-issue-review.md
+++ b/docs/skill-issue-review.md
@@ -1,0 +1,38 @@
+# Skill Issue review and reconciliation
+
+Website changes do not use this workflow. This workflow processes **New Skill** Issues only; metadata corrections and safety reports require engineering/source investigation.
+
+## Maintainer commands
+
+On an open `[Skill]:` Issue, a collaborator with repository `write`, `maintain`, or `admin` permission can post:
+
+```text
+/oas review <full-40-character-commit-sha>
+/oas reconcile
+```
+
+The **Import Skill Issue** workflow also supports manual dispatch with `issue_number`, `operation` (`review` or `reconcile`), and `revision` (required for review).
+
+- Re-review uses the normal submission API, pinned to the requested upstream commit. It does not use owner publication or override a rejected review.
+- Previous review comments and database submissions remain intact. A bot-authored attempt marker is appended **before** submission. The same repository, path, and commit is not submitted twice from one Issue, even when a workflow is retried.
+- There is a six-hour per-Issue cooldown for new review attempts, in addition to the application submission limits and model budget. Reconciliation does not call a model.
+- Permission is checked against GitHub, not Issue body text, claimed authorship, or upstream instructions. Workflow checkout is the maintained `main` branch, never submitted repository code. No Skill is executed.
+- Reconciliation looks up the exact public repository + SKILL.md path. A confirmed existing listing is linked without a duplicate submission. A missing, pending or quarantined listing keeps the Issue open.
+- An already-published different revision is not overwritten via re-review. Use the existing source-version synchronization workflow and preserve the current review history.
+- Only a confirmed public URL allows automatic closure. Publication is not a runtime test, creator verification, or universal safety approval. Comments distinguish static, AI, manual and unclassified legacy review evidence.
+
+## Recovery after interruption
+
+The attempt marker deliberately fails closed if the network fails after submission: do not remove it and blindly repeat a paid review. Run reconciliation, then inspect the saved submission if publication is still pending. An updated source commit can be submitted after the cooldown. Large histories (300+ comments) require manual inspection.
+
+## Version provenance
+
+All current source-intake paths resolve versions from explicit SKILL.md frontmatter (including `metadata.version`) or a **name-matching** `.claude-plugin/plugin.json` at the same source revision. `2.2` remains `2.2`; absent/invalid declarations are `Unknown`, never invented `1.0.0`. Unrelated root package versions and moving “latest” releases are not evidence for a nested Skill.
+
+The detail API exposes `version_provenance`, `source`, `listing_status` and `review_evidence`. Version corrections are metadata corrections, not approval. Historical records without provenance remain unclassified until checked; do not assume every legacy `1.0.0` is fabricated.
+
+## Risk and license interpretation
+
+Negated prose such as “does not provide trade execution” or “no API key needed” is not itself an affirmative permission claim. Separate positive statements, install commands and fenced code retain their signals. This context matching only improves displayed hints: it does not weaken the executable static scanner or publication gate. Network, subprocess, filesystem and actual environment-access risks still require review.
+
+`PolyForm-Noncommercial-1.0.0` and CC-BY-NC are restricted licenses, not unrestricted commercial-use permission. A missing license must remain unresolved until an upstream declaration is supplied.

--- a/docs/skill-issue-review.md
+++ b/docs/skill-issue-review.md
@@ -18,6 +18,7 @@ The **Import Skill Issue** workflow also supports manual dispatch with `issue_nu
 - There is a six-hour per-Issue cooldown for new review attempts, in addition to the application submission limits and model budget. Reconciliation does not call a model.
 - Permission is checked against GitHub, not Issue body text, claimed authorship, or upstream instructions. Workflow checkout is the maintained `main` branch, never submitted repository code. No Skill is executed.
 - Reconciliation looks up the exact public repository + SKILL.md path. A confirmed existing listing is linked without a duplicate submission. A missing, pending or quarantined listing keeps the Issue open.
+- A daily 12:20 UTC sweep reconciles at most five open submission Issues, rotating within the oldest 100 GitHub issues/PRs. It never starts a review or calls a model, and stops on upstream failure. Larger backlogs can use explicit maintainer reconciliation.
 - An already-published different revision is not overwritten via re-review. Use the existing source-version synchronization workflow and preserve the current review history.
 - Only a confirmed public URL allows automatic closure. Publication is not a runtime test, creator verification, or universal safety approval. Comments distinguish static, AI, manual and unclassified legacy review evidence.
 

--- a/lib/agent-safety.ts
+++ b/lib/agent-safety.ts
@@ -2,6 +2,7 @@ import { auditRiskLabel, type ComputedSkillAudit } from '@/lib/audits'
 import type { SkillRecord } from '@/lib/db/skills'
 import { needsOwnerPublicationReview, OWNER_PUBLICATION_NOTICE } from '@/lib/skills/publication'
 import { getSkillSourceEvidence } from '@/lib/skills/source-evidence'
+import { hasSkillRiskHint, SECRET_ACCESS_PATTERN } from '@/lib/security/risk-context'
 
 export type AgentSafetyLevel = 'safe_to_install' | 'review_before_install' | 'avoid_auto_install'
 export type SkillSafetyTier = 'verified' | 'reviewed' | 'experimental' | 'blocked'
@@ -88,7 +89,7 @@ const PERMISSION_PATTERNS: Array<{
     label: 'Secrets or environment access',
     reason: 'Skill metadata references credentials, tokens, environment variables, or secret-bearing workflows.',
     severity: 'high',
-    pattern: /\b(secret|token|credential|api key|env|environment variable|oauth|auth)\b/i,
+    pattern: SECRET_ACCESS_PATTERN,
   },
   {
     id: 'database',
@@ -249,7 +250,7 @@ function safetyTierProfile({
 export function getPermissionHints(skill: SkillRecord): PermissionHint[] {
   const text = skillPolicyText(skill)
   const hints = PERMISSION_PATTERNS
-    .filter((item) => item.pattern.test(text))
+    .filter((item) => item.id === 'secrets' ? hasSkillRiskHint(skill, item.pattern) : item.pattern.test(text))
     .map(({ id, label, reason, severity }) => ({ id, label, reason, severity }))
 
   if (hints.length === 0) {

--- a/lib/audits.ts
+++ b/lib/audits.ts
@@ -2,6 +2,7 @@ import { needsOwnerPublicationReview } from '@/lib/skills/publication'
 import type { SkillAuditRecord, SkillEventStats, SkillRecord } from '@/lib/db/skills'
 import { formatCompactNumber, getFreshnessDays, getSkillQualityProfile } from '@/lib/quality'
 import { getSkillTrustProfile } from '@/lib/trust'
+import { FINANCIAL_EXECUTION_PATTERN, hasSkillRiskHint } from '@/lib/security/risk-context'
 
 export type AuditRiskLevel = SkillAuditRecord['risk_level']
 export type AuditCheckStatus = 'pass' | 'warn' | 'fail' | 'info'
@@ -65,7 +66,7 @@ function licenseKnown(skill: SkillRecord) {
 
 function hasRestrictedLicense(skill: SkillRecord) {
   const license = (skill.license || '').trim().toLowerCase()
-  return license.includes('cc-by-nc') || license.includes('non-commercial')
+  return /\bcc[- ]?by[- ]?nc\b|\bnon[- ]?commercial\b/i.test(license)
 }
 
 function hasInstallPath(skill: SkillRecord) {
@@ -95,16 +96,7 @@ function isFinancialDomainSkill(skill: SkillRecord) {
 }
 
 function hasFinancialExecutionRisk(skill: SkillRecord) {
-  const text = [
-    skill.name,
-    skill.category,
-    skill.description,
-    skill.long_description,
-    skill.install_command,
-    ...(skill.tags || []),
-  ].join(' ').toLowerCase()
-
-  return /\b(place orders?|order execution|execute trades?|trade execution|live trading|brokerage|broker account|exchange connectivity|wallet|private key|swap(?:ping)?|withdraw(?:al)?|deposit(?:ing)?|margin trading|perpetual futures?|api trading)\b/.test(text)
+  return hasSkillRiskHint(skill, FINANCIAL_EXECUTION_PATTERN)
 }
 
 function statusForScore(score: number): AuditCheckStatus {

--- a/lib/creator-ownership.ts
+++ b/lib/creator-ownership.ts
@@ -85,7 +85,7 @@ export function getLicenseEvidence(frontmatterLicense?: string, repositoryLicens
     source: declared ? 'skill_frontmatter' : repository ? 'github_repository' : 'unknown',
     status: !license || ['unknown', 'noassertion', 'other'].includes(normalized)
       ? 'missing'
-      : /non-commercial|cc-by-nc/.test(normalized)
+      : /\bnon[- ]?commercial\b|\bcc[- ]?by[- ]?nc\b/.test(normalized)
         ? 'restricted'
         : 'detected',
   } as const

--- a/lib/db/skills.ts
+++ b/lib/db/skills.ts
@@ -38,7 +38,7 @@ export interface SkillRecord {
   ai_review_score: any
   ai_review_approved: boolean
   listing_status?: string | null
-  owner_publication?: { channel: string; static_analysis?: { riskLevel?: string }; notice?: string } | null
+  owner_publication?: { channel: string; static_analysis?: { riskLevel?: string; version_evidence?: unknown }; notice?: string } | null
   ai_review_issues: string[]
   ai_review_suggestions: string[]
   downloads: number
@@ -1154,13 +1154,13 @@ export function convertSkillRecordToManifest(record: SkillRecord): Skill {
       weeklyGrowth: 0,
     },
     technical: {
-      version: record.version || '1.0.0',
+      version: record.version || 'Unknown',
       language: ['TypeScript'],
       frameworks: record.frameworks || [],
       dependencies: [],
       documentation: record.repository,
       repository: record.repository,
-      license: record.license || 'MIT',
+      license: record.license || 'Unknown',
       size: '1 MB',
       lastUpdated: record.updated_at,
       installCommand: record.install_command || `npx skills add ${record.github_repo}`,

--- a/lib/github/skill-source.ts
+++ b/lib/github/skill-source.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import type { GitHubRepo } from '@/lib/schema/skill-schema'
+import { resolveSkillVersion } from '@/lib/skills/version-evidence'
 
 const GITHUB_API = 'https://api.github.com'
 const MAX_DISCOVERED_SKILLS = 50
@@ -196,6 +197,15 @@ function parseFrontmatterBlock(source: string) {
       continue
     }
 
+    if (key === 'metadata' && !rawValue.trim()) {
+      index += 1
+      while (index < lines.length && (/^\s+/.test(lines[index]) || !lines[index].trim())) {
+        const nested = lines[index].match(/^ {2}(version|author):\s*(.+)$/)
+        if (nested) values.set(`metadata.${nested[1]}`, unquote(nested[2]))
+        index += 1
+      }
+      continue
+    }
     values.set(key, unquote(rawValue))
     index += 1
   }
@@ -219,9 +229,9 @@ export function parseSkillDocument(source: string): SkillFrontmatter | null {
   return {
     name: name.slice(0, 120),
     description: description.slice(0, 1000),
-    version: values.get('version') || undefined,
+    version: values.get('version') || values.get('metadata.version') || undefined,
     license: values.get('license') || undefined,
-    author: values.get('author') || undefined,
+    author: values.get('author') || values.get('metadata.author') || undefined,
     category: values.get('category') || undefined,
     tags: parseInlineList(values.get('tags') || values.get('keywords')),
     frameworks: parseInlineList(values.get('frameworks')),
@@ -438,4 +448,22 @@ export async function fetchSkillPackageFiles(
   options: { maxFiles?: number } = {}
 ) {
   return (await fetchSkillPackageSnapshot(skill, options)).files
+}
+
+export async function fetchSkillVersionEvidence(skill: DiscoveredGitHubSkill, repositoryTree?: GitHubTreeItem[] | null) {
+  const input = { name: skill.frontmatter.name, path: skill.path, ref: skill.ref, declared: skill.frontmatter.version }
+  const declared = resolveSkillVersion(input)
+  if (declared.value) return declared
+  const paths = [...new Set([skill.directory ? `${skill.directory}/.claude-plugin/plugin.json` : '.claude-plugin/plugin.json', '.claude-plugin/plugin.json'])]
+    .filter(path => !repositoryTree || repositoryTree.some(item => item.type === 'blob' && item.path === path))
+  const pluginManifests = []
+  for (const path of paths) {
+    try {
+      pluginManifests.push({ path, content: await fetchRepositoryFile(skill.owner, skill.repo, skill.ref, path) })
+    } catch (error) {
+      // Only absence is optional; rate limits/network errors must stop source preparation.
+      if (!(error instanceof Error) || !error.message.includes('(404)')) throw error
+    }
+  }
+  return resolveSkillVersion({ ...input, pluginManifests })
 }

--- a/lib/indexer/high-star-import.ts
+++ b/lib/indexer/high-star-import.ts
@@ -1783,7 +1783,7 @@ function buildSkill(repo: GitHubSearchRepo, query: HighStarQuery, evaluation: Sk
     category: query.category,
     tags,
     frameworks,
-    version: '1.0.0',
+    version: 'Unknown',
     license: normalizeLicense(repo),
     install_command: `npx skills add ${repo.full_name}`,
     verified: repo.stargazers_count >= 1000,

--- a/lib/indexer/processor.ts
+++ b/lib/indexer/processor.ts
@@ -331,7 +331,7 @@ export async function processRepo(
       category: review.category,
       tags: review.tags,
       frameworks: repoMeta.language ? [repoMeta.language] : [],
-      version: '1.0.0',
+      version: 'Unknown',
       license,
       install_command: `npx skills add ${repoRef}`,
       verified: stars >= 100,

--- a/lib/indexer/repository-skill-sync.ts
+++ b/lib/indexer/repository-skill-sync.ts
@@ -9,6 +9,7 @@ import {
   discoverGitHubSkills,
   fetchDelegatedGitHubSkill,
   fetchSkillPackageSnapshot,
+  fetchSkillVersionEvidence,
   parseGitHubSkillReference,
   type DiscoveredGitHubSkill,
   type GitHubTreeItem,
@@ -101,10 +102,6 @@ function normalizeTags(skill: DiscoveredGitHubSkill, extraTags: string[] = []) {
     .slice(0, 10)
 }
 
-function normalizeVersion(value: string | undefined) {
-  return value && /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/.test(value) ? value : '1.0.0'
-}
-
 function contentHash(value: string) {
   return createHash('sha256').update(value).digest('hex')
 }
@@ -173,6 +170,7 @@ async function payloadForNew(
     }
   }
   const license = getLicenseEvidence(skill.frontmatter.license, repository.license)
+  const versionEvidence = await fetchSkillVersionEvidence(skill, repositoryTree)
   let reviewScores: { security: number; quality: number; usefulness: number; compliance: number }
   let reviewTotal: number
   let reviewSource: string
@@ -254,7 +252,7 @@ async function payloadForNew(
       category: inferIndexedSkillCategory(skill),
       tags,
       frameworks: skill.frontmatter.frameworks,
-      version: normalizeVersion(skill.frontmatter.version),
+      version: versionEvidence.value || 'Unknown',
       license: license.license,
       license_source: license.source,
       license_status: license.status,
@@ -264,6 +262,7 @@ async function payloadForNew(
       submission_source: discoverySource,
       submitted_by_agent: 'open-agent-skill-source-sync',
       ai_review_score: {
+        version_evidence: versionEvidence,
         ...reviewScores,
         total: reviewTotal,
         source: reviewSource,
@@ -476,10 +475,11 @@ export async function syncRepositorySkills(
         p_source_content_hash: sourceContentHash,
         p_source_ref: skill.ref,
         p_source_path: skill.path,
-        p_version: String(result.payload.version || '1.0.0'),
+        p_version: String(result.payload.version || 'Unknown'),
         p_license: String(result.payload.license || 'Unknown'),
         p_license_source: String(result.payload.license_source || 'unknown'),
         p_metadata: {
+          version_evidence: result.payload.ai_review_score.version_evidence,
           source_url: skill.sourceUrl,
           discovery_source: discoverySource,
         },

--- a/lib/indexer/verified-skill-sources.ts
+++ b/lib/indexer/verified-skill-sources.ts
@@ -156,7 +156,7 @@ function buildPayload(
     category: skill.category,
     tags: skill.tags,
     frameworks: skill.frameworks,
-    version: skill.version || '1.0.0',
+    version: skill.version || 'Unknown',
     license: skill.license,
     install_command: skill.install_command,
     verified: listingVerified,

--- a/lib/security/risk-context.ts
+++ b/lib/security/risk-context.ts
@@ -1,0 +1,39 @@
+/** Presentation hints only. Never use prose denials to bypass executable/static review gates. */
+export const FINANCIAL_EXECUTION_PATTERN = /\b(place orders?|order execution|execute trades?|trade execution|live trading|brokerage|broker account|exchange connectivity|wallet|private key|swap(?:ping)?|withdraw(?:al)?|deposit(?:ing)?|margin trading|perpetual futures?|api trading)\b/i
+export const SECRET_ACCESS_PATTERN = /\b(secrets?|tokens?|credentials?|api[ _-]?keys?|oauth|auth|env|environment variables?|passwords?)\b/i
+
+export function hasAffirmativeRiskText(text: string, pattern: RegExp) {
+  const matches = (value: string) => [...value.matchAll(new RegExp(pattern.source, `${pattern.ignoreCase ? 'i' : ''}g`))]
+  // Executable examples retain their risk even when the surrounding prose denies it.
+  for (const block of text.matchAll(/```[^\n]*\n([\s\S]*?)(?:```|$)|~~~[^\n]*\n([\s\S]*?)(?:~~~|$)/g)) {
+    if (matches(block[1] || block[2] || '').length) return true
+  }
+  const prose = text.replace(/```[\s\S]*?(?:```|$)|~~~[\s\S]*?(?:~~~|$)/g, '\n')
+  const clauses = prose.split(/[.!?;](?:\s|$)|\n\s*\n|\n(?=\s*(?:[-*]|\d+\.)\s|#{1,6}\s)|\b(?:but|however|instead|although|yet)\b/i)
+  for (const clause of clauses) {
+    for (const match of matches(clause)) {
+      const before = clause.slice(0, match.index).replace(/\s+/g, ' ')
+      const after = clause.slice((match.index || 0) + match[0].length).replace(/\s+/g, ' ')
+      const denial = before.match(/\b(?:(?:does|do|will|can) not (?:provide|perform|support|require|use|access|execute|read|collect)|never (?:uses?|requires?|accesses?|executes?)|no)\b([^.!?;]{0,220})$/i)
+      // Do not let a denial of one requirement swallow another affirmative action.
+      const denialHasNewAction = denial && /\b(?:need(?:s|ed)?|required|then|read|reads|write|writes|execute|executes|use|uses|access|accesses|collect|collects|upload|uploads|send|sends|must|can)\b/i.test(denial[1])
+      const deniedBefore = /\b(?:(?:does|do|will|can) not|never)\s*$/i.test(before) || Boolean(denial && !denialHasNewAction && !/\bnot only\b/i.test(before))
+      const deniedAfter = /^\s*(?:,?\s*(?:or|and)\s+[^.;!?]{1,70})?\s+(?:(?:is|are)\s+)?(?:not (?:required|needed|used|supported)|unnecessary)\b/i.test(after)
+      if (!deniedBefore && !deniedAfter) return true
+    }
+  }
+  return false
+}
+
+export function hasSkillRiskHint(skill: {
+  name?: string | null; description?: string | null; long_description?: string | null
+  tagline?: string | null; category?: string | null; install_command?: string | null
+  github_repo?: string | null; repository?: string | null; npm_package?: string | null
+  tags?: string[] | null; frameworks?: string[] | null
+}, pattern: RegExp) {
+  // Check fields separately: a disclaimer cannot cancel an install command or another field.
+  const direct = [skill.install_command, skill.github_repo, skill.repository, skill.npm_package, ...(skill.tags || []), ...(skill.frameworks || [])]
+  if (direct.some(value => value && new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, '')).test(value))) return true
+  return [skill.name, skill.description, skill.long_description, skill.tagline, skill.category]
+    .some(value => value && hasAffirmativeRiskText(value, pattern))
+}

--- a/lib/seo/curated-skill-snapshot.ts
+++ b/lib/seo/curated-skill-snapshot.ts
@@ -41,7 +41,7 @@ function snapshotSkill(input: {
     category: input.category,
     tags: input.tags,
     frameworks: input.frameworks,
-    version: '1.0.0',
+    version: 'Unknown',
     license: input.license || 'Unknown',
     install_command: input.installCommand || `npx skills add ${input.repo}`,
     npm_package: null,

--- a/lib/seo/search-indexability.ts
+++ b/lib/seo/search-indexability.ts
@@ -47,7 +47,7 @@ export function getSearchEvidenceProfile(
 
   if (skill.ai_review_approved) {
     score += 25
-    signals.push('AI review approved')
+    signals.push('Registry review approval recorded')
   }
   score += Math.min(25, Number(skill.quality_score || 0) / 4)
   if (Number(skill.quality_score || 0) >= SEARCH_INDEX_MIN_QUALITY_SCORE) signals.push('Quality-gated metadata')

--- a/lib/skills/open-submission.ts
+++ b/lib/skills/open-submission.ts
@@ -4,6 +4,7 @@ import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypt
 import { revalidatePath, revalidateTag } from 'next/cache'
 import type { GitHubRepo } from '@/lib/schema/skill-schema'
 import type { DiscoveredGitHubSkill } from '@/lib/github/skill-source'
+import { fetchSkillVersionEvidence } from '@/lib/github/skill-source'
 import { reviewSkill } from '@/lib/ai-review/reviewer'
 import { analyzeCode } from '@/lib/security/static-analysis'
 import { evaluateSkillSubmissionPolicy } from '@/lib/skills/submission-policy'
@@ -176,10 +177,6 @@ function normalizeTags(input: OpenSubmissionInput) {
   return result
 }
 
-function normalizeVersion(value: string | undefined) {
-  return value && /^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/.test(value) ? value : '1.0.0'
-}
-
 export async function createOpenSubmission(input: OpenSubmissionInput): Promise<OpenSubmissionReceipt> {
   await enforceSubmissionRateLimit(input.requestFingerprint)
 
@@ -256,6 +253,7 @@ export async function reviewOpenSubmission(input: OpenSubmissionInput, submissio
   if (!staticAnalysis.passed) return
 
   try {
+    const versionEvidence = await fetchSkillVersionEvidence(input.skill)
     const review = await reviewSkill({
       repository: input.skill.sourceUrl,
       readmeContent: input.skill.document,
@@ -325,12 +323,13 @@ export async function reviewOpenSubmission(input: OpenSubmissionInput, submissio
       category,
       tags,
       frameworks: input.skill.frontmatter.frameworks,
-      version: normalizeVersion(input.skill.frontmatter.version),
+      version: versionEvidence.value || 'Unknown',
       license: input.skill.frontmatter.license || input.repository.license || 'Unknown',
       install_command: `npx skills add ${input.repository.fullName} --skill ${input.skill.frontmatter.name}`,
       verified: false,
       listing_status: review.method === 'static' ? 'static_checked' : 'reviewed',
       source_ref: input.skill.ref,
+      source_commit_sha: /^[a-f0-9]{40}$/.test(input.skill.ref) ? input.skill.ref : null,
       source_path: input.skill.path,
       source_content_hash: sourceContentHash,
       publisher_github: input.makerGithub || null,
@@ -339,6 +338,7 @@ export async function reviewOpenSubmission(input: OpenSubmissionInput, submissio
       submission_source: input.submissionSource,
       submitted_by_agent: input.submittedByAgent || null,
       ai_review_score: {
+        version_evidence: versionEvidence,
         ...review.scores,
         total: review.totalScore,
         source: 'open-skill-submission',

--- a/lib/skills/owner-publication.ts
+++ b/lib/skills/owner-publication.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 import { createHash } from 'node:crypto'
 import { fetchRepositoryCommitSha, validateGitHubRepo } from '@/lib/github/api'
-import { discoverGitHubSkills, fetchSkillPackageSnapshot, parseGitHubSkillReference } from '@/lib/github/skill-source'
+import { discoverGitHubSkills, fetchSkillPackageSnapshot, fetchSkillVersionEvidence, parseGitHubSkillReference } from '@/lib/github/skill-source'
 import { analyzeCode } from '@/lib/security/static-analysis'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { isMcpOnlySkillRecord } from '@/lib/skills/registry-scope'
@@ -31,6 +31,7 @@ export async function prepareOwnerPublication(input: OwnerPublicationInput) {
   // Never execute repository code. Persist the scope of this advisory scan.
   const snapshot = await fetchSkillPackageSnapshot(skill, { maxFiles: 12, repositoryTree: discovery.tree })
   const staticAnalysis = analyzeCode(snapshot.files)
+  const versionEvidence = await fetchSkillVersionEvidence(skill, discovery.tree)
   const hash = createHash('sha256').update(skill.document).digest('hex')
   const slugPart = (text: string) => text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
   const base = `${slugPart(repository.owner)}-${slugPart(repository.repo)}`
@@ -56,7 +57,7 @@ export async function prepareOwnerPublication(input: OwnerPublicationInput) {
     category: skill.frontmatter.category || 'developer-tools',
     tags: [...new Set([...skill.frontmatter.tags, 'agent-skill'])].slice(0, 10),
     frameworks: skill.frontmatter.frameworks,
-    version: skill.frontmatter.version || '1.0.0',
+    version: versionEvidence.value || 'Unknown',
     license: skill.frontmatter.license || repository.license || 'Unknown',
     // Quote values sourced from untrusted repository metadata before handing
     // this command to a shell. The source is pinned to the recorded commit.
@@ -70,6 +71,7 @@ export async function prepareOwnerPublication(input: OwnerPublicationInput) {
   return {
     skill: metadata,
     scan: {
+      version_evidence: versionEvidence,
       ...staticAnalysis,
       advisory: true,
       executed: false,

--- a/lib/skills/review-evidence.ts
+++ b/lib/skills/review-evidence.ts
@@ -8,6 +8,7 @@ export function getReviewEvidence(skill: {
     indexed: true,
     static_checked: review.method === 'static' && current,
     ai_reviewed: review.method === 'ai' && Boolean(review.reviewed_at) && current,
+    manual_reviewed: (review.method === 'manual' || review.source === 'manual-review-v1') && Boolean(review.reviewed_at) && current,
     creator_verified: skill.publisher_verified === true,
     review_result: current ? String(review.decision || 'not_recorded') : 'version_needs_review',
     reviewed_at: typeof review.reviewed_at === 'string' ? review.reviewed_at : null,

--- a/lib/skills/version-evidence.ts
+++ b/lib/skills/version-evidence.ts
@@ -1,0 +1,45 @@
+/** Upstream declarations, not a registry-generated release or a security approval. */
+export interface SkillVersionEvidence {
+  value: string | null
+  source: 'skill_frontmatter' | 'plugin_manifest' | 'unknown'
+  path: string | null
+  ref: string | null
+}
+
+export function declaredSkillVersion(value: unknown): string | null {
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+  const version = String(value).trim()
+  // Preserve upstream versions such as 2.2 or v0.1.0; never pad or invent a release.
+  return /^[vV]?\d+(?:\.\d+){0,3}(?:[-+][a-zA-Z0-9.-]+)?$/.test(version) && version.length <= 80 ? version : null
+}
+
+export function resolveSkillVersion(input: {
+  name: string; path: string; ref: string; declared?: unknown
+  pluginManifests?: { path: string; content: string }[]
+}): SkillVersionEvidence {
+  const declared = declaredSkillVersion(input.declared)
+  if (declared) return { value: declared, source: 'skill_frontmatter', path: input.path, ref: input.ref }
+  for (const file of input.pluginManifests || []) {
+    try {
+      const manifest = JSON.parse(file.content)
+      // A monorepo/package version must not be borrowed from an unrelated plugin.
+      if (manifest.name !== input.name) continue
+      const value = declaredSkillVersion(manifest.version)
+      if (value) return { value, source: 'plugin_manifest', path: file.path, ref: input.ref }
+    } catch { /* Invalid optional metadata is not evidence. */ }
+  }
+  return { value: null, source: 'unknown', path: null, ref: input.ref }
+}
+
+export function getStoredSkillVersionEvidence(skill: {
+  ai_review_score?: Record<string, unknown> | null
+  owner_publication?: { static_analysis?: { version_evidence?: unknown } } | null
+}): SkillVersionEvidence | null {
+  const raw = skill.ai_review_score?.version_evidence || skill.owner_publication?.static_analysis?.version_evidence
+  if (!raw || typeof raw !== 'object') return null
+  const evidence = raw as SkillVersionEvidence
+  if (!['skill_frontmatter', 'plugin_manifest', 'unknown'].includes(evidence.source)) return null
+  return { value: declaredSkillVersion(evidence.value), source: evidence.source,
+    path: typeof evidence.path === 'string' ? evidence.path : null,
+    ref: typeof evidence.ref === 'string' ? evidence.ref : null }
+}

--- a/lib/trust.ts
+++ b/lib/trust.ts
@@ -1,5 +1,6 @@
 import { needsOwnerPublicationReview, OWNER_PUBLICATION_NOTICE } from '@/lib/skills/publication'
 import { getSkillSourceEvidence } from '@/lib/skills/source-evidence'
+import { FINANCIAL_EXECUTION_PATTERN, SECRET_ACCESS_PATTERN, hasSkillRiskHint } from '@/lib/security/risk-context'
 import type { SkillAgentStats, SkillEventStats, SkillOutcomeStats, SkillRecord } from '@/lib/db/skills'
 import { getAgentProvenProfile } from '@/lib/agent-proven'
 import { formatCompactNumber, getFreshnessDays } from '@/lib/quality'
@@ -561,9 +562,7 @@ function isFinancialDomainSkill(skill: SkillRecord) {
 }
 
 function hasFinancialExecutionRisk(skill: SkillRecord) {
-  return /\b(place orders?|order execution|execute trades?|trade execution|live trading|brokerage|broker account|exchange connectivity|wallet|private key|swap(?:ping)?|withdraw(?:al)?|deposit(?:ing)?|margin trading|perpetual futures?|api trading)\b/.test(
-    trustSignalText(skill)
-  )
+  return hasSkillRiskHint(skill, FINANCIAL_EXECUTION_PATTERN)
 }
 
 function scoreMaintenance(days: number | null) {
@@ -653,7 +652,7 @@ function getPermissionSurface(skill: SkillRecord) {
   const notes: string[] = []
   let exposure = 0
 
-  if (/\b(secret|token|credential|api key|oauth|env|environment variable|password)\b/.test(text)) {
+  if (hasSkillRiskHint(skill, SECRET_ACCESS_PATTERN)) {
     exposure += 26
     notes.push('secrets or environment access')
   }
@@ -694,7 +693,7 @@ function getDependencyRisk(skill: SkillRecord) {
     risk += 18
     notes.push('command execution surface')
   }
-  if (/\b(secret|token|credential|api key|oauth|env|environment variable)\b/.test(text)) {
+  if (hasSkillRiskHint(skill, SECRET_ACCESS_PATTERN)) {
     risk += 18
     notes.push('credential or environment access')
   }
@@ -884,7 +883,8 @@ export function getSkillTrustProfile(
   }
 
   if (skill.ai_review_approved) {
-    strengths.push('AI review approved')
+    strengths.push(skill.ai_review_score?.source === 'manual-review-v1' || skill.ai_review_score?.method === 'manual'
+      ? 'Manual source review recorded' : skill.ai_review_score?.method === 'ai' ? 'AI review approved' : 'Legacy review approval recorded')
   } else {
     warnings.push('AI review approval is missing')
   }

--- a/scripts/process-skill-issue.mjs
+++ b/scripts/process-skill-issue.mjs
@@ -264,6 +264,25 @@ async function main() {
   }
 
   const event = JSON.parse(await readFile(eventPath, 'utf8'))
+  if (process.env.GITHUB_EVENT_NAME === 'schedule') {
+    const issues = await fetchJson(`https://api.github.com/repos/${repository}/issues?state=open&sort=created&direction=asc&per_page=100`, { headers: githubHeaders(githubToken) })
+    const candidates = issues.filter(issue => !issue.pull_request && /^\[Skill\]:/i.test(issue.title || '') && isNewSkillRequest(issue.body || ''))
+    // Bounded rotating sweep. It only reconciles publication; never starts a review.
+    const offset = candidates.length ? (Math.floor(Date.now() / 86400000) * 5) % candidates.length : 0
+    const selected = [...candidates.slice(offset), ...candidates.slice(0, offset)].slice(0, 5)
+    for (const issue of selected) {
+      try {
+        const result = await processSkillIssue({ event: { issue }, repository, githubToken, operation: 'reconcile' })
+        console.log(JSON.stringify({ issue: issue.number, ...result }))
+      } catch {
+        // An outage is not a rejection. Avoid overwriting review comments or spamming the Issue.
+        console.error(`Publication reconciliation unavailable for Issue #${issue.number}; left open.`)
+        process.exitCode = 1
+        break
+      }
+    }
+    return
+  }
   if (process.env.GITHUB_EVENT_NAME === 'workflow_dispatch') {
     if (!/^\d+$/.test(event.inputs?.issue_number || '')) throw new Error('Invalid issue number.')
     event.issue = await fetchJson(`https://api.github.com/repos/${repository}/issues/${event.inputs.issue_number}`, { headers: githubHeaders(githubToken) })

--- a/scripts/process-skill-issue.mjs
+++ b/scripts/process-skill-issue.mjs
@@ -5,6 +5,24 @@ export const AUTOMATION_MARKER = '<!-- openagentskill-auto-ingest -->'
 
 const FINAL_STATUSES = new Set(['listed', 'reviewed', 'duplicate', 'quarantined'])
 const DEFAULT_API_BASE_URL = 'https://www.openagentskill.com'
+const ATTEMPT_MARKER = '<!-- openagentskill-review-attempt:'
+const REVIEW_COOLDOWN_MS = 6 * 60 * 60 * 1000
+
+export function parseMaintainerCommand(body) {
+  const match = String(body || '').trim().match(/^\/oas\s+(review\s+([a-f0-9]{40})|reconcile)$/i)
+  return match ? { operation: match[2] ? 'review' : 'reconcile', revision: match[2]?.toLowerCase() } : null
+}
+
+export function reviewAttemptDecision(comments, { repository, path, commit }, now = Date.now()) {
+  const attempts = comments.filter(c => c.user?.login === 'github-actions[bot]').flatMap(c => {
+    const match = c.body?.match(/<!-- openagentskill-review-attempt:(\{[^\n]+\}) -->/)
+    if (!match) return []
+    try { return [{ ...JSON.parse(match[1]), createdAt: Date.parse(c.created_at) }] } catch { return [] }
+  })
+  if (attempts.some(a => a.repository === repository && a.path === path && a.commit === commit)) return 'This immutable revision was already submitted. Reconcile its status instead of paying for another review.'
+  if (attempts.some(a => !Number.isFinite(a.createdAt) || now - a.createdAt < REVIEW_COOLDOWN_MS)) return 'Re-review cooldown: wait six hours before submitting another revision of this Issue.'
+  return null
+}
 
 function sectionBody(markdown, heading) {
   const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -57,10 +75,13 @@ export function buildResultComment({ status, skill, review, apiBaseUrl = DEFAULT
   const noteList = notes.length > 0 ? `\n\nReview notes:\n${notes.map((note) => `- ${note}`).join('\n')}` : ''
 
   if (status === 'reviewed') {
-    return `${AUTOMATION_MARKER}\nThanks for submitting **${name}**. The automated security and quality review passed, and the Skill is now published:\n\n${publicUrl}`
+    const method = review?.method === 'static' ? 'Static checks passed (not an AI review or runtime test).'
+      : review?.method === 'ai' ? 'AI review passed for the submitted revision (not a runtime test or safety guarantee).'
+      : 'The submission pipeline reports publication; the review method is not recorded.'
+    return `${AUTOMATION_MARKER}\nThanks for submitting **${name}**. ${method}\n\n${publicUrl || 'Public URL is not yet available; this Issue remains open.'}`
   }
   if (status === 'duplicate') {
-    return `${AUTOMATION_MARKER}\nThanks for submitting **${name}**. This Skill is already in OpenAgentSkill${publicUrl ? `:\n\n${publicUrl}` : '.'}`
+    return `${AUTOMATION_MARKER}\nThanks for submitting **${name}**. This Skill is already in OpenAgentSkill${publicUrl ? `:\n\n${publicUrl}` : '.'}\n\nPublication and review are separate facts. ${skill?.reviewEvidence?.manual_reviewed ? 'A manual source review is recorded; this is not an AI review or runtime test.' : skill?.reviewEvidence?.static_checked ? 'Static checks are recorded, not an AI review or runtime test.' : skill?.reviewEvidence?.ai_reviewed ? 'AI review evidence is recorded; runtime safety is not guaranteed.' : 'No current, classified AI-review evidence is recorded.'}${skill?.license ? ` License: ${skill.license}.` : ''}`
   }
   if (status === 'listed') {
     return `${AUTOMATION_MARKER}\nThanks for submitting **${name}**. It was saved to the OpenAgentSkill community review queue, but automated review did not approve immediate publication. This issue will remain open for manual review.${noteList}`
@@ -76,7 +97,7 @@ export function buildFailureComment(message) {
 }
 
 async function fetchJson(url, options = {}) {
-  const response = await fetch(url, options)
+  const response = await fetch(url, { signal: AbortSignal.timeout(60_000), redirect: 'error', ...options })
   const text = await response.text()
   let payload = {}
   try {
@@ -104,19 +125,7 @@ function githubHeaders(token) {
 
 async function upsertIssueComment({ repository, issueNumber, token, body }) {
   const commentsUrl = `https://api.github.com/repos/${repository}/issues/${issueNumber}/comments`
-  const comments = await fetchJson(`${commentsUrl}?per_page=100`, { headers: githubHeaders(token) })
-  const previous = Array.isArray(comments)
-    ? comments.find((comment) => comment?.user?.type === 'Bot' && comment?.body?.includes(AUTOMATION_MARKER))
-    : null
-
-  if (previous?.id) {
-    return fetchJson(`https://api.github.com/repos/${repository}/issues/comments/${previous.id}`, {
-      method: 'PATCH',
-      headers: githubHeaders(token),
-      body: JSON.stringify({ body }),
-    })
-  }
-
+  // Append rather than rewrite: previous review decisions remain visible.
   return fetchJson(commentsUrl, {
     method: 'POST',
     headers: githubHeaders(token),
@@ -135,6 +144,7 @@ async function closeIssue({ repository, issueNumber, token }) {
 async function waitForSubmission(apiBaseUrl, receipt) {
   if (FINAL_STATUSES.has(receipt.status)) return receipt
   const statusUrl = new URL(receipt.statusUrl, apiBaseUrl).toString()
+  if (new URL(statusUrl).origin !== apiBaseUrl) throw new Error('Invalid receipt origin.')
 
   for (let attempt = 0; attempt < 45; attempt += 1) {
     await new Promise((resolve) => setTimeout(resolve, 2_000))
@@ -147,19 +157,40 @@ async function waitForSubmission(apiBaseUrl, receipt) {
   return receipt
 }
 
-export async function processSkillIssue({ event, repository, githubToken, apiBaseUrl = DEFAULT_API_BASE_URL }) {
+async function issueComments(repository, number, token) {
+  const comments = []
+  for (let page = 1; page <= 3; page++) {
+    const batch = await fetchJson(`https://api.github.com/repos/${repository}/issues/${number}/comments?per_page=100&page=${page}`, { headers: githubHeaders(token) })
+    comments.push(...batch)
+    if (batch.length < 100) return comments
+  }
+  throw new Error('Issue history exceeds the automatic review window; inspect manually.')
+}
+
+export async function processSkillIssue({ event, repository, githubToken, apiBaseUrl = DEFAULT_API_BASE_URL, operation, revision }) {
   const issue = event.issue
-  if (!issue || !/^\[Skill\]:/i.test(issue.title || '')) {
+  if (!issue || issue.pull_request || issue.state === 'closed' || !/^\[Skill\]:/i.test(issue.title || '')) {
     return { skipped: true, reason: 'Not a Skill submission issue.' }
   }
   if (!isNewSkillRequest(issue.body || '')) {
     return { skipped: true, reason: 'This issue is not a New Skill request.' }
   }
 
+  if (event.comment) {
+    const command = parseMaintainerCommand(event.comment.body)
+    if (!command || event.action !== 'created') return { skipped: true, reason: 'Not a maintainer command.' }
+    const actor = event.comment.user?.login
+    const permission = await fetchJson(`https://api.github.com/repos/${repository}/collaborators/${encodeURIComponent(actor || '')}/permission`, { headers: githubHeaders(githubToken) })
+    if (!['admin', 'maintain', 'write'].includes(permission.permission)) return { skipped: true, reason: 'Maintainer permission required.' }
+    ;({ operation, revision } = command)
+  }
+
   const sourceUrl = extractGitHubSource(issue.body || '')
   if (!sourceUrl) throw new Error('No supported public GitHub repository, directory, or SKILL.md URL was found.')
 
   const baseUrl = apiBaseUrl.replace(/\/$/, '')
+  if (baseUrl !== DEFAULT_API_BASE_URL) throw new Error('Issue ingestion only targets the production first-party API.')
+  const comments = await issueComments(repository, issue.number, githubToken)
   const validation = await fetchJson(`${baseUrl}/api/skills/validate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'User-Agent': 'OpenAgentSkill-Issue-Ingest/1.0' },
@@ -172,15 +203,37 @@ export async function processSkillIssue({ event, repository, githubToken, apiBas
       : 'No valid SKILL.md was found at the submitted source.')
   }
 
+  const sourceParts = new URL(sourceUrl).pathname.split('/').filter(Boolean)
+  const sourceRepository = sourceParts.slice(0, 2).join('/').toLowerCase()
+  const lookupUrl = `${baseUrl}/api/skills/lookup?${new URLSearchParams({ repository: sourceRepository, path: candidate.path })}`
+  const existing = (await fetchJson(lookupUrl)).skill
+  if (existing) {
+    if (operation === 'review' && revision && existing.commit !== revision) {
+      return { skipped: true, reason: 'A different revision is already published. Use source-version sync; do not overwrite its review with a new submission.' }
+    }
+    await upsertIssueComment({ repository, issueNumber: issue.number, token: githubToken, body: buildResultComment({ status: 'duplicate', skill: existing, apiBaseUrl: baseUrl }) })
+    await closeIssue({ repository, issueNumber: issue.number, token: githubToken })
+    return { status: 'duplicate', skill: existing }
+  }
+  if (operation === 'reconcile') return { skipped: true, reason: 'No public listing matches this repository and Skill path. The Issue remains open.' }
+  const requestedRef = revision || candidate.ref
+  if (operation === 'review' && !/^[a-f0-9]{40}$/.test(revision || '')) throw new Error('Re-review requires a full immutable commit SHA.')
+  const commitResult = await fetchJson(`https://api.github.com/repos/${sourceRepository}/commits/${encodeURIComponent(requestedRef)}`, { headers: githubHeaders(githubToken) })
+  if (!/^[a-f0-9]{40}$/.test(commitResult.sha || '')) throw new Error('Could not pin source commit.')
+  const attempt = { repository: sourceRepository, path: candidate.path, commit: commitResult.sha }
+  const decision = reviewAttemptDecision(comments, attempt)
+  if (decision) return { skipped: true, reason: decision }
+  await upsertIssueComment({ repository, issueNumber: issue.number, token: githubToken,
+    body: `${ATTEMPT_MARKER}${JSON.stringify(attempt)} -->\nReview requested for immutable revision \`${attempt.commit}\`. Previous reviews remain unchanged. Publication requires the normal submission checks.` })
+
   const submitted = await fetchJson(`${baseUrl}/api/skills/submit`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'User-Agent': 'OpenAgentSkill-Issue-Ingest/1.0' },
     body: JSON.stringify({
       repository: sourceUrl,
       skillPath: candidate.path,
-      sourceRef: candidate.ref,
+      sourceRef: attempt.commit,
       tags: extractSuggestedTags(issue.body || ''),
-      makerGithub: issue.user?.login,
       submissionSource: 'api',
     }),
   })
@@ -193,11 +246,13 @@ export async function processSkillIssue({ event, repository, githubToken, apiBas
     token: githubToken,
     body: comment,
   })
-  if (result.status === 'reviewed' || result.status === 'duplicate') {
+  if (['reviewed', 'duplicate'].includes(result.status) && result.skill?.slug) {
+    const confirmed = (await fetchJson(lookupUrl)).skill
+    if (confirmed?.slug !== result.skill.slug) throw new Error('Publication could not be confirmed; Issue remains open.')
     await closeIssue({ repository, issueNumber: issue.number, token: githubToken })
   }
 
-  return { skipped: false, sourceUrl, candidate, submission: result }
+  return { skipped: false, sourceUrl, commit: attempt.commit, status: result.status, skill: result.skill, review: result.review }
 }
 
 async function main() {
@@ -209,12 +264,18 @@ async function main() {
   }
 
   const event = JSON.parse(await readFile(eventPath, 'utf8'))
+  if (process.env.GITHUB_EVENT_NAME === 'workflow_dispatch') {
+    if (!/^\d+$/.test(event.inputs?.issue_number || '')) throw new Error('Invalid issue number.')
+    event.issue = await fetchJson(`https://api.github.com/repos/${repository}/issues/${event.inputs.issue_number}`, { headers: githubHeaders(githubToken) })
+  }
   try {
     const result = await processSkillIssue({
       event,
       repository,
       githubToken,
       apiBaseUrl: process.env.OPENAGENTSKILL_API_BASE_URL || DEFAULT_API_BASE_URL,
+      operation: event.inputs?.operation,
+      revision: event.inputs?.revision,
     })
     console.log(JSON.stringify(result, null, 2))
   } catch (error) {

--- a/scripts/test-owner-publication.mjs
+++ b/scripts/test-owner-publication.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import './test-review-provenance.mjs'
 import { readFileSync } from 'node:fs'
 import { register } from 'node:module'
 register('./test-owner-publication-loader.mjs', import.meta.url)

--- a/scripts/test-review-provenance.mjs
+++ b/scripts/test-review-provenance.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { register } from 'node:module'
+register('./test-owner-publication-loader.mjs', import.meta.url)
+const { declaredSkillVersion, resolveSkillVersion } = await import('../lib/skills/version-evidence.ts')
+const { parseSkillDocument, fetchSkillVersionEvidence } = await import('../lib/github/skill-source.ts')
+const { hasAffirmativeRiskText, hasSkillRiskHint, FINANCIAL_EXECUTION_PATTERN: financial, SECRET_ACCESS_PATTERN: secrets } = await import('../lib/security/risk-context.ts')
+const { getSkillTrustProfile } = await import('../lib/trust.ts')
+const { buildSkillAudit } = await import('../lib/audits.ts')
+const { getAgentSafetyProfile } = await import('../lib/agent-safety.ts')
+const { getLicenseEvidence } = await import('../lib/creator-ownership.ts')
+
+for (const value of [undefined, null, '', 'Unknown', '1.0.0;rm -rf', '<script>']) assert.equal(declaredSkillVersion(value), null)
+for (const value of ['2.2', '0.1.0', 'v3.4.5-beta.1']) assert.equal(declaredSkillVersion(value), value)
+const ref = 'a'.repeat(40)
+const versionInput = { name: 'market-brief', path: 'skills/market-brief/SKILL.md', ref }
+assert.equal(resolveSkillVersion(versionInput).source, 'unknown')
+assert.equal(resolveSkillVersion({ ...versionInput, pluginManifests: [{ path: '.claude-plugin/plugin.json', content: '{"name":"other","version":"9.0.0"}' }] }).value, null)
+const manifest = { path: '.claude-plugin/plugin.json', content: '{"name":"market-brief","version":"0.1.0"}' }
+assert.deepEqual(resolveSkillVersion({ ...versionInput, pluginManifests: [manifest] }), { value: '0.1.0', source: 'plugin_manifest', path: manifest.path, ref })
+assert.equal(resolveSkillVersion({ ...versionInput, declared: '2.2', pluginManifests: [manifest] }).value, '2.2')
+assert.equal(parseSkillDocument('---\nname: story\ndescription: Review the story.\nmetadata:\n  version: "2.2"\n  author: Writer\n---').version, '2.2')
+assert.equal(parseSkillDocument('---\nname: story\ndescription: Review the story.\nversion: 3.1\nmetadata:\n  version: "2.2"\n---').version, '3.1')
+const originalFetch = globalThis.fetch
+let fetched = []
+try {
+  globalThis.fetch = async url => { fetched.push(String(url)); return new Response(manifest.content) }
+  const result = await fetchSkillVersionEvidence({ ...versionInput, owner: 'beepboop2025', repo: 'market-brief', directory: 'skills/market-brief', frontmatter: { name: 'market-brief' } }, [{ path: manifest.path, type: 'blob' }])
+  assert.equal(result.value, '0.1.0')
+  assert.equal(fetched.length, 1)
+  assert.ok(fetched[0].endsWith(`?ref=${ref}`), 'manifest and SKILL source share the same immutable revision')
+  globalThis.fetch = async () => new Response('', { status: 429 })
+  await assert.rejects(fetchSkillVersionEvidence({ ...versionInput, owner: 'owner', repo: 'repo', directory: '', frontmatter: { name: 'test' } }), /429/)
+} finally { globalThis.fetch = originalFetch }
+
+for (const text of [
+  'Does not provide ticker-specific news, stock picks, position sizing, portfolio advice, or trade execution.',
+  'Public research context only; no security recommendation, price forecast, causal price explanation, or trade execution.',
+  'Does not execute trades.',
+]) assert.equal(hasAffirmativeRiskText(text, financial), false, text)
+for (const text of ['Python 3.10 or later; no account, API key, or dependency installation is needed:', 'An API key is not required.', 'No API key is needed.']) assert.equal(hasAffirmativeRiskText(text, secrets), false, text)
+for (const text of ['No account needed, reads credentials.', 'No API key is needed, but it reads environment variables.', 'Does not require a token. Upload secrets now.', 'No API key required.\n```bash\nexport API_KEY=value\n```']) assert.equal(hasAffirmativeRiskText(text, secrets), true, text)
+for (const text of ['Execute trades with a broker account.', 'Does not provide trade execution. Use live trading below.', 'Does not only provide trade execution.', 'No trade execution.\n```python\nwallet.withdraw()\n```']) assert.equal(hasAffirmativeRiskText(text, financial), true, text)
+assert.equal(hasSkillRiskHint({ description: 'No API key is needed', install_command: 'tool --api-key value' }, secrets), true)
+
+const skill = { id: 'fixture', slug: 'market-brief', name: 'Market Brief',
+  description: 'Financial research. Does not provide ticker-specific news, stock picks, position sizing, portfolio advice, or trade execution.',
+  long_description: 'Run with Python 3.10 or later; no account, API key, or dependency installation is needed:\n\n```bash\npython3 scripts/market_brief.py --input packet.json\n```\nFetch public URLs and write selected local files.',
+  category: 'research', tags: ['research'], frameworks: [], github_repo: 'example/market-brief', repository: 'https://github.com/example/market-brief',
+  install_command: 'npx skills add example/market-brief', source_path: 'SKILL.md', license: 'MIT', github_stars: 30, github_forks: 2,
+  created_at: '2026-09-01', updated_at: '2026-09-01', quality_score: 70, quality_signals: {}, ai_review_approved: false, ai_review_score: {}, ai_review_issues: [], ai_review_suggestions: [] }
+const trust = getSkillTrustProfile(skill)
+const audit = buildSkillAudit(skill)
+const safety = getAgentSafetyProfile(skill, audit)
+assert.doesNotMatch(JSON.stringify(trust.warnings), /real-money trading/)
+assert.match(JSON.stringify(trust.warnings), /not financial advice/)
+assert.doesNotMatch(JSON.stringify(audit.warnings), /real-money trading/)
+assert.equal(safety.permission_hints.some(h => h.id === 'secrets'), false)
+assert.equal(safety.permission_hints.some(h => h.id === 'network'), true)
+assert.equal(safety.permission_hints.some(h => h.id === 'filesystem'), true)
+assert.equal(getAgentSafetyProfile({ ...skill, long_description: skill.long_description + '\nRead environment variables and execute a shell command.' }, audit).permission_hints.some(h => h.id === 'secrets'), true)
+for (const license of ['PolyForm-Noncommercial-1.0.0', 'CC-BY-NC-4.0', 'Non Commercial']) {
+  assert.equal(getLicenseEvidence(license).status, 'restricted')
+  assert.match(JSON.stringify(buildSkillAudit({ ...skill, license }).warnings), /commercial/i)
+}
+for (const path of ['lib/skills/open-submission.ts', 'lib/skills/owner-publication.ts', 'lib/indexer/repository-skill-sync.ts']) {
+  const source = readFileSync(new URL('../' + path, import.meta.url), 'utf8')
+  assert.ok(source.includes('fetchSkillVersionEvidence'), path)
+  assert.doesNotMatch(source, /version[^\n]*\|\| '1\.0\.0'/)
+}
+const migration = readFileSync(new URL('../supabase/migrations/20260909090953_skill_version_provenance.sql', import.meta.url), 'utf8')
+assert.match(migration, /version_correction/)
+assert.match(migration, /previous_version/)
+assert.match(migration, /perform public\.assert_indexer_secret/)
+assert.match(migration, /from public, anon, authenticated/)
+assert.doesNotMatch(migration, /ai_review_approved\s*=|update public\.skill_submissions/i, 'metadata repair cannot rewrite approvals or rejected submissions')
+assert.match(migration, /source_commit_sha = '5f40a60426a2ced36c6331bcb3bf47dbd1333398'/)
+assert.match(migration, /source_content_hash = '91f2be4e/)
+console.log('Version provenance, negated-risk context, affirmative/code risk retention and restricted-license regression tests passed.')

--- a/scripts/test-review-provenance.mjs
+++ b/scripts/test-review-provenance.mjs
@@ -69,6 +69,13 @@ for (const path of ['lib/skills/open-submission.ts', 'lib/skills/owner-publicati
   assert.doesNotMatch(source, /version[^\n]*\|\| '1\.0\.0'/)
 }
 const migration = readFileSync(new URL('../supabase/migrations/20260909090953_skill_version_provenance.sql', import.meta.url), 'utf8')
+for (const endpoint of ['validate', 'submit']) {
+  const source = readFileSync(new URL(`../app/api/skills/${endpoint}/route.ts`, import.meta.url), 'utf8')
+  const guard = source.indexOf('.isPrivate)')
+  assert.ok(guard > 0 && guard < source.indexOf('await discoverGitHubSkills'), 'public intake must reject private repositories before reading skill content')
+}
+const lookup = readFileSync(new URL('../app/api/skills/lookup/route.ts', import.meta.url), 'utf8')
+assert.ok(lookup.includes(String.raw`replace(/[\\%_]/g, '\\$&')`), 'exact lookup escapes all LIKE metacharacters')
 assert.match(migration, /version_correction/)
 assert.match(migration, /previous_version/)
 assert.match(migration, /perform public\.assert_indexer_secret/)

--- a/scripts/test-skill-issue-ingest.mjs
+++ b/scripts/test-skill-issue-ingest.mjs
@@ -7,6 +7,9 @@ import {
   extractGitHubSource,
   extractSuggestedTags,
   isNewSkillRequest,
+  parseMaintainerCommand,
+  processSkillIssue,
+  reviewAttemptDecision,
 } from './process-skill-issue.mjs'
 
 const issueBody = `## Public repository, subdirectory, or SKILL.md URL
@@ -58,5 +61,68 @@ const queued = buildResultComment({
 assert.match(queued, /remain open/)
 assert.match(queued, /Needs manual review/)
 assert.match(buildFailureComment('bad\ninput'), /bad input/)
+
+const commit = 'a'.repeat(40)
+assert.deepEqual(parseMaintainerCommand(`/oas review ${commit}`), { operation: 'review', revision: commit })
+assert.equal(parseMaintainerCommand(`/oas review ${commit}; echo injected`), null)
+assert.equal(parseMaintainerCommand('/oas review main'), null)
+assert.equal(parseMaintainerCommand('Please /oas reconcile'), null)
+const attempt = { repository: 'example/repo', path: 'one/SKILL.md', commit }
+const attemptBody = `<!-- openagentskill-review-attempt:${JSON.stringify(attempt)} -->`
+const history = [{ user: { login: 'github-actions[bot]' }, body: attemptBody, created_at: '2026-09-01T00:00:00Z' }]
+assert.match(reviewAttemptDecision(history, attempt), /already submitted/)
+assert.equal(reviewAttemptDecision([{ ...history[0], user: { login: 'attacker' } }], attempt), null)
+assert.match(reviewAttemptDecision([{ ...history[0], created_at: new Date().toISOString() }], { ...attempt, commit: 'b'.repeat(40) }), /cooldown/)
+assert.match(buildResultComment({ status: 'reviewed', skill: { slug: 'example' }, review: { method: 'static' } }), /not an AI review/)
+assert.match(buildResultComment({ status: 'duplicate', skill: { slug: 'example', license: 'PolyForm-Noncommercial-1.0.0', reviewEvidence: { manual_reviewed: true } } }), /manual source review/)
+
+const originalFetch = globalThis.fetch
+const base = 'https://www.openagentskill.com'
+const event = { action: 'created', issue: { number: 118, title: '[Skill]: Example', state: 'open', body: issueBody, user: { login: 'submitter' } }, comment: { body: `/oas review ${commit}`, user: { login: 'maintainer' } } }
+let permission = 'write', publicSkill = null, status = 'reviewed', comments = [], calls = []
+const sourceRepo = 'musoyangrigor/scroll-video-website-skill'
+const candidate = { path: 'scroll-video-website/SKILL.md', ref: 'main', name: 'Example' }
+const listedSkill = { name: 'Example', slug: 'example', repository: sourceRepo, path: candidate.path, commit, license: 'MIT', reviewEvidence: { static_checked: true } }
+try {
+  globalThis.fetch = async (url, options = {}) => {
+    const target = new URL(url), method = options.method || 'GET'
+    calls.push({ url: target.href, method, body: options.body })
+    if (target.origin === base) assert.equal(options.headers?.Authorization, undefined, 'GitHub credentials must never reach the publication API')
+    if (target.pathname.endsWith('/permission')) return Response.json({ permission })
+    if (target.pathname.endsWith('/comments') && method === 'GET') return Response.json(comments)
+    if (target.pathname.endsWith('/comments') && method === 'POST') return Response.json({ id: 123 })
+    if (target.pathname.endsWith('/issues/118') && method === 'PATCH') return Response.json({ state: 'closed' })
+    if (target.pathname === '/api/skills/validate') return Response.json({ skills: [candidate] })
+    if (target.pathname === '/api/skills/lookup') return Response.json({ skill: publicSkill })
+    if (target.pathname.includes('/commits/')) return Response.json({ sha: commit })
+    if (target.pathname === '/api/skills/submit') {
+      assert.equal(JSON.parse(options.body).sourceRef, commit)
+      assert.equal(JSON.parse(options.body).makerGithub, undefined, 'issue reporter is not assumed to be the creator')
+      publicSkill = status === 'reviewed' ? listedSkill : null
+      return Response.json({ submission: { status, skill: { name: 'Example', slug: status === 'reviewed' ? 'example' : null }, review: { method: 'static' } } })
+    }
+    throw new Error(`Unexpected test request: ${target.href}`)
+  }
+  permission = 'read'
+  assert.equal((await processSkillIssue({ event, repository: 'Leon-Drq/openagentskill', githubToken: 'fixture-token' })).skipped, true)
+  assert.equal(calls.length, 1, 'untrusted comments must not validate, submit or write comments')
+  permission = 'write'; calls = []
+  assert.equal((await processSkillIssue({ event, repository: 'Leon-Drq/openagentskill', githubToken: 'fixture-token' })).status, 'reviewed')
+  assert.equal(calls.filter(c => c.url.endsWith('/api/skills/submit')).length, 1)
+  assert.equal(calls.filter(c => c.method === 'PATCH').length, 1, 'close only after confirmed publication')
+  assert.ok(calls.findIndex(c => c.method === 'POST' && c.url.endsWith('/comments')) < calls.findIndex(c => c.url.endsWith('/api/skills/submit')), 'persist dedupe marker before submitting')
+  calls = []
+  await processSkillIssue({ event: { ...event, comment: { ...event.comment, body: '/oas reconcile' } }, repository: 'Leon-Drq/openagentskill', githubToken: 'fixture-token' })
+  assert.equal(calls.filter(c => c.url.endsWith('/api/skills/submit')).length, 0, 'already-public reconciliation does not resubmit')
+  publicSkill = null; calls = []; status = 'listed'
+  await processSkillIssue({ event, repository: 'Leon-Drq/openagentskill', githubToken: 'fixture-token' })
+  assert.equal(calls.filter(c => c.method === 'PATCH').length, 0, 'manual review keeps Issue open')
+  calls = []; status = 'quarantined'
+  await processSkillIssue({ event, repository: 'Leon-Drq/openagentskill', githubToken: 'fixture-token' })
+  assert.equal(calls.filter(c => c.method === 'PATCH').length, 0, 'quarantine never closes as published')
+  calls = []; comments = [{ ...history[0], body: `<!-- openagentskill-review-attempt:${JSON.stringify({ ...attempt, repository: sourceRepo, path: candidate.path })} -->` }]
+  assert.equal((await processSkillIssue({ event, repository: 'Leon-Drq/openagentskill', githubToken: 'fixture-token' })).skipped, true)
+  assert.equal(calls.filter(c => c.url.endsWith('/api/skills/submit')).length, 0, 'same source revision never gets another automatic review')
+} finally { globalThis.fetch = originalFetch }
 
 console.log('Skill Issue ingestion tests passed.')

--- a/scripts/test-skill-issue-ingest.mjs
+++ b/scripts/test-skill-issue-ingest.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import {
   AUTOMATION_MARKER,
   buildFailureComment,
@@ -124,5 +125,10 @@ try {
   assert.equal((await processSkillIssue({ event, repository: 'Leon-Drq/openagentskill', githubToken: 'fixture-token' })).skipped, true)
   assert.equal(calls.filter(c => c.url.endsWith('/api/skills/submit')).length, 0, 'same source revision never gets another automatic review')
 } finally { globalThis.fetch = originalFetch }
+const scriptSource = readFileSync(new URL('./process-skill-issue.mjs', import.meta.url), 'utf8')
+const scheduledSweep = scriptSource.slice(scriptSource.indexOf("if (process.env.GITHUB_EVENT_NAME === 'schedule')"), scriptSource.indexOf("if (process.env.GITHUB_EVENT_NAME === 'workflow_dispatch')"))
+assert.ok(scheduledSweep.includes("operation: 'reconcile'"))
+assert.ok(scheduledSweep.includes('.slice(0, 5)'))
+assert.ok(!scheduledSweep.includes('/api/skills/submit'), 'daily reconciliation must not start paid reviews')
 
 console.log('Skill Issue ingestion tests passed.')

--- a/scripts/test-skill-source.ts
+++ b/scripts/test-skill-source.ts
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict'
+import { register } from 'node:module'
+register('./test-owner-publication-loader.mjs', import.meta.url)
 // Node's type-stripping runner needs the explicit extension; the app compiler resolves the same module by alias.
 // @ts-expect-error TS5097 is expected for this standalone Node test entrypoint.
-import { detectSkillDelegationName, parseGitHubSkillReference, parseSkillDocument, selectSkillDocumentPaths } from '../lib/github/skill-source.ts'
+const { detectSkillDelegationName, parseGitHubSkillReference, parseSkillDocument, selectSkillDocumentPaths } = await import('../lib/github/skill-source.ts')
 
 assert.deepEqual(parseGitHubSkillReference('Leon-Drq/openagentskill'), {
   owner: 'Leon-Drq',

--- a/supabase/migrations/20260909090953_skill_version_provenance.sql
+++ b/supabase/migrations/20260909090953_skill_version_provenance.sql
@@ -1,0 +1,132 @@
+-- Version defaults are absence markers, not invented upstream releases.
+alter table public.skills alter column version set default 'Unknown';
+alter table public.skill_versions alter column version set default 'Unknown';
+
+-- Keep the existing source-sync authorization and audit semantics; only fix
+-- absent-version fallback and the noncommercial license spelling variant.
+create or replace function public.record_skill_source_version(
+  p_server_secret text,
+  p_skill_slug text,
+  p_source_commit_sha text,
+  p_source_content_hash text,
+  p_source_ref text,
+  p_source_path text,
+  p_version text,
+  p_license text,
+  p_license_source text,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_previous_hash text;
+  v_changed boolean;
+  v_license_status text;
+begin
+  perform public.assert_indexer_secret(p_server_secret);
+
+  if p_source_content_hash is null or p_source_content_hash !~ '^[a-f0-9]{64}$' then
+    raise exception 'Invalid source content hash';
+  end if;
+
+  select source_content_hash into v_previous_hash
+  from public.skills where slug = p_skill_slug for update;
+
+  if not found then
+    raise exception 'Skill not found';
+  end if;
+
+  v_changed := v_previous_hash is not null and v_previous_hash is distinct from p_source_content_hash;
+  v_license_status := case
+    when coalesce(trim(p_license), '') = '' or lower(trim(p_license)) in ('unknown', 'noassertion', 'other') then 'missing'
+    when lower(p_license) ~ 'non[- ]?commercial' or lower(p_license) like '%cc-by-nc%' then 'restricted'
+    else 'detected'
+  end;
+
+  update public.skills set
+    source_commit_sha = nullif(p_source_commit_sha, ''),
+    source_content_hash = p_source_content_hash,
+    source_sync_status = case when v_changed then 'changed' else 'current' end,
+    source_ref = coalesce(nullif(p_source_ref, ''), source_ref),
+    source_path = coalesce(nullif(p_source_path, ''), source_path),
+    license_source = case
+      when p_license_source in ('skill_frontmatter', 'github_repository', 'manual') then p_license_source
+      else 'unknown'
+    end,
+    license_status = v_license_status,
+    last_synced_at = now(),
+    updated_at = now()
+  where slug = p_skill_slug;
+
+  insert into public.skill_versions (
+    skill_slug, version, source_commit_sha, source_content_hash,
+    source_ref, source_path, license, license_source, metadata
+  ) values (
+    p_skill_slug, coalesce(nullif(p_version, ''), 'Unknown'),
+    nullif(p_source_commit_sha, ''), p_source_content_hash,
+    nullif(p_source_ref, ''), nullif(p_source_path, ''),
+    coalesce(nullif(p_license, ''), 'Unknown'),
+    case when p_license_source in ('skill_frontmatter', 'github_repository', 'manual')
+      then p_license_source else 'unknown' end,
+    coalesce(p_metadata, '{}'::jsonb)
+  ) on conflict (skill_slug, source_content_hash) do update set
+    source_commit_sha = excluded.source_commit_sha,
+    version = excluded.version,
+    license = excluded.license,
+    license_source = excluded.license_source,
+    metadata = public.skill_versions.metadata || excluded.metadata;
+
+  return jsonb_build_object(
+    'changed', v_changed,
+    'previous_hash', v_previous_hash,
+    'current_hash', p_source_content_hash,
+    'license_status', v_license_status
+  );
+end;
+$$;
+
+revoke all on function public.record_skill_source_version(
+  text, text, text, text, text, text, text, text, text, jsonb
+) from public, anon, authenticated;
+grant execute on function public.record_skill_source_version(
+  text, text, text, text, text, text, text, text, text, jsonb
+) to service_role;
+
+-- #111: correct only the already-recorded immutable snapshot. Do not replace
+-- source content, alter submission state, approve a review, or change scores.
+-- The matching plugin manifest declares 0.1.0; SKILL.md has no version field.
+do $$
+declare
+  s public.skills;
+  evidence jsonb := jsonb_build_object(
+    'value', '0.1.0', 'source', 'plugin_manifest',
+    'path', '.claude-plugin/plugin.json',
+    'ref', '5f40a60426a2ced36c6331bcb3bf47dbd1333398');
+begin
+  select * into s from public.skills
+  where slug = 'beepboop2025-market-brief-market-brief'
+    and github_repo = 'beepboop2025/market-brief'
+    and source_path = 'skills/market-brief/SKILL.md'
+    and source_commit_sha = '5f40a60426a2ced36c6331bcb3bf47dbd1333398'
+    and source_content_hash = '91f2be4e2035579e03d9744083e5bb5f0a8f9a7277a0cf6c3a2740518b1b4461'
+    and version = '1.0.0'
+  for update;
+  if not found then return; end if;
+
+  insert into public.skill_versions (skill_slug,version,source_commit_sha,source_content_hash,source_ref,source_path,license,license_source,metadata)
+  values (s.slug,'0.1.0',s.source_commit_sha,s.source_content_hash,s.source_ref,s.source_path,s.license,coalesce(s.license_source,'unknown'),
+    jsonb_build_object('version_evidence',evidence,'version_correction',jsonb_build_object(
+      'previous_version',s.version,'corrected_version','0.1.0','recorded_at',now(),
+      'issue','https://github.com/Leon-Drq/openagentskill/issues/111',
+      'reason','Replace registry fallback with the same-revision matching plugin manifest declaration; review decisions unchanged.')))
+  on conflict (skill_slug,source_content_hash) do update
+    set version=excluded.version,metadata=public.skill_versions.metadata || excluded.metadata;
+
+  update public.skills set version='0.1.0',
+    ai_review_score=coalesce(ai_review_score,'{}'::jsonb) || jsonb_build_object('version_evidence',evidence)
+  where id=s.id;
+end;
+$$;


### PR DESCRIPTION
## Summary

- Preserve upstream version declarations (including nested metadata), resolve matching plugin manifests at the same immutable revision, and mark missing versions Unknown instead of inventing 1.0.0.
- Pin community submissions to a commit; expose source/version and distinct review provenance in the agent API.
- Fix negated trade-execution/API-key hint false positives without changing executable static security gates; consistently classify noncommercial licenses and manual review evidence.
- Add permission-checked maintainer re-review commands, per-revision attempt dedupe, six-hour cooldown, append-only comments and exact public-listing reconciliation. Public user submissions retain the normal review gate.
- Include an audited, hash-guarded version-only correction for #111. Existing review approval, scores, rejected submissions and source contents are unchanged.

## Verification

- Full regression/contract suite passed locally (including new provenance and workflow cases).
- Type generation, TypeScript check, targeted ESLint and production build passed.
- Local browser: detail + home load; no error overlay or browser console errors; incorrect execution/key warnings removed.
- Read-only API checks: exact existing source found, unlisted source absent, traversal rejected.
- #118 updated immutable source preflight: 14 text files, complete package, MIT, version 2.2, low-risk static path, no model call.

Production migration and live Issue reconciliation will be verified after deployment; no Skill is approved by this PR's metadata correction. URLs, canonical paths, navigation and indexing gates are preserved.

Related: #111, #118, #102, #100
