### PR TITLE
Verify agent connections and source-gate install recommendations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run regression and contract tests
         run: pnpm test
+      - name: Verify read-only agent connection and source eligibility
+        run: node --experimental-strip-types scripts/test-agent-connection.mjs
 
   build:
     name: Production build

--- a/app/agent/integration-kit/page.tsx
+++ b/app/agent/integration-kit/page.tsx
@@ -51,7 +51,7 @@ export default function AgentIntegrationKitPage() {
             items={[
               { value: kit.supported_agents.length, label: 'Agent templates' },
               { value: kit.stable_response_fields.length, label: 'Stable fields' },
-              { value: 'v1', label: 'Kit version' },
+              { value: 'v2', label: 'Kit version' },
               { value: 'API', label: 'Install handoff' },
             ]}
           />
@@ -59,6 +59,19 @@ export default function AgentIntegrationKitPage() {
       />
 
       <div className="mx-auto max-w-6xl px-6">
+        <section className="grid gap-6 border-b border-border py-10 md:grid-cols-2">
+          <div>
+            <h2 className="font-display text-2xl font-normal">Try it in this conversation first.</h2>
+            <p className="mt-3 text-sm leading-6 text-secondary">{kit.connection_modes.session}</p>
+            <p className="mt-3 text-sm leading-6 text-secondary">{kit.connection_modes.persistent}</p>
+          </div>
+          <div>
+            <h2 className="font-display text-2xl font-normal">Verify before saying connected.</h2>
+            <p className="mt-3 text-sm leading-6 text-secondary">{kit.self_check.requirements} {kit.self_check.instructions}</p>
+            <Link href="/connect-check.mjs" prefetch={false} className="mt-3 inline-block text-sm underline underline-offset-4">Inspect the read-only connection check</Link>
+            <p className="mt-3 text-sm leading-6 text-secondary">Report API access, MCP tools, and search separately. A passing check does not prove native client configuration was saved or any Skill was installed.</p>
+          </div>
+        </section>
         <section className="grid gap-8 border-b border-border py-10 lg:grid-cols-[0.72fr_1.28fr]">
           <div>
             <p className="mb-3 font-mono text-xs uppercase tracking-[0.2em] text-secondary">Canonical flow</p>

--- a/app/api/agent/integration-kit/route.ts
+++ b/app/api/agent/integration-kit/route.ts
@@ -29,6 +29,20 @@ Canonical:
 Recommended Flow:
 ${payload.recommended_flow.map((item, index) => `${index + 1}. ${item}`).join('\n')}
 
+Connection Modes:
+- Session (default): ${payload.connection_modes.session}
+- Persistent: ${payload.connection_modes.persistent}
+
+Read-only Connection Check:
+- Requirements: ${payload.self_check.requirements}
+- Script: ${payload.self_check.script_url}
+- Command after inspection: ${payload.self_check.command}
+- ${payload.self_check.instructions}
+- Report separately: ${payload.self_check.expected_checks.join(', ')}
+- Configuration saved: ${payload.self_check.configuration_saved}
+- Client verification: ${payload.self_check.client_verification}
+- On failure: ${payload.self_check.failure_action}
+
 Supported Agents:
 ${payload.supported_agents.map((agent) => `- ${agent.name}: ${agent.surface}
   Resolve: ${agent.resolve_url}
@@ -36,6 +50,8 @@ ${payload.supported_agents.map((agent) => `- ${agent.name}: ${agent.surface}
   Best for: ${agent.best_for.join(', ')}
   Setup:
 ${agent.setup_steps.map((step) => `    - ${step}`).join('\n')}
+  Copy prompt:
+${agent.copy_prompt}
 `).join('\n')}
 
 Stable Response Fields:

--- a/app/api/agent/resolve/route.ts
+++ b/app/api/agent/resolve/route.ts
@@ -185,6 +185,9 @@ ${payload.agent_handoff.blocked_actions.map((item) => `- ${item}`).join('\n')}` 
 Alternatives:
 ${alternatives || 'No alternatives'}
 
+Review candidates (not installation recommendations):
+${payload.review_candidates.map((item) => `- ${item.skill.name} (${item.skill.slug}): ${item.urls.web}`).join('\n') || 'No review candidates'}
+
 Blocked for auto-install:
 ${blocked || 'No blocked candidates'}
 `,

--- a/components/connect-ai-inline.tsx
+++ b/components/connect-ai-inline.tsx
@@ -6,7 +6,7 @@ import { Check, Copy } from 'lucide-react'
 import type { Locale } from '@/lib/i18n/config'
 import { getLocalizedNavigationHref } from '@/lib/i18n/market-routing'
 
-export const CONNECT_AI_PROMPT = 'Read https://www.openagentskill.com/api/agent/integration-kit?format=text and help me set up OpenAgentSkill for this AI assistant. Explain the supported setup and ask before changing files or installing anything. Preserve all safety checks. Do not send private project data or credentials to external services.'
+export const CONNECT_AI_PROMPT = 'Read https://www.openagentskill.com/api/agent/integration-kit?format=text and help me use OpenAgentSkill in this conversation. Use the template for this assistant and perform the documented read-only connection checks with your available tools. Report API accessibility, MCP tool availability and search success separately. Do not claim configuration is saved or a Skill is installed. Explain persistent setup and ask before changing files or installing anything. Preserve all safety checks. Do not send private project data or credentials to external services. Once the checks pass, ask which task I want help with.'
 
 const COPY: Record<Locale, readonly [string, string, string, string, string]> = {
   en: ['Copy for AI', 'Copied — paste into your AI', 'Paste into Codex, Claude Code, or Cursor. Copying does not install anything.', 'Setup guide', 'Copy failed. Select the text above and copy it manually.'],

--- a/lib/agent-integration-kit.ts
+++ b/lib/agent-integration-kit.ts
@@ -53,7 +53,14 @@ function setupPrompt(agent: AgentIntegrationId, agentName: string) {
 
   return [
     `You are using OpenAgentSkill as the skill resolution layer for ${agentName}.`,
+    'Default to this conversation only: do not change project instructions, global configuration, or install packages.',
+    `Read ${SITE_URL}/connect-check.mjs and, if Node.js 18+ is available and execution is authorized, run the inspected read-only check. Alternatively perform its documented HTTP/MCP requests with your existing tools.`,
+    'Report API accessibility, MCP tool availability, and search success separately. Configuration saved remains not_verified unless you actually saved and reloaded the client configuration with user approval.',
+    'For persistent MCP setup, request approval first, add https://www.openagentskill.com/api/mcp using the client supported remote HTTP MCP settings, preserve all existing servers, and verify native tool listing and one read-only search after reloading.',
+    'If this client cannot access the network or call tools, explain that limitation; do not claim connected.',
+    'Never transmit private task text, source code, credentials or environment values. Use a public, sanitized task description only.',
     'Before building a custom workflow from scratch, call the Resolve API with the user task.',
+    'If selected is null or policy_decision reports no_match, explain that no eligible Skill was found. review_candidates are research leads, not installation recommendations; never invent an install command or approval for them.',
     `Resolve endpoint: ${placeholderResolveUrl}`,
     `Install receipt endpoint: ${placeholderReceiptUrl}`,
     'Use install_receipt as the stable pre-install record only after checking risk, safety_gate, and agent_handoff.review_checklist.',
@@ -71,7 +78,7 @@ export const AGENT_INTEGRATIONS: AgentIntegration[] = [
     surface: 'Coding agent / local workspace',
     best_for: ['repo-aware implementation', 'code review', 'debugging', 'web automation setup'],
     setup_steps: [
-      'Add the copy prompt to your Codex project instructions or paste it before a task.',
+      'Paste the copy prompt into this conversation first. Save project instructions or MCP settings only after explicit user approval.',
       'Call the Resolve API with the current task and agent=codex.',
       'Read agent_handoff.review_checklist before installing a third-party skill.',
       'Install only in the active workspace after reporting files and commands that will be touched.',
@@ -96,7 +103,7 @@ export const AGENT_INTEGRATIONS: AgentIntegration[] = [
     surface: 'Claude Code skill workflow',
     best_for: ['local skill instructions', 'project workflows', 'documentation-heavy tasks'],
     setup_steps: [
-      'Paste the copy prompt into Claude Code custom instructions or the start of a new task.',
+      'Paste the copy prompt at the start of a task. Persistent custom instructions or MCP setup require explicit user approval.',
       'Call the Resolve API with agent=claude-code.',
       'Use install targets only after audit and eval checks are acceptable.',
       'Keep the skill scoped to the project and summarize activation steps.',
@@ -121,7 +128,7 @@ export const AGENT_INTEGRATIONS: AgentIntegration[] = [
     surface: 'Cursor rules / agent instructions',
     best_for: ['project rules', 'repeatable coding workflows', 'IDE assistant guidance'],
     setup_steps: [
-      'Paste the copy prompt into Cursor rules or the agent chat before a workflow.',
+      'Paste the copy prompt into agent chat. Persistent rules or MCP settings require explicit user approval.',
       'Call the Resolve API with agent=cursor.',
       'Turn the selected skill into a narrow project rule only when the safety gate allows it.',
       'Keep generated rules task-scoped and avoid broad always-on instructions.',
@@ -144,7 +151,21 @@ export const AGENT_INTEGRATIONS: AgentIntegration[] = [
 
 export function getAgentIntegrationKit() {
   return {
-    version: 'openagentskill-agent-integration-kit-v1',
+    version: 'openagentskill-agent-integration-kit-v2',
+    connection_modes: {
+      session: 'Default. Use the API in this conversation without saving configuration or installing anything.',
+      persistent: 'Optional, only with explicit user approval. Add the remote HTTP MCP endpoint through the client supported settings, preserve existing servers, reload, then test tools in that client.',
+    },
+    self_check: {
+      script_url: `${SITE_URL}/connect-check.mjs`,
+      requirements: 'A network-capable agent with HTTP tools, or Node.js 18+ to run the inspected dependency-free script.',
+      command: 'node connect-check.mjs',
+      instructions: 'Download and inspect the script before authorizing execution. It reads public registry data only; it does not save configuration, install Skills, call a model API, or report installation outcomes.',
+      expected_checks: ['api_accessible', 'tools_available', 'search_working'],
+      configuration_saved: 'not_verified',
+      client_verification: 'After any approved persistent setup, use the actual client MCP tool list and search_skills with query mono-color. A standalone script passing does not verify native client configuration.',
+      failure_action: 'Report the failed stage and error. Do not claim connected, bypass safety checks, or install a Skill to make the test pass.',
+    },
     purpose: 'Let an AI agent resolve a task into the right reusable skill, compare alternatives, review trust signals, and install with a safe handoff.',
     canonical_page: `${SITE_URL}/agent/integration-kit`,
     api: `${SITE_URL}/api/agent/integration-kit`,
@@ -158,7 +179,7 @@ export function getAgentIntegrationKit() {
     supported_agents: AGENT_INTEGRATIONS,
     recommended_flow: [
       'Read /llms.txt or /.well-known/agent-manifest.json.',
-      'Connect /api/mcp for native tool calls, or use @openagentskill/sdk from JavaScript.',
+      'Default to session-only HTTP calls. Configure /api/mcp for native tool calls only with explicit user approval.',
       'Choose the Codex, Claude Code, or Cursor template for the active agent surface.',
       'Call /api/agent/resolve with task, agent, max_risk, and optional min_stars.',
       'Read install_receipt, recommendation.best_skill, recommendation.install, recommendation.risk, and agent_handoff.',
@@ -192,6 +213,7 @@ export function getAgentIntegrationKit() {
       'agent_handoff.review_checklist',
       'agent_handoff.api_sequence',
       'policy_decision',
+      'review_candidates',
     ],
     safety_rules: [
       'Do not auto-install when safety_gate.blocked is true.',

--- a/lib/agent-resolve.ts
+++ b/lib/agent-resolve.ts
@@ -27,6 +27,8 @@ import { getSkillSupplyProfile, type SkillSupplyProfile } from '@/lib/supply'
 import { getSkillTrustProfile, getSkillTrustProfileV5, type SkillTrustProfile, type SkillTrustProfileV5 } from '@/lib/trust'
 import { getUseCasesForSkill } from '@/lib/use-cases'
 import { TRUSTED_RESOLVE_FALLBACKS } from '@/lib/resolve-fallbacks'
+import { getSkillSourceEvidence } from '@/lib/skills/source-evidence'
+import { isInstallRecommendationEligible } from '@/lib/resolve-eligibility'
 
 const SITE_URL = 'https://www.openagentskill.com'
 const RESOLVE_CANDIDATE_POOL_SIZE = 750
@@ -523,8 +525,11 @@ export async function resolveAgentSkill(input: AgentResolveInput) {
 
   const ranked = dedupeRankedSkills(rankSkillsForQuery(skills, rankingTask, outcomeStatsMap))
     .filter(({ skill }) => candidateAllowed(skill, constraints))
+    // Keep relevance order within each group, but do not let unverified libraries
+    // exhaust the shortlist before source-backed Skills reach the safety gate.
+    .sort((a, b) => Number(getSkillSourceEvidence(b.skill).canOfferInstall) - Number(getSkillSourceEvidence(a.skill).canOfferInstall))
     .slice(0, Math.max(limit * 3, 10))
-  const topMatchScore = ranked[0]?.score || 0
+  const topMatchScore = Math.max(0, ...ranked.map((candidate) => candidate.score))
 
   const candidates = ranked.map(({ skill, score, semanticRelevance }, index) => {
     const isFallbackSnapshot = skill.submission_source === 'curated_snapshot'
@@ -564,6 +569,7 @@ export async function resolveAgentSkill(input: AgentResolveInput) {
       rank: index + 1,
       match_score: matchScore,
       raw_match_score: score,
+      source_evidence: getSkillSourceEvidence(skill),
       semantic_relevance: semanticRelevance,
       registry_source: {
         kind: isFallbackSnapshot ? 'verified_fallback_snapshot' : 'live_registry',
@@ -648,14 +654,14 @@ export async function resolveAgentSkill(input: AgentResolveInput) {
     }
   })
 
-  const eligibleCandidates = candidates.filter((candidate) => !candidate.safety.blocked)
+  const eligibleCandidates = candidates.filter(isInstallRecommendationEligible)
+  const reviewCandidates = candidates.filter((candidate) => !candidate.safety.blocked && !candidate.source_evidence.canOfferInstall).slice(0, 5)
   const safeCandidates = eligibleCandidates.filter((candidate) =>
     candidate.safety.safety_tier.tier === 'verified' || candidate.safety.safety_tier.tier === 'reviewed'
   )
   const selected =
     safeCandidates[0] ||
     eligibleCandidates[0] ||
-    candidates[0] ||
     null
   const alternatives = eligibleCandidates
     .filter((candidate) => candidate.skill.slug !== selected?.skill.slug)
@@ -965,13 +971,14 @@ export async function resolveAgentSkill(input: AgentResolveInput) {
     selected,
     alternatives,
     blocked_candidates: blockedCandidates,
+    review_candidates: reviewCandidates,
     agent_workflow: agentWorkflow,
     agent_handoff: agentHandoff,
     policy_decision: selected
       ? buildSafetyPolicyDecision(selected.safety)
       : {
           status: 'no_match',
-          summary: 'No matching skill passed the current filters.',
+          summary: 'No source-confirmed installable skill passed the relevance and safety filters. Review candidates are discovery leads only; use built-in tools or inspect their source without installing.',
         },
     agent_decision: agentDecision,
     decision_packet: recommendation?.decision_packet || null,

--- a/lib/resolve-eligibility.ts
+++ b/lib/resolve-eligibility.ts
@@ -1,0 +1,7 @@
+/** Source evidence is an eligibility gate, never a security approval. */
+export function isInstallRecommendationEligible(candidate: {
+  source_evidence: { canOfferInstall: boolean }
+  safety: { blocked: boolean }
+}) {
+  return candidate.source_evidence.canOfferInstall && !candidate.safety.blocked
+}

--- a/public/connect-check.mjs
+++ b/public/connect-check.mjs
@@ -1,0 +1,52 @@
+// Read-only connection check. Requires Node.js 18+. No packages, files, or configuration are installed.
+// Run after inspecting this file: node connect-check.mjs
+import { pathToFileURL } from 'node:url'
+
+export async function checkConnection(fetchImpl = fetch) {
+  const origin = 'https://www.openagentskill.com'
+  const checks = { api_accessible: false, tools_available: false, search_working: false, configuration_saved: 'not_verified', installation: 'not_attempted' }
+  let stage = 'api_accessible'
+  async function request(path, body) {
+    const response = await fetchImpl(`${origin}${path}`, {
+      method: body ? 'POST' : 'GET',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      signal: AbortSignal.timeout(15000),
+      redirect: 'error',
+    })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    return response.json()
+  }
+  async function rpc(id, method, params) {
+    const data = await request('/api/mcp', { jsonrpc: '2.0', id, method, params })
+    if (data.jsonrpc !== '2.0' || data.id !== id || data.error || !data.result || data.result.isError) throw new Error('Invalid or failed MCP response')
+    return data.result
+  }
+  try {
+    const kit = await request('/api/agent/integration-kit')
+    if (!Array.isArray(kit.supported_agents) || !kit.supported_agents.some(agent => agent.id === 'codex' && agent.copy_prompt)) throw new Error('Missing platform templates')
+    checks.api_accessible = true
+    stage = 'tools_available'
+    const initialized = await rpc(1, 'initialize', { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'openagentskill-readonly-check', version: '1.0' } })
+    if (initialized.serverInfo?.name !== 'openagentskill' || initialized.protocolVersion !== '2025-06-18') throw new Error('Unexpected MCP server or protocol')
+    const notification = await fetchImpl(`${origin}/api/mcp`, { method: 'POST', headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' }, body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }), signal: AbortSignal.timeout(15000), redirect: 'error' })
+    if (!notification.ok) throw new Error('MCP initialization notification failed')
+    const tools = await rpc(2, 'tools/list', {})
+    if (!['search_skills', 'resolve_task'].every(name => tools.tools?.some(tool => tool.name === name))) throw new Error('Required MCP tools missing')
+    checks.tools_available = true
+    stage = 'search_working'
+    const search = await rpc(3, 'tools/call', { name: 'search_skills', arguments: { query: 'mono-color', limit: 3 } })
+    const data = JSON.parse(search.content?.find(item => item.type === 'text')?.text || '{}')
+    if (!Array.isArray(data.skills) || !data.skills.some(skill => skill.slug === 'yanliudesign-mono-color-skill')) throw new Error('Expected public search fixture was not returned; registry may be unavailable or the fixture may have changed')
+    checks.search_working = true
+    return { ok: true, checks, note: 'HTTP API and MCP wire protocol work from this process. This does not prove that an AI client saved its configuration or installed a Skill.' }
+  } catch (error) {
+    return { ok: false, checks, failed_stage: stage, error: error instanceof Error ? error.message : 'Connection check failed' }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = await checkConnection()
+  console.log(JSON.stringify(result, null, 2))
+  if (!result.ok) process.exitCode = 1
+}

--- a/scripts/test-agent-connection.mjs
+++ b/scripts/test-agent-connection.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { checkConnection } from '../public/connect-check.mjs'
+import { getSkillSourceEvidence } from '../lib/skills/source-evidence.ts'
+import { isInstallRecommendationEligible } from '../lib/resolve-eligibility.ts'
+
+function mockFetch({ missingTool = false, empty = false, rpcError = false, httpError = false, malformed = false } = {}) {
+  const calls = []
+  const fetch = async (url, options) => {
+    assert.ok(url.startsWith('https://www.openagentskill.com/'))
+    assert.equal(options.redirect, 'error')
+    assert.ok(options.signal)
+    calls.push({ url, options })
+    if (httpError) return new Response('{}', { status: 503 })
+    if (!options.body) return Response.json({ supported_agents: [{ id: 'codex', copy_prompt: 'Public template' }] })
+    const body = JSON.parse(options.body)
+    assert.ok(['initialize', 'notifications/initialized', 'tools/list', 'tools/call'].includes(body.method))
+    if (body.method === 'notifications/initialized') return new Response(null, { status: 202 })
+    let result
+    if (body.method === 'initialize') result = { serverInfo: { name: 'openagentskill' }, protocolVersion: '2025-06-18' }
+    else if (body.method === 'tools/list') result = { tools: (missingTool ? [] : ['search_skills', 'resolve_task']).map(name => ({ name })) }
+    else {
+      assert.deepEqual(body.params, { name: 'search_skills', arguments: { query: 'mono-color', limit: 3 } })
+      result = { isError: rpcError, content: [{ type: 'text', text: malformed ? 'invalid' : JSON.stringify({ skills: empty ? [] : [{ slug: 'yanliudesign-mono-color-skill' }] }) }] }
+    }
+    return Response.json({ jsonrpc: '2.0', id: body.id, result })
+  }
+  return { fetch, calls }
+}
+
+const good = mockFetch()
+const success = await checkConnection(good.fetch)
+assert.equal(success.ok, true)
+assert.equal(good.calls.length, 5)
+assert.equal(success.checks.configuration_saved, 'not_verified')
+assert.equal(success.checks.installation, 'not_attempted')
+for (const [options, stage] of [[{ missingTool: true }, 'tools_available'], [{ empty: true }, 'search_working'], [{ rpcError: true }, 'search_working'], [{ malformed: true }, 'search_working'], [{ httpError: true }, 'api_accessible']]) {
+  const result = await checkConnection(mockFetch(options).fetch)
+  assert.equal(result.ok, false)
+  assert.equal(result.failed_stage, stage)
+  assert.equal(result.checks.configuration_saved, 'not_verified')
+}
+assert.equal((await checkConnection(async () => { throw new Error('timeout') })).ok, false)
+
+for (const [record, blocked, expected] of [
+  [{ source_path: 'SKILL.md', install_command: 'example' }, false, true],
+  [{ source_path: 'SKILL.md', install_command: 'example' }, true, false],
+  [{ install_command: 'example' }, false, false],
+  [{ source_path: 'README.md', install_command: 'example' }, false, false],
+  [{ source_path: 'SKILL.md', install_command: 'example', source_sync_status: 'changed' }, false, false],
+  [{ source_path: 'SKILL.md', install_command: 'example', source_sync_status: 'error' }, false, false],
+  [{ source_path: 'SKILL.md' }, false, false],
+]) {
+  assert.equal(isInstallRecommendationEligible({ source_evidence: getSkillSourceEvidence(record), safety: { blocked } }), expected)
+}
+const resolver = readFileSync('lib/agent-resolve.ts', 'utf8')
+assert.match(resolver, /candidates.filter\(isInstallRecommendationEligible\)/)
+assert.match(resolver, /review_candidates: reviewCandidates/)
+assert.doesNotMatch(resolver, /eligibleCandidates\[0\] \|\|\s*candidates\[0\]/)
+assert.match(readFileSync('app/api/agent/integration-kit/route.ts', 'utf8'), /agent.copy_prompt/)
+assert.match(readFileSync('lib/agent-integration-kit.ts', 'utf8'), /configuration_saved: 'not_verified'/)
+console.log('Agent connection: read-only success/failure, RPC/HTTP/schema failures, private-data-free probes, source eligibility and complete text templates passed.')


### PR DESCRIPTION
## Summary
- Expand the text/JSON integration kit with full Codex, Claude Code and Cursor session-first templates.
- Add a dependency-free read-only API/MCP/search check with distinct truthfully reported states.
- Exclude unknown/changed source structures and blocked candidates from install recommendations; expose review candidates separately.
- Add connection and eligibility regression tests to CI. No source review approvals, scores, installations or client configuration are modified.

## Verification
- All repository regression scripts passed locally.
- TypeScript and scoped ESLint passed.
- Next production build passed (existing transient registry timeout/cache fallback warnings observed).
- Actual production HTTP/MCP/search read-only check passed.
- Local guide and complete text templates verified; source-unknown results return no_match.
- Existing routes/canonical URLs and SEO metadata preserved.