### PR TITLE
Return HTTP 308 for canonical Skill alias before streaming

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,13 @@ const nextConfig = {
   async redirects() {
     return [
       {
+        // Redirect before streaming begins so crawlers receive HTTP 308, not
+        // a 200 page with a client-side redirect. Query parameters are retained.
+        source: '/skills/liamgvchi-gc-minimal-zine-poster',
+        destination: '/skills/liamgvchi-gc-minimal-zine-poster-v0-3',
+        permanent: true,
+      },
+      {
         source: '/agentskill',
         destination: '/agent-skill',
         permanent: true,

--- a/scripts/test-growth-discovery.mjs
+++ b/scripts/test-growth-discovery.mjs
@@ -134,11 +134,13 @@ for (const query of operations) {
 }
 assert.ok(indexPolicy.buildSearchIndexFilter().includes('and(ai_review_approved.eq.true,quality_score.gte.50,or(github_stars.gte.3,publisher_verified.eq.true),'))
 const editorialEntries = JSON.parse(read('lib/seo/editorial-index.json'))
+const redirects = await (await import('../next.config.mjs')).default.redirects()
 for (const entry of editorialEntries) {
   for (const alias of entry.aliases) {
     assert.match(alias, /^[a-z0-9-]+$/)
     assert.equal(indexPolicy.isSearchIndexEligible(item(alias)), false, 'Redirecting aliases must not be in the sitemap')
     assert.ok(read('lib/skill-fallbacks.ts').includes(`'${alias}': '${entry.slug}'`))
+    assert.ok(redirects.some(rule => rule.source === `/skills/${alias}` && rule.destination === `/skills/${entry.slug}` && rule.permanent), 'Canonical aliases redirect before streaming')
   }
   for (const field of ['slug', 'repository', 'path', 'license']) assert.match(entry[field], /^[\w./-]+$/, 'Filter values must not contain PostgREST operators')
   assert.match(entry.commit, /^[a-f0-9]{40}$/)


### PR DESCRIPTION
The final production smoke test found that a late Next.js permanentRedirect produced HTTP 200 plus a refresh tag. Add the verified alias to server routing so clients and crawlers receive HTTP 308 and query parameters are retained. Regression tests now require a permanent server redirect for editorial aliases. Full regression suite, typecheck and production build passed. No database or review changes.