### PR TITLE
Add source-linked RedSkill external catalog

### DIFF
--- a/app/api/external-skills/[slug]/route.ts
+++ b/app/api/external-skills/[slug]/route.ts
@@ -1,0 +1,10 @@
+import { externalSkillDiscoveryRecord, getExternalSkill } from '@/lib/skills/external-catalog'
+
+// Public discovery only. No POST handler, privileged client or install action.
+export async function GET(_request: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const entry = getExternalSkill((await params).slug)
+  if (!entry) return Response.json({ error: 'External skill not found' }, { status: 404, headers: { 'X-Robots-Tag': 'noindex' } })
+  return Response.json(externalSkillDiscoveryRecord(entry), { headers: {
+    'Cache-Control': 'public, max-age=300', 'X-Robots-Tag': 'noindex',
+  } })
+}

--- a/app/skills/external/[slug]/page.tsx
+++ b/app/skills/external/[slug]/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { SiteHeader } from '@/components/site-header'
+import { SiteFooter } from '@/components/site-footer'
+import { EXTERNAL_SKILLS, externalSkillHref, getExternalSkill } from '@/lib/skills/external-catalog'
+
+type Props = { params: Promise<{ slug: string }>; searchParams: Promise<{ lang?: string | string[] }> }
+const base = 'https://www.openagentskill.com'
+// Catalog releases define the route set. The proxy also rejects unknown entries
+// before streaming, since this page reads dynamic language parameters.
+export const dynamicParams = false
+export function generateStaticParams() { return EXTERNAL_SKILLS.map(({ slug }) => ({ slug })) }
+export async function generateMetadata({ params, searchParams }: Props): Promise<Metadata> {
+  const entry = getExternalSkill((await params).slug)
+  if (!entry) return { title: 'External skill not found', robots: { index: false, follow: false } }
+  const query = await searchParams
+  const lang = query.lang === 'zh' ? 'zh' : 'en'
+  const url = base + externalSkillHref(entry.slug)
+  return {
+    title: entry.title[lang], description: entry.description[lang],
+    alternates: { canonical: url }, robots: { index: !query.lang, follow: true },
+    openGraph: { type: 'website', title: entry.title[lang], description: entry.description[lang], url },
+    twitter: { card: 'summary', title: entry.title[lang], description: entry.description[lang] },
+  }
+}
+export default async function ExternalSkillPage({ params, searchParams }: Props) {
+  const entry = getExternalSkill((await params).slug)
+  if (!entry) notFound()
+  const zh = (await searchParams).lang === 'zh'
+  const lang = zh ? 'zh' : 'en'
+  const suffix = zh ? '?lang=zh' : ''
+  const url = base + externalSkillHref(entry.slug)
+  const jsonLd = {
+    '@context': 'https://schema.org', '@graph': [
+      { '@type': 'WebPage', '@id': url, url, name: entry.title[lang], description: entry.description[lang], inLanguage: lang,
+        about: { '@type': 'CreativeWork', name: entry.skillName, version: entry.version, license: entry.licenseUrl,
+          author: { '@type': 'Person', name: entry.author.name, url: entry.author.url }, url: entry.sourcePostUrl } },
+      { '@type': 'BreadcrumbList', itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Skills', item: base + '/skills' },
+        { '@type': 'ListItem', position: 2, name: 'External Skills', item: base + '/skills/external' },
+        { '@type': 'ListItem', position: 3, name: entry.title[lang], item: url },
+      ] },
+    ],
+  }
+  return <div className="min-h-screen bg-background text-foreground">
+    <SiteHeader />
+    <main className="mx-auto max-w-6xl px-6 pb-20 pt-10" lang={lang} data-external-skill={entry.slug}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }} />
+      <nav aria-label={zh ? '面包屑导航' : 'Breadcrumb'} className="flex flex-wrap gap-3 text-sm text-secondary">
+        <Link href={zh ? '/zh/skills' : '/skills'}>{zh ? '技能' : 'Skills'}</Link><span>/</span>
+        <Link href={`/skills/external${suffix}`}>{zh ? '外部平台' : 'External platforms'}</Link><span>/ RedSkill</span>
+      </nav>
+      <header className="border-b border-border py-12 sm:py-16">
+        <p className="font-mono text-xs uppercase tracking-[0.2em] text-[#006b4f]">RedSkill / p5.js / {zh ? '站长收录' : 'Owner curated'}</p>
+        <h1 className="mt-6 max-w-4xl text-balance font-display text-4xl leading-tight sm:text-6xl">{entry.title[lang]}</h1>
+        <p className="mt-6 max-w-3xl text-base leading-8 text-secondary sm:text-lg">{entry.description[lang]}</p>
+        <p className="mt-5 text-sm">{zh ? '作者' : 'By'} <a href={entry.author.url} target="_blank" rel="noopener noreferrer" className="underline underline-offset-4">{entry.author.name} ↗</a></p>
+        <div className="mt-6 flex flex-wrap items-center gap-4">
+          <a href={entry.sourceUrl} target="_blank" rel="noopener noreferrer" className="inline-flex min-h-12 items-center justify-center bg-[#006b4f] px-5 py-3 text-sm font-semibold text-white hover:bg-[#00533d]">{zh ? '打开作者原帖' : 'Open the author’s post'} ↗</a>
+          <p className="text-xs text-secondary">{zh ? '仅限非商业用途 · 未运行验证' : 'Noncommercial use only · Not runtime-verified'}</p>
+        </div>
+      </header>
+      <div className="grid gap-12 py-10 lg:grid-cols-[minmax(0,1fr)_300px]">
+        <div className="min-w-0">
+          <section aria-labelledby="animation-types">
+            <h2 id="animation-types" className="font-display text-3xl">{zh ? '三种动画，一句话定制。' : 'Three animations. Your direction.'}</h2>
+            <p className="mt-3 text-sm text-secondary">{zh ? '以下为技能包的功能说明，并非本站运行效果。' : 'These describe package capabilities, not outputs tested by OpenAgentSkill.'}</p>
+            {entry.examples.map(example => <div key={example.title.en} className="grid gap-3 border-b border-border py-7 sm:grid-cols-[140px_1fr]">
+              <h3 className="font-display text-xl">{example.title[lang]}</h3><p className="text-sm leading-7 text-secondary">{example.description[lang]}</p>
+            </div>)}
+          </section>
+          <section className="mt-10" aria-labelledby="external-use">
+            <h2 id="external-use" className="font-display text-3xl">{zh ? '如何使用' : 'How to use it'}</h2>
+            <p className="mt-4 text-sm leading-8 text-secondary">{entry.usage[lang]}</p>
+            <p className="mt-4 text-sm leading-8 text-secondary">{entry.limitations[lang]}</p>
+          </section>
+          <section className="mt-10 border-t border-border pt-8" aria-labelledby="external-source">
+            <h2 id="external-source" className="font-display text-3xl">{zh ? '来源与版本记录' : 'Source & version record'}</h2>
+            <dl className="mt-5 space-y-4 text-sm">
+              <div><dt className="text-secondary">{zh ? '平台标识' : 'Platform identifier'}</dt><dd className="mt-1 break-all font-mono text-xs">{entry.identifier}</dd></div>
+              <div><dt className="text-secondary">{zh ? '收录时版本' : 'Version at listing'}</dt><dd>{entry.version} · RedSkill manifest</dd></div>
+              <div><dt className="text-secondary">{zh ? '包校验值（不代表安全认证）' : 'Bundle checksum (not a safety certification)'}</dt><dd className="mt-1 break-all font-mono text-xs">SHA-256 {entry.bundleSha256}</dd></div>
+            </dl>
+            <p className="mt-5 text-xs leading-6 text-secondary">{zh ? '版本为收录时快照，当前不自动同步外部平台。本站不提供 AI 审核、运行验证或创作者身份认证。' : 'Version is a listing-time snapshot, not automatically synchronized. This listing carries no AI review, runtime verification or creator-identity certification.'}</p>
+            <Link href={`/api/external-skills/${entry.slug}`} className="mt-4 inline-block text-sm text-[#006b4f] underline underline-offset-4">{zh ? '查看只读元数据' : 'Read-only metadata'} →</Link>
+          </section>
+        </div>
+        <aside className="self-start border-t-2 border-[#006b4f] pt-6 lg:sticky lg:top-24" aria-label={zh ? '使用与许可' : 'Access & license'}>
+          <p className="font-mono text-xs text-secondary">{zh ? '前往原平台使用' : 'USE ON THE SOURCE PLATFORM'}</p>
+          <p className="mt-3 text-xs leading-6 text-secondary">{zh ? '帖内提供 RedSkill 入口，可能需要小红书 App 或登录。' : 'Use the RedSkill entry in the post. Xiaohongshu may require its app or sign-in.'}</p>
+          <div className="mt-7 border-t border-border pt-6">
+            <h2 className="text-base font-semibold">{zh ? '仅限非商业用途' : 'Noncommercial use only'}</h2>
+            <a href={entry.licenseUrl} target="_blank" rel="noopener noreferrer" className="mt-2 inline-block text-sm underline underline-offset-4">CC BY-NC 4.0 ↗</a>
+            <p className="mt-4 text-xs leading-7 text-secondary">{entry.licenseNote[lang]}</p>
+          </div>
+          <p className="mt-7 border-t border-border pt-5 text-xs leading-6 text-secondary">{zh ? '独立外部条目，不计入 GitHub Star 排行或自动安装推荐。不托管源代码和作者素材。' : 'An independent external listing, excluded from GitHub Star rankings and automatic install recommendations. Source code and author media are not hosted here.'}</p>
+        </aside>
+      </div>
+    </main>
+    <SiteFooter />
+  </div>
+}

--- a/app/skills/external/page.tsx
+++ b/app/skills/external/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { SiteHeader } from '@/components/site-header'
+import { SiteFooter } from '@/components/site-footer'
+import { ExternalSkillResults } from '@/components/external-skills'
+
+type Props = { searchParams: Promise<{ q?: string | string[]; lang?: string | string[] }> }
+export async function generateMetadata({ searchParams }: Props): Promise<Metadata> {
+  const params = await searchParams
+  const zh = params.lang === 'zh'
+  return {
+    title: zh ? '外部平台 Agent Skills' : 'External platform Agent Skills',
+    description: zh ? '发现外部平台的创意技能，了解作者、用途和许可限制，并前往原平台使用。' : 'Discover creative skills from external platforms with author attribution, license restrictions and links to their original sources.',
+    alternates: { canonical: 'https://www.openagentskill.com/skills/external' },
+    robots: { index: !params.q && !params.lang, follow: true },
+  }
+}
+export default async function ExternalSkillsPage({ searchParams }: Props) {
+  const params = await searchParams
+  const zh = params.lang === 'zh'
+  const q = (Array.isArray(params.q) ? params.q[0] : params.q) || ''
+  return <div className="min-h-screen bg-background text-foreground">
+    <SiteHeader />
+    <main className="mx-auto max-w-6xl px-6 py-12" lang={zh ? 'zh' : 'en'}>
+      <Link href={zh ? '/zh/skills' : '/skills'} className="text-sm text-secondary underline underline-offset-4">← {zh ? '技能目录' : 'Skills directory'}</Link>
+      <p className="mt-10 font-mono text-xs tracking-widest text-[#006b4f]">OPENAGENTSKILL / EXTERNAL</p>
+      <h1 className="mt-4 font-display text-4xl sm:text-6xl">{zh ? '外部平台技能' : 'External Skills'}</h1>
+      <p className="mt-5 max-w-2xl text-base leading-8 text-secondary">{zh ? '发现创作者在其他平台发布的技能。我们提供用途说明与原帖入口，不镜像分发技能包，不代表安全认证或商业授权。' : 'Discover skills published by creators on other platforms. We provide context and source links, not mirrored packages, security certification or commercial permission.'}</p>
+      <form action="/skills/external" role="search" className="mt-7 flex max-w-xl gap-2 border border-border bg-card p-2">
+        {zh && <input type="hidden" name="lang" value="zh" />}
+        <input type="search" name="q" defaultValue={q} maxLength={200} aria-label={zh ? '搜索外部技能' : 'Search external skills'} className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm" />
+        <button className="bg-[#006b4f] px-5 py-3 text-sm font-semibold text-white">{zh ? '搜索' : 'Search'}</button>
+      </form>
+      <ExternalSkillResults query={q} locale={zh ? 'zh' : 'en'} />
+    </main>
+    <SiteFooter />
+  </div>
+}

--- a/app/skills/page.tsx
+++ b/app/skills/page.tsx
@@ -4,6 +4,7 @@ import { buildSkillAudit } from '@/lib/audits'
 import { getAgentSafetyProfile } from '@/lib/agent-safety'
 import { getSkillDirectory, getCategories, type SkillAgentStats, type SkillRecord, type SkillSortMode, getSkillStats, searchSkillsStrict } from '@/lib/db/skills'
 import { SkillsPageClient } from '@/components/skills-page-client'
+import { ExternalSkillResults } from '@/components/external-skills'
 import { getSkillQualityProfile, getPlatformHints } from '@/lib/quality'
 import { getSkillSupplyProfile, getSupplyTrackSummaries } from '@/lib/supply'
 import { getSkillTrustProfile } from '@/lib/trust'
@@ -1053,6 +1054,7 @@ export default async function SkillsPage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <SkillsPageClient
+        externalDiscovery={<ExternalSkillResults query={query} locale={locale} />}
         skills={skills}
         query={query}
         sort={sort}

--- a/components/external-skills.tsx
+++ b/components/external-skills.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+import { externalSkillHref, searchExternalSkills } from '@/lib/skills/external-catalog'
+
+export function ExternalSkillResults({ query = '', locale = 'en' }: { query?: string; locale?: string }) {
+  const zh = locale === 'zh'
+  const lang = zh ? 'zh' : 'en'
+  const entries = searchExternalSkills(query)
+  const suffix = zh ? '?lang=zh' : ''
+  return <section className="my-10 border-y border-border py-7" aria-labelledby="external-skills-heading" data-external-skills lang={lang}>
+    <div className="flex flex-wrap items-baseline justify-between gap-3">
+      <h2 id="external-skills-heading" className="font-display text-2xl">{zh ? '外部平台技能' : 'External platform skills'}</h2>
+      <Link href={`/skills/external${suffix}`} className="text-sm text-[#006b4f] underline underline-offset-4">{zh ? '浏览外部目录' : 'Browse external directory'} →</Link>
+    </div>
+    <p className="mt-2 text-xs leading-6 text-secondary">{zh ? '站长精选的外部来源；不使用上方评分或兼容性筛选，不计入 GitHub 排行和自动安装结果。' : 'Owner-curated external sources. Not filtered by the scores or compatibility controls above; excluded from GitHub rankings and automatic installation.'}</p>
+    {entries.map(entry => <article key={entry.slug} className="mt-5 border-t border-border pt-5">
+      <p className="font-mono text-xs text-secondary">RedSkill · {entry.author.name} · {entry.version}</p>
+      <h3 className="mt-2 text-lg font-semibold"><Link href={`${externalSkillHref(entry.slug)}${suffix}`} className="hover:text-[#006b4f]">{entry.title[lang]} →</Link></h3>
+      <p className="mt-2 max-w-3xl text-sm leading-7 text-secondary">{entry.description[lang]}</p>
+      <p className="mt-3 text-xs font-medium">{zh ? '仅限非商业用途 · 未运行验证 · 前往原平台使用' : 'Noncommercial use only · Not runtime-verified · Use on the source platform'}</p>
+    </article>)}
+    {entries.length === 0 && <p className="mt-4 text-sm text-secondary">{zh ? '外部目录没有匹配此关键词的条目。' : 'No external entries match this query.'}</p>}
+  </section>
+}

--- a/components/skills-page-client.tsx
+++ b/components/skills-page-client.tsx
@@ -4,7 +4,7 @@ import { NativeSelect } from '@/components/ui/native-select'
 
 import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { useSyncExternalStore, useTransition } from 'react'
+import { useSyncExternalStore, useTransition, type ReactNode } from 'react'
 import { SiteFooter } from './site-footer'
 import { SiteHeader } from './site-header'
 import type { SupplyTrackSummary } from '@/lib/supply'
@@ -174,6 +174,7 @@ interface Props {
   degraded: boolean
   directorySections: DirectorySection[]
   directoryLinks: DirectoryLink[]
+  externalDiscovery?: ReactNode
 }
 
 
@@ -345,6 +346,7 @@ export function SkillsPageClient(props: Props) {
           </nav>}
         </section>
 
+        {props.externalDiscovery}
         {!query && directorySections.length > 0 && <section className="mt-16 border-t border-border pt-8" aria-labelledby="directory-collections">
           <h2 id="directory-collections" className="font-display text-3xl">{c.collections}</h2>
           <div className="mt-6 grid gap-x-10 gap-y-6 sm:grid-cols-2">

--- a/docs/external-skill-publication.md
+++ b/docs/external-skill-publication.md
@@ -1,0 +1,58 @@
+# External-platform Skill listings
+
+External entries are owner-curated **link-only editorial records**, not GitHub
+SkillRecords. The first entry is `redskill-curtain-branch-swallow` by 流白Livo,
+published at the explicit request of the site owner. Its source is the author post
+provided by the owner: https://xhslink.cn/o/2WbYk12a1h4.
+
+## Publication interface
+
+Use the typed `ExternalSkillSchema` and `EXTERNAL_SKILLS` catalog in
+`lib/skills/external-catalog.ts`. This is a Git-reviewed publication interface,
+not a new public submission endpoint. A maintainer adds or updates one explicit
+entry, runs regression tests/typecheck/build, and publishes through the existing
+GitHub pull-request and production deployment workflow. Git history preserves the
+request reason, source, license and listing-time version. Removing an entry from
+the current catalog unpublishes it on the next deployment without erasing history.
+
+GitHub repository publications continue to use the CLI in
+[owner-publishing.md](owner-publishing.md). Community submissions, owner tokens,
+Supabase review records and rejected submissions are not changed by this lane.
+
+Required external fields include provider/identifier, author attribution, stable
+source link, version, bundle checksum, license restrictions, explicit owner reason
+and false review/runtime/auto-install flags. Runtime validation rejects unknown
+fields, duplicate slugs/identifiers/checksums and non-HTTPS or signed URLs. Do not
+infer ownership certification from a supplied author name or a package checksum.
+
+## Discovery and boundaries
+
+- `/skills/external` lists and searches external entries.
+- `/skills/external/[slug]` presents original editorial descriptions and source links.
+- `/skills?q=...` shows matching external entries in a separate labeled section;
+  the GitHub compatibility/score filters and counts do not apply to that section.
+- `GET /api/external-skills/[slug]` returns read-only discovery metadata with
+  `auto_install_allowed=false`, `human_review_required=true`, and no install command.
+  Other HTTP methods have no implementation. No secrets or package content are returned.
+- Core sitemap includes canonical external pages. Query/language variants point
+  to the canonical English URL and are noindex. Chinese UI/copy is provided;
+  other language selections currently use English body copy marked `lang=en`.
+- External entries are not passed to Resolve, GitHub rankings, GitHub skill counts,
+  reviewed/Installable datasets, creator verification or auto-posting jobs.
+
+No remote API is called on page loads; there is no added model/API cost. RedSkill
+version `1.0.0` and bundle SHA-256 are observations at listing time, not a promise
+of automatic synchronization. The original Skill was not executed. No package,
+template code, screenshots or creator media are mirrored on this site.
+
+The RedSkill package README declares CC BY-NC 4.0 and separately mentions
+share-alike. Preserve that discrepancy and the noncommercial restriction. Do not
+claim MIT licensing, commercial permission, OSI approval or an author endorsement.
+Do not republish code or create Gallery previews without addressing usage rights.
+
+## Verification
+
+`node --experimental-strip-types scripts/test-external-skills.mjs` is included in
+the existing SEO regression suite. Also run the complete regression suite,
+typecheck and production build. Check English/Chinese detail pages, directory
+search, unknown slug 404, API read-only policy and the core sitemap after deployment.

--- a/docs/owner-publishing.md
+++ b/docs/owner-publishing.md
@@ -1,5 +1,9 @@
 # Owner/developer publishing channel
 
+For non-GitHub, link-only external platform listings, use the separate
+[external publication interface](external-skill-publication.md). Do not invent
+a GitHub repository or pass external entries through this repository-only API.
+
 The site's owner can publish a valid public GitHub Skill without waiting for an
 AI review or a minimum star count. Ordinary community submissions still use the
 existing static-analysis and AI-review gates. Website code development is unrelated

--- a/lib/seo/sitemap.ts
+++ b/lib/seo/sitemap.ts
@@ -19,6 +19,7 @@ import { SKILL_CLUSTERS } from '@/lib/seo/skill-clusters'
 import { SKILL_PACKS } from '@/lib/skill-packs'
 import { USE_CASES } from '@/lib/use-cases'
 import { SHOWCASE_CASES, SHOWCASE_UPDATED_AT } from '@/lib/showcase'
+import { EXTERNAL_SKILLS, externalSkillHref } from '@/lib/skills/external-catalog'
 import { createPublicClient } from '@/lib/supabase/public'
 import { FEATURED_CREATORS, creatorHref } from '@/lib/creator-directory'
 import {
@@ -120,6 +121,8 @@ export async function getSitemapIndexEntries() {
 
 export function getCoreSitemapEntries(): SitemapEntry[] {
   const staticPages: SitemapEntry[] = [
+    { url: `${SITEMAP_BASE_URL}/skills/external`, changeFrequency: 'weekly', priority: 0.6 },
+    ...EXTERNAL_SKILLS.map((entry): SitemapEntry => ({ url: `${SITEMAP_BASE_URL}${externalSkillHref(entry.slug)}`, lastModified: entry.publishedAt, changeFrequency: 'monthly', priority: 0.6 })),
     { url: `${SITEMAP_BASE_URL}/showcase`, lastModified: SHOWCASE_UPDATED_AT, changeFrequency: 'weekly', priority: 0.9 },
     ...SHOWCASE_CASES.map((item): SitemapEntry => ({ url: `${SITEMAP_BASE_URL}/showcase/${item.slug}`, lastModified: item.updatedAt, changeFrequency: 'monthly', priority: 0.8 })),
     { url: SITEMAP_BASE_URL, changeFrequency: 'daily', priority: 1 },

--- a/lib/skills/external-catalog.ts
+++ b/lib/skills/external-catalog.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod'
+
+// Editorial metadata only. Never mirror bundles or turn these records into
+// GitHub SkillRecords: external discovery is not installation authorization.
+const httpsUrl = z.string().url().refine(value => {
+  const url = new URL(value)
+  return url.protocol === 'https:' && !url.username && !url.password && !url.search && !url.hash
+}, 'Use a stable HTTPS URL without credentials or signed query parameters.')
+const localized = z.object({ en: z.string().min(1), zh: z.string().min(1) }).strict()
+export const ExternalSkillSchema = z.object({
+  slug: z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+  provider: z.literal('redskill'),
+  identifier: z.string().regex(/^skill-[a-z0-9-]+$/),
+  skillName: z.string().min(1),
+  title: localized,
+  description: localized,
+  author: z.object({ name: z.string().min(1), url: httpsUrl }).strict(),
+  sourceUrl: httpsUrl,
+  sourcePostUrl: httpsUrl,
+  version: z.string().min(1),
+  bundleSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  license: z.literal('CC-BY-NC-4.0'),
+  licenseUrl: httpsUrl,
+  commercialUse: z.literal('not-permitted-without-separate-permission'),
+  licenseNote: localized,
+  limitations: localized,
+  usage: localized,
+  examples: z.array(z.object({ title: localized, description: localized }).strict()).min(1),
+  tags: z.array(z.string().min(1)).min(1),
+  publishedAt: z.string().datetime(),
+  publication: z.object({ channel: z.literal('owner-curated-external'), reason: z.string().min(10) }).strict(),
+  runtimeVerified: z.literal(false),
+  aiReviewed: z.literal(false),
+  autoInstallAllowed: z.literal(false),
+}).strict()
+export type ExternalSkill = z.infer<typeof ExternalSkillSchema>
+
+export function validateExternalCatalog(input: unknown): ExternalSkill[] {
+  const entries = z.array(ExternalSkillSchema).parse(input)
+  for (const key of ['slug', 'identifier', 'bundleSha256'] as const) {
+    if (new Set(entries.map(entry => entry[key])).size !== entries.length) throw new Error(`Duplicate external ${key}`)
+  }
+  return entries
+}
+
+export const EXTERNAL_SKILLS = validateExternalCatalog([
+  {
+    slug: 'redskill-curtain-branch-swallow', provider: 'redskill',
+    identifier: 'skill-curtain-branch-swallow', skillName: 'p5-animation',
+    title: { en: 'p5.js animations: rain, branches & swallows', zh: 'p5.js 创意动画：雨帘、花枝与飞燕' },
+    description: {
+      en: 'Describe a rain curtain, growing flowering branches or a flock of swallows. This RedSkill package adapts three p5.js templates into sketch.js code with custom colors, density and speed.',
+      zh: '用一句话描述雨帘、开花的树枝或飞过的燕群，基于三套 p5.js 模板输出 sketch.js 代码，可定制颜色、数量与速度。',
+    },
+    author: { name: '流白Livo', url: 'https://www.xiaohongshu.com/user/profile/687e6455000000001e00b765' },
+    sourceUrl: 'https://xhslink.cn/o/2WbYk12a1h4',
+    sourcePostUrl: 'https://www.xiaohongshu.com/explore/6a632c13000000000a03a59a',
+    version: '1.0.0',
+    bundleSha256: '481b20db720959d2268cb3fb9ee4251dad0aa9ea800a46ff242932a586ef6f69',
+    license: 'CC-BY-NC-4.0', licenseUrl: 'https://creativecommons.org/licenses/by-nc/4.0/',
+    commercialUse: 'not-permitted-without-separate-permission',
+    licenseNote: {
+      en: 'The package README declares CC BY-NC 4.0 and requires attribution and noncommercial use. It also mentions share-alike terms; ask the author to clarify this discrepancy before redistribution. Commercial use requires separate permission.',
+      zh: '技能包 README 声明 CC BY-NC 4.0，要求署名并限非商业用途；另有“相同方式共享”的表述，转载分发前请向作者确认。商用需要单独获得授权。',
+    },
+    limitations: {
+      en: 'Requires a compatible coding agent and a p5.js runtime/editor. Some templates load images from an external CDN. RedSkill’s supplied installer uses Bash and Unix-only Python interfaces; native Windows compatibility is not established. OpenAgentSkill has not run these animations or certified agent compatibility.',
+      zh: '需要兼容的编程 Agent 与 p5.js 运行环境或编辑器；部分模板从外部 CDN 加载图片。RedSkill 提供的安装器依赖 Bash 和 Unix 专用 Python 接口，尚未确认原生 Windows 兼容性。OpenAgentSkill 未运行这些动画，也未认证 Agent 兼容性。',
+    },
+    usage: {
+      en: 'Open the author’s post and use its RedSkill entry to obtain the package. Review the license and files in your own environment. Describe an animation to your coding agent, then review the generated sketch.js in the p5.js editor. We do not host the package or install it on your behalf.',
+      zh: '打开作者原帖，通过帖内 RedSkill 入口获取技能。在自己的环境中查看许可与文件后，向编程 Agent 描述动画需求，再到 p5.js 编辑器检查生成的 sketch.js。本站不托管技能包，也不代你安装。',
+    },
+    examples: [
+      { title: { en: 'Rain curtain', zh: '雨帘' }, description: { en: 'Hanging raindrops respond to pointer movement; adjust density, color and falling speed.', zh: '帘线上的雨滴响应鼠标动作，可调整密度、颜色与下落速度。' } },
+      { title: { en: 'Flowering branches', zh: '花枝' }, description: { en: 'Branches grow, divide and bloom with a gentle sway; adjust branch count and flower color.', zh: '树枝自然生长、分叉、开花并轻轻摇摆，可调整枝条数量与花色。' } },
+      { title: { en: 'Swallow flock', zh: '飞燕' }, description: { en: 'A flock follows curved flight paths with flapping wings and trailing tails; adjust count, color and timing.', zh: '燕群沿弧线飞过，伴随扑翼和拖尾，可调整数量、颜色与飞行节奏。' } },
+    ],
+    tags: ['p5.js', 'p5js', 'creative coding', 'web animation', 'design', 'rain', 'branch', 'swallow', '雨帘', '花枝', '飞燕', '创意编程', '网页动画'],
+    publishedAt: '2026-09-11T05:28:00.000Z',
+    publication: { channel: 'owner-curated-external', reason: 'Site owner requested listing the RedSkill package with the supplied author post and noncommercial license notice.' },
+    runtimeVerified: false, aiReviewed: false, autoInstallAllowed: false,
+  },
+])
+
+export function externalSkillHref(slug: string) { return `/skills/external/${slug}` }
+export function getExternalSkill(slug: string) { return EXTERNAL_SKILLS.find(entry => entry.slug === slug) }
+// Reject unknown external pages before streaming starts, preserving a real 404.
+export function isMissingExternalSkillPath(pathname: string) {
+  const match = pathname.match(/^\/skills\/external\/([^/]+)\/?$/)
+  if (!match) return false
+  try { return !getExternalSkill(decodeURIComponent(match[1])) } catch { return true }
+}
+export function searchExternalSkills(query = '') {
+  const terms = query.normalize('NFKC').toLocaleLowerCase().trim().slice(0, 200).split(/\s+/).filter(Boolean)
+  return EXTERNAL_SKILLS.filter(entry => {
+    const haystack = [entry.slug, entry.identifier, entry.skillName, entry.author.name, ...Object.values(entry.title), ...Object.values(entry.description), ...entry.tags].join(' ').normalize('NFKC').toLocaleLowerCase()
+    return terms.every(term => haystack.includes(term))
+  })
+}
+
+export function externalSkillDiscoveryRecord(entry: ExternalSkill) {
+  return {
+    type: 'external-platform-skill', slug: entry.slug, name: entry.title.en,
+    description: entry.description.en, provider: entry.provider, identifier: entry.identifier,
+    url: `https://www.openagentskill.com${externalSkillHref(entry.slug)}`,
+    source_url: entry.sourceUrl, author: entry.author, version: entry.version,
+    version_source: 'RedSkill bundle manifest observed at publication; not automatically synchronized',
+    bundle_sha256: entry.bundleSha256, license: entry.license, license_note: entry.licenseNote.en,
+    commercial_use: entry.commercialUse, publication_channel: entry.publication.channel,
+    ai_reviewed: false, runtime_verified: false, auto_install_allowed: false,
+    human_review_required: true, install_command: null,
+  }
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,6 +4,7 @@ import { getCanonicalSkillSlug } from '@/lib/skill-slug-aliases'
 import { isMissingShowcasePath } from '@/lib/showcase'
 import { isMissingFeaturedCreatorPath } from '@/lib/creator-directory'
 import { isMissingRankingPath } from '@/lib/rankings'
+import { isMissingExternalSkillPath } from '@/lib/skills/external-catalog'
 
 const MARKET_LOCALE_CODES = new Set(['zh', 'ja', 'ko', 'es', 'de', 'fr', 'id'])
 const DOCUMENT_LANG_BY_LOCALE: Record<string, string> = {
@@ -92,7 +93,7 @@ export async function proxy(request: NextRequest) {
   const locale = pathLocale || (queryLocale && MARKET_LOCALE_CODES.has(queryLocale) ? queryLocale : null)
   const noindex = isSkillDetailVariant(pathname, searchParams)
 
-  if (isMissingShowcasePath(pathname) || isMissingFeaturedCreatorPath(pathname) || isMissingRankingPath(pathname)) {
+  if (isMissingShowcasePath(pathname) || isMissingFeaturedCreatorPath(pathname) || isMissingRankingPath(pathname) || isMissingExternalSkillPath(pathname)) {
     return NextResponse.rewrite(new URL('/404', request.url), {
       status: 404,
       headers: { 'X-Robots-Tag': 'noindex, follow' },

--- a/scripts/check-external-skills.mjs
+++ b/scripts/check-external-skills.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+
+const base = process.argv[2] || 'http://localhost:3114'
+const slug = 'redskill-curtain-branch-swallow'
+const path = `/skills/external/${slug}`
+const get = (suffix, options = {}) => fetch(base + suffix, { ...options, signal: AbortSignal.timeout(20000) })
+for (const lang of ['', '?lang=zh']) {
+  const response = await get(path + lang)
+  const html = await response.text()
+  assert.equal(response.status, 200)
+  assert.ok(html.includes('流白Livo'))
+  assert.ok(html.includes('CC BY-NC 4.0'))
+  assert.ok(html.includes('https://xhslink.cn/o/2WbYk12a1h4'))
+  const title = html.match(/<title>(.*?)<\/title>/)?.[1]
+  assert.equal((title?.match(/OpenAgentSkill/g) || []).length, 1, 'single title suffix')
+  assert.ok(html.includes(`rel="canonical" href="https://www.openagentskill.com${path}"`))
+  assert.ok(html.includes(`name="robots" content="${lang ? 'noindex' : 'index'}, follow"`))
+  const json = [...html.matchAll(/<script[^>]+type="application\/ld\+json"[^>]*>(.*?)<\/script>/gs)].map(match => JSON.parse(match[1]))
+  assert.ok(json.some(value => value['@graph']?.some(item => item.about?.author?.name === '流白Livo')))
+}
+assert.equal((await get('/skills/external/unknown-entry')).status, 404)
+const api = `/api/external-skills/${slug}`
+const data = await (await get(api)).json()
+assert.equal(data.auto_install_allowed, false)
+assert.equal(data.human_review_required, true)
+assert.equal(data.install_command, null)
+assert.equal(data.github_stars, undefined)
+assert.equal((await get(api, { method: 'POST' })).status, 405)
+assert.equal((await get('/api/external-skills/unknown-entry')).status, 404)
+const search = await (await get('/skills?q=skill-curtain-branch-swallow')).text()
+assert.ok(search.includes(path))
+const sitemap = await (await get('/sitemaps/core.xml')).text()
+assert.ok(sitemap.includes(`https://www.openagentskill.com${path}</loc>`))
+console.log(`External listing smoke passed at ${base}: EN/ZH SSR, metadata, JSON-LD, HTTP 404, search, sitemap, read-only API.`)

--- a/scripts/check-external-skills.mjs
+++ b/scripts/check-external-skills.mjs
@@ -10,7 +10,8 @@ for (const lang of ['', '?lang=zh']) {
   assert.equal(response.status, 200)
   assert.ok(html.includes('流白Livo'))
   assert.ok(html.includes('CC BY-NC 4.0'))
-  assert.ok(html.includes('https://xhslink.cn/o/2WbYk12a1h4'))
+  const links = [...html.matchAll(/<a\b[^>]*\bhref="([^"]+)"/g)].map(match => match[1])
+  assert.ok(links.some(href => href === 'https://xhslink.cn/o/2WbYk12a1h4'), 'exact author source link')
   const title = html.match(/<title>(.*?)<\/title>/)?.[1]
   assert.equal((title?.match(/OpenAgentSkill/g) || []).length, 1, 'single title suffix')
   assert.ok(html.includes(`rel="canonical" href="https://www.openagentskill.com${path}"`))

--- a/scripts/test-external-skills.mjs
+++ b/scripts/test-external-skills.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import ts from 'typescript'
+import { EXTERNAL_SKILLS, ExternalSkillSchema, validateExternalCatalog, searchExternalSkills, getExternalSkill, externalSkillDiscoveryRecord, isMissingExternalSkillPath } from '../lib/skills/external-catalog.ts'
+
+const entry = getExternalSkill('redskill-curtain-branch-swallow')
+assert.ok(entry)
+assert.equal(entry.author.name, '流白Livo')
+assert.equal(entry.license, 'CC-BY-NC-4.0')
+assert.equal(entry.version, '1.0.0')
+assert.ok(entry.licenseNote.en.includes('share-alike'))
+for (const query of ['p5.js', 'p5js', '雨帘', '花枝', '飞燕', '流白Livo', 'skill-curtain-branch-swallow', 'p5-animation', 'RedSkill', 'RAIN BRANCHES']) {
+  assert.equal(searchExternalSkills(query).length, 1, query)
+}
+assert.equal(searchExternalSkills('unrelated finance').length, 0)
+assert.equal(getExternalSkill('missing'), undefined)
+for (const path of ['/skills', '/skills/external', `/skills/external/${entry.slug}`, `/skills/external/${entry.slug}/`]) assert.equal(isMissingExternalSkillPath(path), false)
+for (const path of ['/skills/external/missing', '/skills/external/%GG']) assert.equal(isMissingExternalSkillPath(path), true)
+assert.equal(searchExternalSkills('').length, EXTERNAL_SKILLS.length)
+assert.throws(() => validateExternalCatalog([entry, entry]), /Duplicate/)
+for (const changes of [
+  { aiReviewed: true }, { runtimeVerified: true }, { autoInstallAllowed: true },
+  { github_stars: 500 }, { install_command: 'npx fake' },
+  { sourceUrl: 'javascript:alert(1)' }, { sourceUrl: 'http://example.com' },
+  { sourceUrl: 'https://user:pass@example.com/' }, { sourceUrl: 'https://example.com/a?sign=secret' },
+  { bundleSha256: 'not-a-hash' }, { publication: { channel: 'owner-curated-external', reason: '' } },
+]) assert.equal(ExternalSkillSchema.safeParse({ ...entry, ...changes }).success, false)
+const record = externalSkillDiscoveryRecord(entry)
+assert.equal(record.auto_install_allowed, false)
+assert.equal(record.human_review_required, true)
+assert.equal(record.runtime_verified, false)
+assert.equal(record.ai_reviewed, false)
+assert.equal(record.install_command, null)
+assert.equal(record.github_stars, undefined)
+assert.equal(record.commercial_use, 'not-permitted-without-separate-permission')
+assert.match(record.url, /\/skills\/external\//)
+const read = path => readFileSync(new URL('../' + path, import.meta.url), 'utf8')
+assert.match(read('proxy.ts'), /isMissingExternalSkillPath\(pathname\)/)
+const route = read('app/api/external-skills/[slug]/route.ts')
+assert.match(route, /export async function GET/)
+assert.doesNotMatch(route, /export async function (POST|PUT|DELETE)|createAdminClient/)
+const routeExports = {}
+new Function('exports', 'require', ts.transpileModule(route, { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 } }).outputText)(routeExports, name => {
+  assert.equal(name, '@/lib/skills/external-catalog')
+  return { getExternalSkill, externalSkillDiscoveryRecord }
+})
+const response = await routeExports.GET(new Request('https://example.com'), { params: Promise.resolve({ slug: entry.slug }) })
+assert.equal(response.status, 200)
+assert.equal((await response.json()).auto_install_allowed, false)
+assert.equal(response.headers.get('x-robots-tag'), 'noindex')
+assert.equal((await routeExports.GET(new Request('https://example.com'), { params: Promise.resolve({ slug: 'missing' }) })).status, 404)
+const page = read('app/skills/external/[slug]/page.tsx')
+assert.match(page, /notFound\(\)/)
+assert.match(page, /export const dynamicParams = false/)
+assert.match(page, /alternates: \{ canonical: url \}/)
+assert.doesNotMatch(page, /aggregateRating|install_command|<iframe|<video|<img/)
+assert.match(read('app/skills/page.tsx'), /externalDiscovery=\{<ExternalSkillResults query=\{query\}/)
+assert.match(read('lib/seo/sitemap.ts'), /EXTERNAL_SKILLS\.map/)
+for (const path of ['lib/skills/owner-publication.ts', 'app/api/admin/skills/publish/route.ts']) {
+  assert.doesNotMatch(read(path), /EXTERNAL_SKILLS|external-catalog/, 'GitHub owner lane unchanged')
+}
+console.log('External skill catalog, safe links, licensing, discovery and publication boundaries passed.')

--- a/scripts/test-seo-foundation.mjs
+++ b/scripts/test-seo-foundation.mjs
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict'
+import './test-external-skills.mjs'
+import * as externalCatalog from '../lib/skills/external-catalog.ts'
 import { readFileSync } from 'node:fs'
 import ts from 'typescript'
 import { selectGuideSkills, selectComparisonSkills, scoreSkillForGuide } from '../lib/seo/guide-selection.ts'
@@ -33,6 +35,7 @@ function compile(path, dependencies) {
   return exports
 }
 const mocks = {
+  '@/lib/skills/external-catalog': externalCatalog,
   '@/lib/agent-tasks': { AGENT_TASKS: [] }, '@/lib/collections': { SKILL_STACKS: [] },
   '@/lib/async': { withTimeout: promise => promise },
   '@/lib/db/skills': { getApprovedSkillSitemapCount: async () => 2001, getApprovedSkillSitemapRecords: async () => [] },
@@ -50,6 +53,7 @@ const mocks = {
 }
 const sitemap = compile('lib/seo/sitemap.ts', mocks)
 const core = sitemap.getCoreSitemapEntries()
+assert.equal(core.filter(p => p.url.endsWith('/skills/external/redskill-curtain-branch-swallow')).length, 1)
 assert.equal(core.find(p => p.url.endsWith('/about')).lastModified, undefined)
 assert.equal(core.find(p => p.url.endsWith('/showcase/example')).lastModified, '2026-09-01')
 assert.equal(sitemap.getGuideSitemapEntries().find(p => p.url.endsWith(videoGuide.slug)).lastModified, videoGuide.updatedAt)


### PR DESCRIPTION
## Summary
- Add owner-curated external listing for skill-curtain-branch-swallow by 流白Livo with author source links and explicit CC BY-NC 4.0 restrictions.
- Add EN/ZH external directory/detail pages, separate Skills search results, read-only metadata and canonical sitemap entries.
- No package/media mirroring, Skill execution, auto-install, invented reviews or database approval changes. Existing community and GitHub owner flows unchanged.

## Verification
- Full regression suite, typecheck, targeted lint and production build passed.
- Production-mode HTTP checks passed: EN/ZH SSR, canonical, JSON-LD, real 404, directory search, sitemap and GET-only API.
- Browser checked responsive source CTA and noncommercial warning.
- Unrelated local editorial changes excluded.